### PR TITLE
[WIP, but there's just one thing] - MOAIAnimCurveCustom

### DIFF
--- a/src/moaicore/MOAIAnimCurve.cpp
+++ b/src/moaicore/MOAIAnimCurve.cpp
@@ -73,7 +73,7 @@ void MOAIAnimCurve::ApplyValueAttrOp ( MOAIAttrOp& attrOp, u32 op ) {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurve::Draw ( u32 resolution ) const {
+void MOAIAnimCurve::Draw ( u32 resolution ) {
 
 	// TODO: this isn't entirely correct. the value of each key frame should be drawn
 	// and then the spans between keys should be filled in with an approximation of
@@ -115,7 +115,7 @@ float MOAIAnimCurve::GetCurveDelta () const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurve::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const {
+void MOAIAnimCurve::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) {
 
 	float v0 = this->GetValue ( span0 );
 	float v1 = this->GetValue ( span1 );
@@ -133,14 +133,14 @@ float MOAIAnimCurve::GetSample ( u32 id ) {
 }
 
 //----------------------------------------------------------------//
-float MOAIAnimCurve::GetValue ( float time ) const {
+float MOAIAnimCurve::GetValue ( float time ) {
 
 	MOAIAnimKeySpan span = this->GetSpan ( time );
 	return this->GetValue ( span );
 }
 
 //----------------------------------------------------------------//
-float MOAIAnimCurve::GetValue ( const MOAIAnimKeySpan& span ) const {
+float MOAIAnimCurve::GetValue ( const MOAIAnimKeySpan& span ) {
 
 	MOAIAnimKey& key = this->mKeys [ span.mKeyID ];
 	float v0 = this->mSamples [ span.mKeyID ];
@@ -152,7 +152,7 @@ float MOAIAnimCurve::GetValue ( const MOAIAnimKeySpan& span ) const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurve::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const {
+void MOAIAnimCurve::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) {
 
 	attrOp.SetValue < float >( this->GetValue ( span ));
 }

--- a/src/moaicore/MOAIAnimCurve.h
+++ b/src/moaicore/MOAIAnimCurve.h
@@ -30,7 +30,7 @@ protected:
 	USLeanArray < float > mSamples;
 	
 	//----------------------------------------------------------------//
-	float			GetValue			( const MOAIAnimKeySpan& span );
+	virtual float	GetValue			( const MOAIAnimKeySpan& span );
 	float			GetCurveDelta		() const;
 
 public:

--- a/src/moaicore/MOAIAnimCurve.h
+++ b/src/moaicore/MOAIAnimCurve.h
@@ -18,17 +18,20 @@
 class MOAIAnimCurve :
 	public virtual MOAIAnimCurveBase {
 private:
-
-	USLeanArray < float > mSamples;
+	
 	float mValue;
 
 	//----------------------------------------------------------------//
 	static int		_getValueAtTime		( lua_State* L );
 	static int		_setKey				( lua_State* L );
-
+	
+protected:
+	
+	USLeanArray < float > mSamples;
+	
 	//----------------------------------------------------------------//
-	float			GetCurveDelta		() const;
 	float			GetValue			( const MOAIAnimKeySpan& span ) const;
+	float			GetCurveDelta		() const;
 
 public:
 	

--- a/src/moaicore/MOAIAnimCurve.h
+++ b/src/moaicore/MOAIAnimCurve.h
@@ -30,7 +30,7 @@ protected:
 	USLeanArray < float > mSamples;
 	
 	//----------------------------------------------------------------//
-	float			GetValue			( const MOAIAnimKeySpan& span ) const;
+	float			GetValue			( const MOAIAnimKeySpan& span );
 	float			GetCurveDelta		() const;
 
 public:
@@ -39,11 +39,11 @@ public:
 	
 	//----------------------------------------------------------------//
 	void			ApplyValueAttrOp	( MOAIAttrOp& attrOp, u32 op );
-	void			Draw				( u32 resolution ) const;
-	void			GetDelta			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const;
+	void			Draw				( u32 resolution );
+	void			GetDelta			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 );
 	float			GetSample			( u32 id );
-	float			GetValue			( float time ) const;
-	void			GetValue			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const;
+	float			GetValue			( float time );
+	void			GetValue			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span );
 	void			GetZero				( MOAIAttrOp& attrOp ) const;
 					MOAIAnimCurve		();
 					~MOAIAnimCurve		();

--- a/src/moaicore/MOAIAnimCurveBase.cpp
+++ b/src/moaicore/MOAIAnimCurveBase.cpp
@@ -94,7 +94,7 @@ void MOAIAnimCurveBase::Clear () {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurveBase::Draw ( u32 resolution ) const {
+void MOAIAnimCurveBase::Draw ( u32 resolution ) {
 	UNUSED ( resolution );
 }
 

--- a/src/moaicore/MOAIAnimCurveBase.h
+++ b/src/moaicore/MOAIAnimCurveBase.h
@@ -71,9 +71,9 @@ protected:
 
 	//----------------------------------------------------------------//
 	virtual void		ApplyValueAttrOp	( MOAIAttrOp& attrOp, u32 op ) = 0;
-	virtual void		GetDelta			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const = 0;
+	virtual void		GetDelta			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) = 0;
 	MOAIAnimKeySpan		GetSpan				( float time ) const;
-	virtual void		GetValue			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const = 0;
+	virtual void		GetValue			( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) = 0;
 	virtual void		GetZero				( MOAIAttrOp& attrOp ) const = 0;
 	virtual void		ReserveSamples		( u32 total ) = 0;
 
@@ -97,7 +97,7 @@ public:
 	//----------------------------------------------------------------//
 	bool				ApplyAttrOp				( u32 attrID, MOAIAttrOp& attrOp, u32 op );
 	void				Clear					();
-	virtual void		Draw					( u32 resolution ) const;
+	virtual void		Draw					( u32 resolution );
 	u32					FindKeyID				( float time ) const;
 	void				GetDelta				( MOAIAttrOp& attrOp, float t0, float t1 );
 	const MOAIAnimKey&	GetKey					( u32 id ) const;

--- a/src/moaicore/MOAIAnimCurveCustom.cpp
+++ b/src/moaicore/MOAIAnimCurveCustom.cpp
@@ -1,0 +1,64 @@
+//
+//  MOAIAnimCurveCustom.cpp
+//  libmoai
+//
+//  Created by Aaron Barrett on 5/29/13.
+//
+//
+
+#include "pch.h"
+#include <moaicore/MOAIAnimCurveCustom.h>
+#include <moaicore/MOAILogMessages.h>
+
+//================================================================//
+// local
+//================================================================//
+
+//----------------------------------------------------------------//
+/**  @name  setCallback
+  + @text  Sets or clears the custom interpolation callback.
+  +
+  + @in    MOAICustomAnimCurve self
+  + @opt  function callback    Default value is nil.
+  + @out  nil
+  + */
+int MOAIAnimCurveCustom::_setCallback ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIAnimCurveCustom, "U" )
+
+	self->mCallback.SetStrongRef ( state, 2 );
+
+	return 0;
+}
+
+//================================================================//
+// MOAIAnimCurveCustom
+//================================================================//
+
+//----------------------------------------------------------------//
+MOAIAnimCurveCustom::MOAIAnimCurveCustom () {
+	
+	RTTI_SINGLE ( MOAIAnimCurve )
+}
+
+//----------------------------------------------------------------//
+MOAIAnimCurveCustom::~MOAIAnimCurveCustom () {
+}
+
+//----------------------------------------------------------------//
+void MOAIAnimCurveCustom::RegisterLuaClass ( MOAILuaState& state ) {
+	
+	MOAIAnimCurve::RegisterLuaClass ( state );
+}
+
+//----------------------------------------------------------------//
+void MOAIAnimCurveCustom::RegisterLuaFuncs ( MOAILuaState& state ) {
+	
+	MOAIAnimCurve::RegisterLuaFuncs ( state );
+	
+	luaL_Reg regTable [] = {
+		{ "setCallback",    _setCallback },
+		{ NULL, NULL }
+	};
+	
+	luaL_register ( state, 0, regTable );
+}

--- a/src/moaicore/MOAIAnimCurveCustom.cpp
+++ b/src/moaicore/MOAIAnimCurveCustom.cpp
@@ -35,7 +35,7 @@ int MOAIAnimCurveCustom::_setCallback ( lua_State* L ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-float MOAIAnimCurveCustom::GetValue ( const MOAIAnimKeySpan& span ) const {
+float MOAIAnimCurveCustom::GetValue ( const MOAIAnimKeySpan& span ) {
 	
 	MOAIAnimKey& key = this->mKeys [ span.mKeyID ];
 	float v0 = this->mSamples [ span.mKeyID ];
@@ -46,7 +46,7 @@ float MOAIAnimCurveCustom::GetValue ( const MOAIAnimKeySpan& span ) const {
 	return v0 + ( this->GetCurveDelta () * span.mCycle );
 }
 
-float MOAIAnimCurveCustom::InterpolateCustom(float x0, float x1, float t, float weight) const {
+float MOAIAnimCurveCustom::InterpolateCustom(float x0, float x1, float t, float weight) {
 	float v0 = t; // quicker way of doing: USInterpolate::Curve( USInterpolate::kLinear, t);
 	float v1 = 0.0f; // use custom function
 

--- a/src/moaicore/MOAIAnimCurveCustom.h
+++ b/src/moaicore/MOAIAnimCurveCustom.h
@@ -21,8 +21,12 @@ private:
 	static int      _setCallback			( lua_State* L );
 	
 	//----------------------------------------------------------------//
-	float			GetValue			( const MOAIAnimKeySpan& span );
 	float			InterpolateCustom	( float x0, float x1, float t, float weight);
+
+protected:
+	
+	//----------------------------------------------------------------//
+	virtual float			GetValue			( const MOAIAnimKeySpan& span );
 	
 public:
 	

--- a/src/moaicore/MOAIAnimCurveCustom.h
+++ b/src/moaicore/MOAIAnimCurveCustom.h
@@ -20,15 +20,19 @@ private:
 	//----------------------------------------------------------------//
 	static int      _setCallback			( lua_State* L );
 	
+	//----------------------------------------------------------------//
+	float			GetValue			( const MOAIAnimKeySpan& span ) const;
+	float			InterpolateCustom	( float x0, float x1, float t, float weight) const;
+	
 public:
 	
 	DECL_LUA_FACTORY ( MOAIAnimCurveCustom )
 	
 	//----------------------------------------------------------------//
-	MOAIAnimCurveCustom				();
-	~MOAIAnimCurveCustom			();
-	void			RegisterLuaClass		( MOAILuaState& state );
-	void			RegisterLuaFuncs		( MOAILuaState& state );
+	MOAIAnimCurveCustom					();
+	~MOAIAnimCurveCustom				();
+	void			RegisterLuaClass	( MOAILuaState& state );
+	void			RegisterLuaFuncs	( MOAILuaState& state );
 };
 
 

--- a/src/moaicore/MOAIAnimCurveCustom.h
+++ b/src/moaicore/MOAIAnimCurveCustom.h
@@ -1,0 +1,35 @@
+//
+//  MOAIAnimCurveCustom.h
+//  libmoai
+//
+//  Created by Aaron Barrett on 5/29/13.
+//
+//
+
+#ifndef	MOAIANIMCURVECUSTOM_H
+#define	MOAIANIMCURVECUSTOM_H
+
+#include <moaicore/MOAIAnimCurve.h>
+
+class MOAIAnimCurveCustom :
+	public MOAIAnimCurve {
+private:
+	
+	MOAILuaRef mCallback; 
+	
+	//----------------------------------------------------------------//
+	static int      _setCallback			( lua_State* L );
+	
+public:
+	
+	DECL_LUA_FACTORY ( MOAIAnimCurveCustom )
+	
+	//----------------------------------------------------------------//
+	MOAIAnimCurveCustom				();
+	~MOAIAnimCurveCustom			();
+	void			RegisterLuaClass		( MOAILuaState& state );
+	void			RegisterLuaFuncs		( MOAILuaState& state );
+};
+
+
+#endif

--- a/src/moaicore/MOAIAnimCurveCustom.h
+++ b/src/moaicore/MOAIAnimCurveCustom.h
@@ -21,8 +21,8 @@ private:
 	static int      _setCallback			( lua_State* L );
 	
 	//----------------------------------------------------------------//
-	float			GetValue			( const MOAIAnimKeySpan& span ) const;
-	float			InterpolateCustom	( float x0, float x1, float t, float weight) const;
+	float			GetValue			( const MOAIAnimKeySpan& span );
+	float			InterpolateCustom	( float x0, float x1, float t, float weight);
 	
 public:
 	

--- a/src/moaicore/MOAIAnimCurveQuat.cpp
+++ b/src/moaicore/MOAIAnimCurveQuat.cpp
@@ -101,7 +101,7 @@ USQuaternion MOAIAnimCurveQuat::GetCurveDelta () const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurveQuat::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const {
+void MOAIAnimCurveQuat::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) {
 
 	USQuaternion v0 = this->GetValue ( span0 );
 	USQuaternion v1 = this->GetValue ( span1 );
@@ -112,14 +112,14 @@ void MOAIAnimCurveQuat::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& sp
 }
 
 //----------------------------------------------------------------//
-USQuaternion MOAIAnimCurveQuat::GetValue ( float time ) const {
+USQuaternion MOAIAnimCurveQuat::GetValue ( float time ) {
 
 	MOAIAnimKeySpan span = this->GetSpan ( time );
 	return this->GetValue ( span );
 }
 
 //----------------------------------------------------------------//
-USQuaternion MOAIAnimCurveQuat::GetValue ( const MOAIAnimKeySpan& span ) const {
+USQuaternion MOAIAnimCurveQuat::GetValue ( const MOAIAnimKeySpan& span ) {
 
 	MOAIAnimKey& key = this->mKeys [ span.mKeyID ];
 	USQuaternion v0 = this->mSamples [ span.mKeyID ];
@@ -140,7 +140,7 @@ USQuaternion MOAIAnimCurveQuat::GetValue ( const MOAIAnimKeySpan& span ) const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurveQuat::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const {
+void MOAIAnimCurveQuat::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) {
 
 	attrOp.SetValue < USQuaternion >( this->GetValue ( span ));
 }

--- a/src/moaicore/MOAIAnimCurveQuat.h
+++ b/src/moaicore/MOAIAnimCurveQuat.h
@@ -28,7 +28,7 @@ private:
 
 	//----------------------------------------------------------------//
 	USQuaternion	GetCurveDelta		() const;
-	USQuaternion	GetValue			( const MOAIAnimKeySpan& span ) const;
+	USQuaternion	GetValue			( const MOAIAnimKeySpan& span );
 
 public:
 	
@@ -36,9 +36,9 @@ public:
 	
 	//----------------------------------------------------------------//
 	void			ApplyValueAttrOp		( MOAIAttrOp& attrOp, u32 op );
-	void			GetDelta				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const;
-	USQuaternion	GetValue				( float time ) const;
-	void			GetValue				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const;
+	void			GetDelta				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 );
+	USQuaternion	GetValue				( float time );
+	void			GetValue				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span );
 	void			GetZero					( MOAIAttrOp& attrOp ) const;
 					MOAIAnimCurveQuat		();
 					~MOAIAnimCurveQuat		();

--- a/src/moaicore/MOAIAnimCurveVec.cpp
+++ b/src/moaicore/MOAIAnimCurveVec.cpp
@@ -96,7 +96,7 @@ USVec3D MOAIAnimCurveVec::GetCurveDelta () const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurveVec::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const {
+void MOAIAnimCurveVec::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) {
 
 	USVec3D v0 = this->GetValue ( span0 );
 	USVec3D v1 = this->GetValue ( span1 );
@@ -107,14 +107,14 @@ void MOAIAnimCurveVec::GetDelta ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& spa
 }
 
 //----------------------------------------------------------------//
-USVec3D MOAIAnimCurveVec::GetValue ( float time ) const {
+USVec3D MOAIAnimCurveVec::GetValue ( float time ) {
 
 	MOAIAnimKeySpan span = this->GetSpan ( time );
 	return this->GetValue ( span );
 }
 
 //----------------------------------------------------------------//
-USVec3D MOAIAnimCurveVec::GetValue ( const MOAIAnimKeySpan& span ) const {
+USVec3D MOAIAnimCurveVec::GetValue ( const MOAIAnimKeySpan& span ) {
 
 	MOAIAnimKey& key = this->mKeys [ span.mKeyID ];
 	USVec3D v0 = this->mSamples [ span.mKeyID ];
@@ -137,7 +137,7 @@ USVec3D MOAIAnimCurveVec::GetValue ( const MOAIAnimKeySpan& span ) const {
 }
 
 //----------------------------------------------------------------//
-void MOAIAnimCurveVec::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const {
+void MOAIAnimCurveVec::GetValue ( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) {
 
 	attrOp.SetValue < USVec3D >( this->GetValue ( span ));
 }

--- a/src/moaicore/MOAIAnimCurveVec.h
+++ b/src/moaicore/MOAIAnimCurveVec.h
@@ -28,7 +28,7 @@ private:
 
 	//----------------------------------------------------------------//
 	USVec3D			GetCurveDelta		() const;
-	USVec3D			GetValue			( const MOAIAnimKeySpan& span ) const;
+	USVec3D			GetValue			( const MOAIAnimKeySpan& span );
 
 public:
 	
@@ -36,9 +36,9 @@ public:
 	
 	//----------------------------------------------------------------//
 	void			ApplyValueAttrOp		( MOAIAttrOp& attrOp, u32 op );
-	void			GetDelta				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 ) const;
-	USVec3D			GetValue				( float time ) const;
-	void			GetValue				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span ) const;
+	void			GetDelta				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span0, const MOAIAnimKeySpan& span1 );
+	USVec3D			GetValue				( float time );
+	void			GetValue				( MOAIAttrOp& attrOp, const MOAIAnimKeySpan& span );
 	void			GetZero					( MOAIAttrOp& attrOp ) const;
 					MOAIAnimCurveVec		();
 					~MOAIAnimCurveVec		();

--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -306,7 +306,7 @@ void MOAIDraw::Bind () {
 }
 
 //----------------------------------------------------------------//
-void MOAIDraw::DrawAnimCurve ( const MOAIAnimCurve& curve, u32 resolution ) {
+void MOAIDraw::DrawAnimCurve ( MOAIAnimCurve& curve, u32 resolution ) {
 
 	curve.Draw ( resolution );
 }

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -46,7 +46,7 @@ public:
 
 	//----------------------------------------------------------------//
 	static void			Bind					();
-	static void			DrawAnimCurve			( const MOAIAnimCurve& curve, u32 resolution );
+	static void			DrawAnimCurve			( MOAIAnimCurve& curve, u32 resolution );
 	static void			DrawAxisGrid			( USVec2D loc, USVec2D vec, float size );
 	static void			DrawBoxOutline			( const USBox& box );
 	static void			DrawEllipseFill			( const USRect& rect, u32 steps );

--- a/src/moaicore/moaicore.cpp
+++ b/src/moaicore/moaicore.cpp
@@ -96,6 +96,7 @@ void moaicore::InitGlobals ( MOAIGlobals* globals ) {
 	REGISTER_LUA_CLASS ( MOAIAnimCurve )
 	REGISTER_LUA_CLASS ( MOAIAnimCurveQuat )
 	REGISTER_LUA_CLASS ( MOAIAnimCurveVec )
+	REGISTER_LUA_CLASS ( MOAIAnimCurveCustom )
 	REGISTER_LUA_CLASS ( MOAIBitmapFontReader )
 	REGISTER_LUA_CLASS ( MOAIBoundsDeck )
 	REGISTER_LUA_CLASS ( MOAIButtonSensor )

--- a/src/moaicore/moaicore.h
+++ b/src/moaicore/moaicore.h
@@ -20,6 +20,7 @@
 #include <moaicore/MOAIAnimCurveBase.h>
 #include <moaicore/MOAIAnimCurveQuat.h>
 #include <moaicore/MOAIAnimCurveVec.h>
+#include <moaicore/MOAIAnimCurveCustom.h>
 #include <moaicore/MOAIAttrOp.h>
 #include <moaicore/MOAIBitmapFontReader.h>
 #include <moaicore/MOAIBlendMode.h>

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -3625,6 +3625,10 @@
 		E9CA1E5B151C8578005F39B7 /* MOAIWebViewIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */; };
 		E9DE4581157EA38800630A7D /* MOAIMoviePlayerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */; };
 		E9DE4582157EA38800630A7D /* MOAIMoviePlayerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */; };
+		EB665DEB1756B13B009A8F29 /* MOAIAnimCurveCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB665DE91756B13B009A8F29 /* MOAIAnimCurveCustom.cpp */; };
+		EB665DEC1756B13B009A8F29 /* MOAIAnimCurveCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB665DE91756B13B009A8F29 /* MOAIAnimCurveCustom.cpp */; };
+		EB665DED1756B13B009A8F29 /* MOAIAnimCurveCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */; };
+		EB665DEE1756B13B009A8F29 /* MOAIAnimCurveCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */; };
 		EB92A50816B6671000FC326E /* MOAITakeCameraListener.h in Headers */ = {isa = PBXBuildFile; fileRef = EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */; };
 		EB92A50916B6671000FC326E /* MOAITakeCameraListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */; };
 /* End PBXBuildFile section */
@@ -6014,6 +6018,8 @@
 		E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAIWebViewIOS.mm; path = "moaiext-iphone/MOAIWebViewIOS.mm"; sourceTree = "<group>"; };
 		E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MOAIMoviePlayerIOS.h; path = "moaiext-iphone/MOAIMoviePlayerIOS.h"; sourceTree = "<group>"; };
 		E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAIMoviePlayerIOS.mm; path = "moaiext-iphone/MOAIMoviePlayerIOS.mm"; sourceTree = "<group>"; };
+		EB665DE91756B13B009A8F29 /* MOAIAnimCurveCustom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIAnimCurveCustom.cpp; sourceTree = "<group>"; };
+		EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIAnimCurveCustom.h; sourceTree = "<group>"; };
 		EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MOAITakeCameraListener.h; path = "moaiext-iphone/MOAITakeCameraListener.h"; sourceTree = "<group>"; };
 		EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAITakeCameraListener.mm; path = "moaiext-iphone/MOAITakeCameraListener.mm"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -8139,6 +8145,8 @@
 				0324E53013564BC7000ADC60 /* MOAIEaseDriver.h */,
 				0324E53113564BC7000ADC60 /* MOAIEaseType.cpp */,
 				0324E53213564BC7000ADC60 /* MOAIEaseType.h */,
+				EB665DE91756B13B009A8F29 /* MOAIAnimCurveCustom.cpp */,
+				EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */,
 			);
 			name = anim;
 			sourceTree = "<group>";
@@ -10648,6 +10656,7 @@
 				DD80D66916D8021D00C172D2 /* MOAIMath.h in Headers */,
 				DD80D69116D8025000C172D2 /* MOAIFrameBufferTexture.h in Headers */,
 				DD9C3F6617440A1E005BDA76 /* MOAITimerCoroutine.h in Headers */,
+				EB665DEE1756B13B009A8F29 /* MOAIAnimCurveCustom.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11436,6 +11445,7 @@
 				DD80D65D16D8021D00C172D2 /* MOAIMath.h in Headers */,
 				DD80D68516D8025000C172D2 /* MOAIFrameBufferTexture.h in Headers */,
 				DD9C3F6417440A19005BDA76 /* MOAITimerCoroutine.h in Headers */,
+				EB665DED1756B13B009A8F29 /* MOAIAnimCurveCustom.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12755,6 +12765,7 @@
 				DD80D67E16D8025000C172D2 /* MOAIFrameBufferTexture.cpp in Sources */,
 				DD80D6A616D8029700C172D2 /* SFMT.c in Sources */,
 				DD9C3F6517440A1E005BDA76 /* MOAITimerCoroutine.cpp in Sources */,
+				EB665DEC1756B13B009A8F29 /* MOAIAnimCurveCustom.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -13990,6 +14001,7 @@
 				DD80D67216D8025000C172D2 /* MOAIFrameBufferTexture.cpp in Sources */,
 				DD80D69A16D8029700C172D2 /* SFMT.c in Sources */,
 				DD9C3F6317440A19005BDA76 /* MOAITimerCoroutine.cpp in Sources */,
+				EB665DEB1756B13B009A8F29 /* MOAIAnimCurveCustom.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
`MOAIAnimCurve` doesn't have many ease functions.  In fact, they're almost all just variations on `powf(t, rate)`.  That sucks.  :spaghetti: 

We could just add our own ease types in C++, but that's not very flexible.  So here's `MOAIAnimCurveCustom`.  It's just like `MOAIAnimCurve`, but it allows you to define a lua function (using `curve:setCallback(easeFunction)`) that will be used for all interpolation by the curve.  :curly_loop: 

This will let us define a library of lua eases to use with `ease()` in the ActionHelpers.  :smoking: 

I haven't noticed any slowdown compared to using regular `MOAIAnimCurve`, even with a bunch of eases running simultaneously, but that's something that we should be watching out for if we start having performance problems.  :bread: 

I should note that this is all based off my brother's work: https://github.com/IkeBart/moai-dev/commit/2e3071931da3e9ac6460645d60311857be150738

---

The one thing that isn't done here has to do with the fact that I don't remember C++.  I'm getting a compiler warning because apparently I don't know how to do inheritance right.

MOAIAnimCurve.h:46: 'virtual void MOAIAnimCurve::GetValue(MOAIAttrOp&, const MOAIAnimKeySpan&)' was hidden
MOAIAnimCurveCustom.h:29: By 'virtual float MOAIAnimCurveCustom::GetValue(const MOAIAnimKeySpan&)'

I want `MOAIAnimCurveCustom` to be just like `MOAIAnimCurve`, except that when it calls `GetValue(const MOAIAnimKeySpan&)`, I want it to use its own method.  That's all.  Can anyone tell me what I'm doing wrong? :question: 

Also, I had to remove a lot of `const` declarations on functions all over `MOAIAnimCurveBase` and its subclasses in order to get `GetValue(const MOAIAnimKeySpan&)` to reference its own `mCallback`.  Does anyone know of a better way to do this?  :question: 
