### PR TITLE
Hacky hack to stop MOAIScriptNode from crashing Moai.

### DIFF
--- a/src/moaicore/MOAIScriptNode.cpp
+++ b/src/moaicore/MOAIScriptNode.cpp
@@ -36,9 +36,20 @@ int MOAIScriptNode::_reserveAttrs ( lua_State* L ) {
 	@out	nil
 */
 int MOAIScriptNode::_setCallback ( lua_State* L ) {
-	MOAI_LUA_SETUP ( MOAIScriptNode, "UF" );
+	MOAI_LUA_SETUP ( MOAIScriptNode, "U" );
 
 	self->SetLocal ( state, 2, self->mOnUpdate );
+	
+	self->isAllowedToCallOnUpdate = true;
+	
+	return 0;
+}
+
+int MOAIScriptNode::_clearCallback( lua_State* L ) {
+	MOAI_LUA_SETUP( MOAIScriptNode, "U" );
+	
+	self->isAllowedToCallOnUpdate = false;
+	
 	return 0;
 }
 
@@ -61,6 +72,8 @@ bool MOAIScriptNode::ApplyAttrOp ( u32 attrID, MOAIAttrOp& attrOp, u32 op ) {
 MOAIScriptNode::MOAIScriptNode () {
 	
 	RTTI_SINGLE ( MOAINode )
+	
+	this->isAllowedToCallOnUpdate = false;
 }
 
 //----------------------------------------------------------------//
@@ -70,7 +83,7 @@ MOAIScriptNode::~MOAIScriptNode () {
 //----------------------------------------------------------------//
 void MOAIScriptNode::OnDepNodeUpdate () {
 
-	if ( this->mOnUpdate ) {
+	if ( this->isAllowedToCallOnUpdate && this->mOnUpdate ) {
 		
 		MOAILuaStateHandle state = MOAILuaRuntime::Get ().State ();
 		
@@ -95,6 +108,7 @@ void MOAIScriptNode::RegisterLuaFuncs ( MOAILuaState& state ) {
 	luaL_Reg regTable [] = {
 		{ "reserveAttrs",			_reserveAttrs },
 		{ "setCallback",			_setCallback },
+		{ "clearCallback",			_clearCallback },
 		{ NULL, NULL }
 	};
 	

--- a/src/moaicore/MOAIScriptNode.cpp
+++ b/src/moaicore/MOAIScriptNode.cpp
@@ -36,7 +36,7 @@ int MOAIScriptNode::_reserveAttrs ( lua_State* L ) {
 	@out	nil
 */
 int MOAIScriptNode::_setCallback ( lua_State* L ) {
-	MOAI_LUA_SETUP ( MOAIScriptNode, "U" );
+	MOAI_LUA_SETUP ( MOAIScriptNode, "UF" );
 
 	self->SetLocal ( state, 2, self->mOnUpdate );
 	

--- a/src/moaicore/MOAIScriptNode.h
+++ b/src/moaicore/MOAIScriptNode.h
@@ -18,13 +18,15 @@
 class MOAIScriptNode :
 	public MOAINode {
 private:
-
+	
+	bool isAllowedToCallOnUpdate;
 	MOAILuaLocal mOnUpdate;
 	USLeanArray < float > mAttributes;
 
 	//----------------------------------------------------------------//
 	static int		_reserveAttrs			( lua_State* L );
 	static int		_setCallback			( lua_State* L );
+	static int		_clearCallback			( lua_State* L );
 	
 
 protected:


### PR DESCRIPTION
`MOAIScriptNode` is pretty cool, but apparently it's seldom used.  There's no documentation or tutorials to speak of on the Internets :information_source: .  So when there's a bug that crashes Moai, like the one I just uncovered, it's hard to figure out the _right_ way to fix it.

This is the _wrong_ way to fix it, but it stops the game from crashing.

It looks like this is going on.  Occasionally when a `loop`, `sequence`, or `animate` ActionHelper action is `stop()`ped, it will attempt to pull values from attribute links one last time--even after the linked nodes (or perhaps even the node itself?!) have been garbage collected.  :scream:  I checked to see why this is happening, and apparently when `onDepNodeUpdate` gets called on a `MOAIScriptNode`, the only thing it checks to determine whether or not to pull links is whether `mOnUpdate` (the reference to the `MOAIScriptNode`'s callback function) is not `NULL`.  Frst I tried just setting the callback to `NULL`, but that caused a bunch of error messages about trying to call a nil function.  So I added another flag :us: : `isAllowedToCallOnUpdate`, which gets set from Lua when you call `setCallback()`, and cleared when you call `clearCallback()`.  `MOAIScriptNode` now checks this flag before pulling links, and it seems to fix the crashes.

I'd _really_ like to figure out the _right_ way to fix this.  I'm going to tell the Moai maintainers about this, but I'm not holding my breath for a quick solution.  In the meantime, this hack will allow us to ship Bloon.  :balloon: 
