### PR TITLE
[FINAL] [BOOM!] - Retina Text

### DIFF
--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -767,6 +767,9 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 		
 	}
 	
+	// use the floor function to make optimumSize an integer if not already
+	optimumSize = floorf(optimumSize);
+	
 	// make sure return value is between minSize and maxSize
 	if ( optimumSize < minSize ) {
 		optimumSize = minSize;

--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -689,6 +689,7 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 				testSize = floorf( testSize );
 			} while ( testSize > minSize );
 			
+			optimumSize = testSize;
 			
 			
 			// remember that cutting font size in half will quadruple text box capacity.

--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -672,7 +672,7 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 			float testSize = calcSize;
 			bool lastCharacterDidRender = false;
 			bool allCharactersDidRender = true;
-			USRect testRect;
+			USRect testRect, lastRect;
 			do {
 				// set up style and text box
 				style->SetSize ( testSize );
@@ -688,7 +688,28 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 					allCharactersDidRender = true;
 					int charIdx = textLength - 2;
 					while (charIdx >= 0 && allCharactersDidRender) {
+						// set lastRect's members to those of testRect
+						lastRect.Init(testRect.mXMin, testRect.mYMin, testRect.mXMax, testRect.mYMax);
+						
+						// get the character at charIdx
+						cc8 ch = text[charIdx];
+						
+						// get the bounds for the character at charIdx
 						allCharactersDidRender = textBox->GetBoundsForRange(charIdx, 1, testRect);
+						
+						// test to make sure the character is not whitespace, control character, or part of Unicode sequence
+						// the 
+						bool isPrintChar = !MOAIFont::IsControl(ch) && !MOAIFont::IsWhitespace(ch) && ch < 0x80;
+						
+						// if it passes the above condition, the character rendered if at least one member of testRect is different from the corresponding member of lastRect
+						if (isPrintChar && allCharactersDidRender) {
+							allCharactersDidRender = !(testRect.mXMin == lastRect.mXMin &&
+													   testRect.mXMax == lastRect.mXMax &&
+													   testRect.mYMin == lastRect.mYMin &&
+													   testRect.mYMax == lastRect.mYMax);
+						}
+						
+						
 						charIdx -= 1;
 					}
 					

--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -671,6 +671,7 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 			
 			float testSize = calcSize;
 			bool lastCharacterDidRender = false;
+			bool allCharactersDidRender = true;
 			USRect testRect;
 			do {
 				// set up style and text box
@@ -681,10 +682,19 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 				textBox->ScheduleLayout ();
 				
 				// find out if last character renders
-				lastCharacterDidRender = textBox->GetBoundsForRange ( textLength - 1, 1, testRect );
-				
-				if ( lastCharacterDidRender ) {
-					break;
+				lastCharacterDidRender = textBox->GetBoundsForRange(textLength - 1, 1, testRect);
+				if (lastCharacterDidRender) {
+					// check the other characters in the string too starting with the second to last character
+					allCharactersDidRender = true;
+					int charIdx = textLength - 2;
+					while (charIdx >= 0 && allCharactersDidRender) {
+						allCharactersDidRender = textBox->GetBoundsForRange(charIdx, 1, testRect);
+						charIdx -= 1;
+					}
+					
+					if (allCharactersDidRender) {
+						break;
+					}
 				}
 				
 				// reduce size and try again

--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -567,7 +567,10 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 	
 	
 	MOAITextBox *textBox = new MOAITextBox ();
-	textBox -> SetRect(0.0f, 0.0f, textLength * maxSize * 20, maxSize * 20);
+	
+	// set the dimensions of the text box to have one corner at (0, 0) with dimensions large enough to contain the entire string on one line.  I used 20 to be sure, but I think 2 works as well in most cases.
+	const float FONT_SIZE_MULTIPLIER = 20.0f;
+	textBox -> SetRect(0.0f, 0.0f, textLength * maxSize * FONT_SIZE_MULTIPLIER, maxSize * FONT_SIZE_MULTIPLIER);
 	
 	
 	textBox->SetText ( text );
@@ -713,7 +716,7 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 		style->SetSize(optimumSize);
 		style->ScheduleUpdate();
 		
-		textBox -> SetRect(0.0f, 0.0f, maxSize * 20, maxSize * 20);
+		textBox -> SetRect(0.0f, 0.0f, maxSize * FONT_SIZE_MULTIPLIER, maxSize * FONT_SIZE_MULTIPLIER);
 		
 		textBox -> SetText(text);
 		textBox -> SetStyle(style);
@@ -736,7 +739,9 @@ float MOAIFont::OptimalSize (cc8* text, float width, float height, float minSize
 			style->SetSize(optimumSize);
 			style->ScheduleUpdate();
 			
-			textBox -> SetRect(0.0f, 0.0f, width, maxSize * 100);
+			// Make the text box have a width equal to that passed in as a parameter and a height large enough to be sure the whole string fits.
+			const float VERTICAL_MULTIPLIER = 5.0f;
+			textBox -> SetRect(0.0f, 0.0f, width, maxSize * FONT_SIZE_MULTIPLIER * VERTICAL_MULTIPLIER);
 			
 			textBox -> SetText(text);
 			textBox -> SetStyle(style);

--- a/src/moaicore/MOAIFont.h
+++ b/src/moaicore/MOAIFont.h
@@ -125,7 +125,7 @@ public:
 	static bool			IsWhitespace			( u32 c );
 						MOAIFont				();
 						~MOAIFont				();
-	float				OptimalSize				(cc8* text, float width, float height, float minSize, float maxSize, bool allowMultiLine, float adjustmentFactor);
+	float				OptimalSize				(cc8* text, float width, float height, float minSize, float maxSize, bool allowMultiLine);
 	void				ProcessGlyphs			();
 	void				RebuildKerning			();
 	void				RebuildKerning			( float size );

--- a/src/moaicore/MOAITextBox.cpp
+++ b/src/moaicore/MOAITextBox.cpp
@@ -996,25 +996,39 @@ bool MOAITextBox::GetBoundsForRange ( u32 idx, u32 size, USRect& rect ) {
 
 			USRect glyphRect = glyph.GetRect ( sprite.mX, sprite.mY );
 			
-			// added to factor in the effect of glyph scale
-			float scaleFactor = 1.0f / this->mGlyphScale;
 			
-			// record the old X and Y coordinates of lower-left corner
-			float oldX = glyphRect.mXMin;
-			float oldY = glyphRect.mYMax;
+			// added to factor in the effect of glyph scale
+			float scaleFactor = this->mGlyphScale; // tried the reciprocal of it first.
+			
+			// record the old X coordinate of left edge
+			float oldXMin = glyphRect.mXMin;
+			 
+			// record the old center of the rect before scaling
+			USVec2D oldCenter;
+			glyphRect.GetCenter(oldCenter);
 			
 			// scale the rect to bring it to the aparent size in the text box
 			glyphRect.Scale(scaleFactor, scaleFactor);
 			
-			// calcluate the delta for X and Y using lower-left corner of scaled rect
-			float deltaX = glyphRect.mXMin - oldX;
-			float deltaY = glyphRect.mYMax - oldY;
+			// record the new center of the rect after scaling
+			USVec2D newCenter;
+			glyphRect.GetCenter(newCenter);
 			
-			// translate all four vertices to make the lower-left corner is in the same place as it was before
+			// calcluate the delta for X and Y using central point of left edge of scaled rect
+			float deltaX = glyphRect.mXMin - oldXMin;
+			float deltaY = newCenter.mY - oldCenter.mY;
+			
+			// translate all four vertices to make the central point of left edge be in the same place as it was before
+			
 			glyphRect.mXMax -= deltaX;
 			glyphRect.mXMin -= deltaX;
+			
+			glyphRect.mYMin -= deltaY;
 			glyphRect.mYMax -= deltaY;
-			glyphRect.mYMax -= deltaY;
+			
+			
+			// TODO: find the perfect anchor spot so bounds will actually cover text in all cases
+			 
 
 			if ( result ) {
 				rect.Grow ( glyphRect );

--- a/src/moaicore/MOAITextBox.cpp
+++ b/src/moaicore/MOAITextBox.cpp
@@ -995,6 +995,26 @@ bool MOAITextBox::GetBoundsForRange ( u32 idx, u32 size, USRect& rect ) {
 		if ( glyph.mWidth > 0.0f ) {
 
 			USRect glyphRect = glyph.GetRect ( sprite.mX, sprite.mY );
+			
+			// added to factor in the effect of glyph scale
+			float scaleFactor = 1.0f / this->mGlyphScale;
+			
+			// record the old X and Y coordinates of lower-left corner
+			float oldX = glyphRect.mXMin;
+			float oldY = glyphRect.mYMax;
+			
+			// scale the rect to bring it to the aparent size in the text box
+			glyphRect.Scale(scaleFactor, scaleFactor);
+			
+			// calcluate the delta for X and Y using lower-left corner of scaled rect
+			float deltaX = glyphRect.mXMin - oldX;
+			float deltaY = glyphRect.mYMax - oldY;
+			
+			// translate all four vertices to make the lower-left corner is in the same place as it was before
+			glyphRect.mXMax -= deltaX;
+			glyphRect.mXMin -= deltaX;
+			glyphRect.mYMax -= deltaY;
+			glyphRect.mYMax -= deltaY;
 
 			if ( result ) {
 				rect.Grow ( glyphRect );


### PR DESCRIPTION
:boom: 

Retina text works.

Cherry-picked Isaac's commits from https://github.com/IkeBart/moai-dev/tree/ike-font-op-size-exp .  I _think_ I got them all right.

The new code fixes issues with string bounds calculation when a glyphScale is applied to them.  It also fixes an issue where the font size returned for single-line text was sometimes too large.

:boom:
