### PR TITLE
[Final] MOAIColor - Replacing alpha with opacity

### DIFF
--- a/src/moaicore/MOAIColor.cpp
+++ b/src/moaicore/MOAIColor.cpp
@@ -11,107 +11,39 @@
 //================================================================//
 
 //----------------------------------------------------------------//
-/**	@name	moveColor
-	@text	Animate the color by applying a delta. Creates and returns
-			a MOAIEaseDriver initialized to apply the delta.
+/**	@name	getColor
+ @text	Returns the current color.
+ 
+ @in		MOAIColor self
+ @out	number r
+ @out	number g
+ @out	number b
+ @out	number opacity
+ */
+int	MOAIColor::_getColor ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIColor, "U" )
 	
-	@in		MOAIColor self
-	@in		number rDelta		Delta to be added to r.
-	@in		number gDelta		Delta to be added to g.
-	@in		number bDelta		Delta to be added to b.
-	@in		number aDelta		Delta to be added to a.
-	@in		number length		Length of animation in seconds.
-	@opt	number mode			The ease mode. One of MOAIEaseType.EASE_IN, MOAIEaseType.EASE_OUT, MOAIEaseType.FLAT MOAIEaseType.LINEAR,
-								MOAIEaseType.SMOOTH, MOAIEaseType.SOFT_EASE_IN, MOAIEaseType.SOFT_EASE_OUT, MOAIEaseType.SOFT_SMOOTH,
-								MOAIEaseType.BACK_EASE_IN, MOAIEaseType.BACK_EASE_OUT, MOAIEaseType.BACK_SMOOTH, MOAIEaseType.SINE_EASE_IN,
-								MOAIEaseType.SINE_EASE_OUT, or MOAIEaseType.SINE_SMOOTH. Defaults to MOAIEaseType.SMOOTH.
-	@out	MOAIEaseDriver easeDriver
-*/
-int MOAIColor::_moveColor ( lua_State* L ) {
-	MOAI_LUA_SETUP ( MOAIColor, "UNNNNN" )
-
-	float delay		= state.GetValue < float >( 6, 0.0f );
+	lua_pushnumber ( state, self->mUnmultipliedR );
+	lua_pushnumber ( state, self->mUnmultipliedG );
+	lua_pushnumber ( state, self->mUnmultipliedB );
+	lua_pushnumber ( state, self->mA );
 	
-	if ( delay > 0.0f ) {
-	
-		u32 mode = state.GetValue < u32 >( 7, USInterpolate::kSmooth );
-		
-		MOAIEaseDriver* action = new MOAIEaseDriver ();
-		
-		action->ParseForMove ( state, 2, self, 4, mode,
-			MOAIColorAttr::Pack ( ATTR_R_COL ), 0.0f,
-			MOAIColorAttr::Pack ( ATTR_G_COL ), 0.0f,
-			MOAIColorAttr::Pack ( ATTR_B_COL ), 0.0f,
-			MOAIColorAttr::Pack ( ATTR_A_COL ), 0.0f
-		);
-		
-		action->SetSpan ( delay );
-		action->Start ();
-		action->PushLuaUserdata ( state );
-
-		return 1;
-	}
-	
-	self->mR += state.GetValue < float >( 2, 0.0f );
-	self->mG += state.GetValue < float >( 3, 0.0f );
-	self->mB += state.GetValue < float >( 4, 0.0f );
-	self->mA += state.GetValue < float >( 5, 0.0f );
-	self->ScheduleUpdate ();
-	
-	return 0;
+	return 4;
 }
 
 //----------------------------------------------------------------//
-/**	@name	seekColor
-	@text	Animate the color by applying a delta. Delta is computed
-			given a target value. Creates and returns a MOAIEaseDriver
-			initialized to apply the delta.
+/**	@name	getOpacity
+ @text	Returns the current opacity.
+ 
+ @in		MOAIColor self
+ @out	number opacity
+ */
+int MOAIColor::_getOpacity( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIColor, "U" )
 	
-	@in		MOAIColor self
-	@in		number rGoal		Desired resulting value for r.
-	@in		number gGoal		Desired resulting value for g.
-	@in		number bGoal		Desired resulting value for b.
-	@in		number aGoal		Desired resulting value for a.
-	@in		number length		Length of animation in seconds.
-	@opt	number mode			The ease mode. One of MOAIEaseType.EASE_IN, MOAIEaseType.EASE_OUT, MOAIEaseType.FLAT MOAIEaseType.LINEAR,
-								MOAIEaseType.SMOOTH, MOAIEaseType.SOFT_EASE_IN, MOAIEaseType.SOFT_EASE_OUT, MOAIEaseType.SOFT_SMOOTH,
-								MOAIEaseType.BACK_EASE_IN, MOAIEaseType.BACK_EASE_OUT, MOAIEaseType.BACK_SMOOTH, MOAIEaseType.SINE_EASE_IN,
-								MOAIEaseType.SINE_EASE_OUT, or MOAIEaseType.SINE_SMOOTH. Defaults to MOAIEaseType.SMOOTH.
-	@out	MOAIEaseDriver easeDriver
-*/
-int MOAIColor::_seekColor ( lua_State* L ) {
-	MOAI_LUA_SETUP ( MOAIColor, "UNNNNN" )
-
-	float delay		= state.GetValue < float >( 6, 0.0f );
+	lua_pushnumber ( state, self->mA );
 	
-	
-	if ( delay > 0.0f ) {
-	
-		u32 mode = state.GetValue < u32 >( 7, USInterpolate::kSmooth );
-		
-		MOAIEaseDriver* action = new MOAIEaseDriver ();
-		
-		action->ParseForSeek ( state, 2, self, 4, mode,
-			MOAIColorAttr::Pack ( ATTR_R_COL ), self->mR, 0.0f,
-			MOAIColorAttr::Pack ( ATTR_G_COL ), self->mG, 0.0f,
-			MOAIColorAttr::Pack ( ATTR_B_COL ), self->mB, 0.0f,
-			MOAIColorAttr::Pack ( ATTR_A_COL ), self->mA, 0.0f
-		);
-		
-		action->SetSpan ( delay );
-		action->Start ();
-		action->PushLuaUserdata ( state );
-
-		return 1;
-	}
-	
-	self->mR = state.GetValue < float >( 2, 0.0f );
-	self->mG = state.GetValue < float >( 3, 0.0f );
-	self->mB = state.GetValue < float >( 4, 0.0f );
-	self->mA = state.GetValue < float >( 5, 0.0f );
-	self->ScheduleUpdate ();
-	
-	return 0;
+	return 1;
 }
 
 //----------------------------------------------------------------//
@@ -122,7 +54,7 @@ int MOAIColor::_seekColor ( lua_State* L ) {
 	@in		number r	Default value is 0.
 	@in		number g	Default value is 0.
 	@in		number b	Default value is 0.
-	@opt	number a	Default value is 1.
+	@opt	number o	Default value is 1.
 	@out	nil
 */
 int MOAIColor::_setColor ( lua_State* L ) {
@@ -131,11 +63,34 @@ int MOAIColor::_setColor ( lua_State* L ) {
 	float r = state.GetValue < float >( 2, 0.0f );
 	float g = state.GetValue < float >( 3, 0.0f );
 	float b = state.GetValue < float >( 4, 0.0f );
-	float a = state.GetValue < float >( 5, 1.0f );
-
-	self->Set ( r, g, b, a );
+	float o = state.GetValue < float >( 5, 1.0f );
+	
+	self->mUnmultipliedR = r;
+	self->mUnmultipliedG = g;
+	self->mUnmultipliedB = b;
+	
+	self->Set ( r * o, g * o, b * o, o );
 	self->ScheduleUpdate ();
 
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/**	@name	setOpacity
+ @text	Set the opacity.
+ 
+ @in		MOAIColor self
+ @in		number o	Default value is 0.
+ @out	nil
+ */
+int MOAIColor::_setOpacity ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIColor, "UN" )
+	
+	float o = state.GetValue < float >( 2, 1.0f );
+	
+	self->Set ( self->mUnmultipliedR * o, self->mUnmultipliedG * o, self->mUnmultipliedB * o, o );
+	self->ScheduleUpdate ();
+	
 	return 0;
 }
 
@@ -170,17 +125,37 @@ bool MOAIColor::ApplyAttrOp ( u32 attrID, MOAIAttrOp& attrOp, u32 op ) {
 
 		switch ( UNPACK_ATTR ( attrID )) {
 			case ATTR_R_COL:
-				this->mR = USFloat::Clamp ( attrOp.Apply ( this->mR, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+			{
+				float r = USFloat::Clamp ( attrOp.Apply ( this->mUnmultipliedR, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+				this->mUnmultipliedR = r;
+				this->mR = r * this->mA;
 				return true;
+			}
 			case ATTR_G_COL:
-				this->mG = USFloat::Clamp ( attrOp.Apply ( this->mG, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+			{
+				float g = USFloat::Clamp ( attrOp.Apply ( this->mUnmultipliedG, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+				this->mUnmultipliedG = g;
+				this->mG = g * this->mA;
 				return true;
+			}
 			case ATTR_B_COL:
-				this->mB = USFloat::Clamp ( attrOp.Apply ( this->mB, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+			{
+				float b = USFloat::Clamp ( attrOp.Apply ( this->mUnmultipliedB, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+				this->mUnmultipliedB = b;
+				this->mB = b * this->mA;
 				return true;
-			case ATTR_A_COL:
-				this->mA = USFloat::Clamp ( attrOp.Apply ( this->mA, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+			}
+			case ATTR_OPACITY:
+			{
+				float o = USFloat::Clamp ( attrOp.Apply ( this->mA, op, MOAIAttrOp::ATTR_READ_WRITE ), 0.0f, 1.0f );
+				this->mA = o;
+				
+				this->mR = this->mUnmultipliedR * o;
+				this->mG = this->mUnmultipliedG * o;
+				this->mB = this->mUnmultipliedB * o;
+				
 				return true;
+			}
 			case COLOR_TRAIT:
 				attrOp.ApplyNoAdd < USColorVec* >( &this->mColor, op, MOAIAttrOp::ATTR_READ );
 				return true;
@@ -201,6 +176,10 @@ MOAIColor::MOAIColor () {
 	RTTI_BEGIN
 		RTTI_EXTEND ( MOAINode )
 	RTTI_END
+	
+	this->mUnmultipliedR = 1.0f;
+	this->mUnmultipliedG = 1.0f;
+	this->mUnmultipliedB = 1.0f;
 	
 	this->Set ( 1.0f, 1.0f, 1.0f, 1.0f );
 	this->mColor.Set ( 1.0f, 1.0f, 1.0f, 1.0f );
@@ -236,7 +215,7 @@ void MOAIColor::RegisterLuaClass ( MOAILuaState& state ) {
 	state.SetField ( -1, "ATTR_R_COL", MOAIColorAttr::Pack ( ATTR_R_COL ));
 	state.SetField ( -1, "ATTR_G_COL", MOAIColorAttr::Pack ( ATTR_G_COL ));
 	state.SetField ( -1, "ATTR_B_COL", MOAIColorAttr::Pack ( ATTR_B_COL ));
-	state.SetField ( -1, "ATTR_A_COL", MOAIColorAttr::Pack ( ATTR_A_COL ));
+	state.SetField ( -1, "ATTR_OPACITY", MOAIColorAttr::Pack ( ATTR_OPACITY ));
 	
 	state.SetField ( -1, "ADD_COLOR", MOAIColorAttr::Pack ( ADD_COLOR ));
 	state.SetField ( -1, "INHERIT_COLOR", MOAIColorAttr::Pack ( INHERIT_COLOR ));
@@ -249,9 +228,10 @@ void MOAIColor::RegisterLuaFuncs ( MOAILuaState& state ) {
 	MOAINode::RegisterLuaFuncs ( state );
 	
 	luaL_Reg regTable [] = {
-		{ "moveColor",				_moveColor },
-		{ "seekColor",				_seekColor },
+		{ "getColor",				_getColor },
+		{ "getOpacity",				_getOpacity},
 		{ "setColor",				_setColor },
+		{ "setOpacity",				_setOpacity },
 		{ "setParent",				_setParent },
 		{ NULL, NULL }
 	};

--- a/src/moaicore/MOAIColor.h
+++ b/src/moaicore/MOAIColor.h
@@ -38,8 +38,6 @@ protected:
 	//----------------------------------------------------------------//
 	static int		_getColor			( lua_State* L );
 	static int		_getOpacity			( lua_State* L );
-//	static int		_moveColor			( lua_State* L );
-//	static int		_seekColor			( lua_State* L );
 	static int		_setColor			( lua_State* L );
 	static int		_setOpacity			( lua_State* L );
 	static int		_setParent			( lua_State* L );

--- a/src/moaicore/MOAIColor.h
+++ b/src/moaicore/MOAIColor.h
@@ -19,7 +19,7 @@ class MOAILayer;
 	@attr	ATTR_R_COL
 	@attr	ATTR_G_COL
 	@attr	ATTR_B_COL
-	@attr	ATTR_A_COL
+	@attr	ATTR_OPACITY
 	
 	@attr	INHERIT_COLOR
 	@attr	COLOR_TRAIT
@@ -31,10 +31,17 @@ protected:
 	
 	USColorVec	mColor;
 	
+	float		mUnmultipliedR;
+	float		mUnmultipliedG;
+	float		mUnmultipliedB;
+	
 	//----------------------------------------------------------------//
-	static int		_moveColor			( lua_State* L );
-	static int		_seekColor			( lua_State* L );
+	static int		_getColor			( lua_State* L );
+	static int		_getOpacity			( lua_State* L );
+//	static int		_moveColor			( lua_State* L );
+//	static int		_seekColor			( lua_State* L );
 	static int		_setColor			( lua_State* L );
+	static int		_setOpacity			( lua_State* L );
 	static int		_setParent			( lua_State* L );
 
 public:
@@ -46,7 +53,7 @@ public:
 		ATTR_R_COL,
 		ATTR_G_COL,
 		ATTR_B_COL,
-		ATTR_A_COL,
+		ATTR_OPACITY,
 		
 		ADD_COLOR,
 		INHERIT_COLOR,


### PR DESCRIPTION
Moai handles transparency much differently than Cocos did.  It lets you modify a prop's alpha channel directly.  It turns out that alpha is not the same as opacity.  When you set an object's opacity, it should set the object's alpha channel to the opacity value, and it should also multiply the other three channels by the opacity value.  This is really hard to keep track of in game code, so I changed Moai to expose opacity to lua instead of alpha.  Alpha multiplication is handled in C, so we don't have to worry about it anymore.  Just like in Cocos.  :confetti_ball:

Of course, while working on this, @jeiting and I discovered that `MOAITextBox` doesn't do transparency the same way that other props do.  :frowning:  It looks like it's using separate OpenGL blend functions for the glyph textures and for the text box itself.  The result is that semi-opaque text ends up looking darker than it should be.  Ew.  :eggplant: 

We could try to work around that by tearing up `MOATextBox` and using some more fancy OpenGL stuff, but at this point I'm so fed up with `MOAITextBox` problems that I think a better solution is just to create our own text class that renders text to a texture so we can display it in a regular sprite... like we used to do with `CCLabelTTF`.  :name_badge: 

Note that `MOAIColor.ATTR_A_COL` no longer exists.  It has been replaced by `MOAIColor.ATTR_OPACITY`.  Double-check to make sure this doesn't break your games.  :bread: 

TL; DR: Transparency works like it did in Cocos2D.  Don't use it on `MOAITextBox` for now.

Once this gets merged, please move on to https://github.com/mindsnacks/Ahu/pull/93 .  Thank you!  :hamster: 
