### PR TITLE
[FINAL] Fixing MOAIFreeTypeFont cut-off edges and adding glyph info to support finding the blank in Pounce

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1217,7 +1217,8 @@ void MOAIFreeTypeFont::RenderLines(FT_Int imgWidth, FT_Int imgHeight, int hAlign
 			lua_rawseti(state, -2, tableIndex);
 		}
 		
-		pen_y += (face->size->metrics.ascender >> 6) - (face->size->metrics.descender >> 6);
+		pen_y += (face->size->metrics.height >> 6);
+		//pen_y += (face->size->metrics.ascender >> 6) - (face->size->metrics.descender >> 6);
 	}
 	
 	// push the glyph bound table to the Lua state

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -43,33 +43,6 @@ int MOAIFreeTypeFont::_dimensionsOfLine(lua_State *L){
 	state.Push(height);
 	return 2;
 }
-//----------------------------------------------------------------//
-/** @name	getCharacterBounds()
-	@text	
- 
-	@in		MOAIFont self
-	@in		number	characterIndex
-	@in		string	text
-	@in		number	width
-	@in		number	height
-	@in		number	fontSize
-	@opt	enum	horizontalAlignment		default to MOAITextBox.LEFT_JUSTIFY
-	@opt	enum	verticalAlignment		default to MOAITextBox.LEFT_JUSTIFY
-	@opt	enum	wordBreak				default to MOAITextBox.WORD_BREAK_NONE
-	@out	number	xMin
-	@out	number	xMax
-	@out	number	yMin
-	@out	number	yMax
-	@out	number	baselineY
-	
- */
-int MOAIFreeTypeFont::_getCharacterBounds(lua_State *L){
-	MOAI_LUA_SETUP( MOAIFreeTypeFont, "U");
-	
-	
-	return 0;
-}
-
 
 //----------------------------------------------------------------//
 /**	@name	getDefaultSize
@@ -649,30 +622,6 @@ void MOAIFreeTypeFont::GenerateLines(FT_Int imgWidth, cc8 *text, int wordBreak){
 	this->NumberOfLinesToDisplayText(text, imgWidth, wordBreak, true);
 }
 
-USRect MOAIFreeTypeFont::GetCharacterBounds(u32 characterIndex, cc8 *text, float width, float height, int hAlignment, int vAlignment, int wordbreak, int *basslineY){
-	USRect rect;
-	rect.Init(0, 0, 0, 0);
-	
-	UNUSED(characterIndex);
-	UNUSED(text);
-	UNUSED(width);
-	UNUSED(height);
-	UNUSED(hAlignment);
-	UNUSED(vAlignment);
-	UNUSED(wordbreak);
-	UNUSED(basslineY);
-	
-	// generate lines
-	
-	// find out which line in the vector contains the character at the index.
-	
-	// calculate the bounds for that character including translations
-	
-	
-	
-	return rect;
-}
-
 void MOAIFreeTypeFont::Init(cc8 *filename) {
 	if ( USFileSys::CheckFileExists ( filename ) ) {
 		this->mFilename = USFileSys::GetAbsoluteFilePath ( filename );
@@ -1084,7 +1033,6 @@ void MOAIFreeTypeFont::RegisterLuaClass ( MOAILuaState& state ) {
 void MOAIFreeTypeFont::RegisterLuaFuncs(MOAILuaState &state){
 	luaL_Reg regTable [] = {
 		{ "dimensionsOfLine",			_dimensionsOfLine },
-		{ "getCharacterBounds",			_getCharacterBounds },
 		{ "getDefaultSize",				_getDefaultSize },
 		{ "getFilename",				_getFilename },
 		{ "getFlags",					_getFlags },

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1205,8 +1205,8 @@ void MOAIFreeTypeFont::RenderLines(FT_Int imgWidth, FT_Int imgHeight, int hAlign
 			lua_setfield(state, -2, "baselineY");
 			
 			// push rendered characters string to line sub-table
-			u32 utfLen = MOAIFreeTypeFont::LengthOfUTF8Sequence(text_ptr);
-			char *utfString = (char*)malloc(sizeof(char) * utfLen + 1);
+			u32 utfLen = MOAIFreeTypeFont::LengthOfUTF8Sequence(text_ptr) + 1;
+			char *utfString = (char*)malloc(sizeof(char) * utfLen);
 			
 			u8_toutf8(utfString, utfLen, text_ptr, text_len);
 			

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -185,7 +185,7 @@ int MOAIFreeTypeFont::_renderTexture(lua_State *L){
 	int wordBreak = state.GetValue < int > (8, MOAITextBox::WORD_BREAK_NONE);
 	
 	MOAITexture *texture = self->RenderTexture(text, fontSize, width, height, horizontalAlignment,
-											   verticalAlignment, wordBreak, false);
+											   verticalAlignment, wordBreak, false, false, state);
 	state.Push(texture);
 	return 1;
 }
@@ -593,6 +593,30 @@ void MOAIFreeTypeFont::GenerateLines(FT_Int imgWidth, cc8 *text, int wordBreak){
 	this->NumberOfLinesToDisplayText(text, imgWidth, wordBreak, true);
 }
 
+USRect MOAIFreeTypeFont::GetCharacterBounds(u32 characterIndex, cc8 *text, float width, float height, int hAlignment, int vAlignment, int wordbreak, int *basslineY){
+	USRect rect;
+	rect.Init(0, 0, 0, 0);
+	
+	UNUSED(characterIndex);
+	UNUSED(text);
+	UNUSED(width);
+	UNUSED(height);
+	UNUSED(hAlignment);
+	UNUSED(vAlignment);
+	UNUSED(wordbreak);
+	UNUSED(basslineY);
+	
+	// generate lines
+	
+	// find out which line in the vector contains the character at the index.
+	
+	// calculate the bounds for that character including translations
+	
+	
+	
+	return rect;
+}
+
 void MOAIFreeTypeFont::Init(cc8 *filename) {
 	if ( USFileSys::CheckFileExists ( filename ) ) {
 		this->mFilename = USFileSys::GetAbsoluteFilePath ( filename );
@@ -998,7 +1022,11 @@ void MOAIFreeTypeFont::RegisterLuaFuncs(MOAILuaState &state){
 	luaL_register ( state, 0, regTable );
 }
 
-void MOAIFreeTypeFont::RenderLines(FT_Int imgWidth, FT_Int imgHeight, int hAlign, int vAlign){
+void MOAIFreeTypeFont::RenderLines(FT_Int imgWidth, FT_Int imgHeight, int hAlign, int vAlign,
+								   bool returnGlyphBounds, MOAILuaState& state){
+	UNUSED(returnGlyphBounds);
+	UNUSED(state);
+	
 	FT_Int pen_x, pen_y;
 	
 	FT_Face face = this->mFreeTypeFace;
@@ -1066,8 +1094,9 @@ void MOAIFreeTypeFont::RenderLines(FT_Int imgWidth, FT_Int imgHeight, int hAlign
 
 MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width, float height,
 											 int hAlignment, int vAlignment, int wordbreak,
-											 bool autoFit){
+											 bool autoFit, bool returnGlyphBounds, MOAILuaState& state){
 	UNUSED(autoFit);
+	
 	
 	FT_Error error;
 	
@@ -1101,7 +1130,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width,
 	this->GenerateLines(imgWidth, text, wordbreak);
 	
 	// render the lines to the data buffer
-	this->RenderLines(imgWidth, imgHeight, hAlignment, vAlignment);
+	this->RenderLines(imgWidth, imgHeight, hAlignment, vAlignment, returnGlyphBounds, state);
 	
 	// turn the data buffer into an image
 	MOAIImage bitmapImg;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1313,7 +1313,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 			FT_Int bottom = pen.y + (height - bit->top);//(height - bit->top);
 			
 			this->DrawBitmap(&bit->bitmap, left, bottom, imgWidth, imgHeight);
-			FT_Done_Glyph(image);
+			
 			
 			if (returnGlyphBounds) {
 				// create table with five elements
@@ -1347,6 +1347,8 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 				// set index for current glyph
 				lua_rawseti(state, -2, tableIndex);
 			}
+			
+			FT_Done_Glyph(image);
 		}
 		
 	}

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -44,6 +44,34 @@ int MOAIFreeTypeFont::_dimensionsOfLine(lua_State *L){
 	return 2;
 }
 //----------------------------------------------------------------//
+/** @name	getCharacterBounds()
+	@text	
+ 
+	@in		MOAIFont self
+	@in		number	characterIndex
+	@in		string	text
+	@in		number	width
+	@in		number	height
+	@in		number	fontSize
+	@opt	enum	horizontalAlignment		default to MOAITextBox.LEFT_JUSTIFY
+	@opt	enum	verticalAlignment		default to MOAITextBox.LEFT_JUSTIFY
+	@opt	enum	wordBreak				default to MOAITextBox.WORD_BREAK_NONE
+	@out	number	xMin
+	@out	number	xMax
+	@out	number	yMin
+	@out	number	yMax
+	@out	number	baselineY
+	
+ */
+int MOAIFreeTypeFont::_getCharacterBounds(lua_State *L){
+	MOAI_LUA_SETUP( MOAIFreeTypeFont, "U");
+	
+	
+	return 0;
+}
+
+
+//----------------------------------------------------------------//
 /**	@name	getDefaultSize
 	@text	Requests the font's default size
  
@@ -953,6 +981,7 @@ void MOAIFreeTypeFont::RegisterLuaClass ( MOAILuaState& state ) {
 void MOAIFreeTypeFont::RegisterLuaFuncs(MOAILuaState &state){
 	luaL_Reg regTable [] = {
 		{ "dimensionsOfLine",			_dimensionsOfLine },
+		{ "getCharacterBounds",			_getCharacterBounds },
 		{ "getDefaultSize",				_getDefaultSize },
 		{ "getFilename",				_getFilename },
 		{ "getFlags",					_getFlags },

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -176,6 +176,19 @@ int MOAIFreeTypeFont::_optimalSize(lua_State *L){
 												  glyph bounds.  Default to false.
 	@out	MOAITexture	  texture
 	@out	table		  glyphBounds			A table containing glyph bounds for each character.
+												  The table has three levels.  The top level contains
+												  one or more tables, one table for each line indexed
+												  by integer starting with 1.  The table for each
+												  line contains one or more tables, one for each
+												  glyph on the line, indexed by integer starting with
+												  1, along with the entries indexed by the strings
+												  'baselineY' and 'renderedCharacters'. The table for
+												  each glyph contains entries indexed by the strings
+												  'xMin', 'yMin', 'xMax' and 'yMax' each 
+											      corresponding to the bounds of the glyph relative
+												  to texture's coordinate system with the origin 
+												  being in the upper left corner. Nil if 
+												  returnGlyphBounds is false.
  */
 int MOAIFreeTypeFont::_renderTexture(lua_State *L){
 	MOAI_LUA_SETUP ( MOAIFreeTypeFont, "USNN" );
@@ -214,7 +227,16 @@ int MOAIFreeTypeFont::_renderTexture(lua_State *L){
 	@out	MOAITexture		texture
 	@out	number			width
 	@out	number			height
-	@out	table			glyphBounds			A table containing glyph bounds for each character.
+	@out	table			glyphBounds			A table containing glyph bounds for each character.--
+												  The table has two levels.  The top level contains 
+												  one or more tables, one for each glyph in the 
+												  string, indexed by integer beginning with one.  The
+												  table for each glyph contains entries indexed by
+												  the strings 'xMin', 'yMin', 'xMax', 'yMax' and
+												  'baselineY', each corresponding to the bounds of
+												  the glyph relative to the texture's coordinate
+												  system with the origin being in the upper left
+												  corner.  Nil if returnGlyphBounds is false.
  */
 int MOAIFreeTypeFont::_renderTextureSingleLine(lua_State *L){
 	MOAI_LUA_SETUP ( MOAIFreeTypeFont, "US" );

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -494,7 +494,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, FT_Vector *
 	boundingBox.yMin = 32000;
 	boundingBox.yMax = -32000;
 	
-	for (FT_UInt n = 0; n < strlen(text); n++)
+	for (FT_UInt n = 0; n < numGlyphs; n++)
 	{
 		FT_Glyph_Get_CBox( glyphs[n], FT_GLYPH_BBOX_PIXELS, &glyphBoundingBox);
         

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1149,7 +1149,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 		pen.x = startX + posX;
 		pen.y = startY + posY;
 		
-		error = FT_Glyph_To_Bitmap(&image, FT_RENDER_MODE_NORMAL, &pen, 0);
+		error = FT_Glyph_To_Bitmap(&image, FT_RENDER_MODE_NORMAL, 0, 0);
 		
 		if (!error) {
 			FT_BitmapGlyph bit = (FT_BitmapGlyph)image;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -193,9 +193,10 @@ int MOAIFreeTypeFont::_renderTexture(lua_State *L){
 											   state);
 	state.Push(texture);
 	if (returnGlyphBounds) {
-		// TODO: return the glyph bound table
-		// currently returns nil for second return value
-		state.Push();
+		// return the glyph bound table after the texture
+		
+		// Move the table that would appear before the texture to the second return value.
+		state.MoveToTop(-2);
 		return 2;
 	}
 	

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -22,6 +22,7 @@ class MOAITexture;
 
 struct MOAIFreeTypeTextLine {
 	int lineWidth;
+	u32 startIndex;
 	wchar_t* text;
 };
 
@@ -77,8 +78,8 @@ protected:
 		
 	//----------------------------------------------------------------//
 	void				BuildLine				(wchar_t* buffer, size_t buf_len, int pen_x,
-												 u32 lastChar);
-	void				BuildLine				(wchar_t* buffer, size_t bufferLength);
+												 u32 lastChar, u32 startIndex);
+	void				BuildLine				(wchar_t* buffer, size_t bufferLength, u32 startIndex);
 	USRect				DimensionsOfLine		(cc8* text, float fontSize, FT_Vector **glyphPositions,
 												 FT_Glyph **glyphArray, FT_UInt *glyphNumber, FT_Int *maxDescender);
 	int					ComputeLineStart		(FT_UInt unicode, int lineIndex,

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -63,7 +63,6 @@ protected:
 		
 	//----------------------------------------------------------------//
 	static int			_dimensionsOfLine		( lua_State* L );
-	static int			_getCharacterBounds		( lua_State* L );
 	static int			_getDefaultSize         ( lua_State* L );
 	static int			_getFilename			( lua_State* L );
 	static int			_getFlags				( lua_State* L );
@@ -108,9 +107,6 @@ public:
 	//----------------------------------------------------------------//
 		
 	USRect				DimensionsOfLine		(cc8* text, float fontSize);
-	USRect				GetCharacterBounds		(u32 characterIndex, cc8* text, float width,
-												 float height, int hAlignment, int vAlignment,
-												 int wordbreak, int* basslineY);
 	void				Init					( cc8* filename );
 	static bool			IsWordBreak				(u32 character, int wordBreakMode);
 	static u32			LengthOfUTF8Sequence	(const u32 *sequence);

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -62,6 +62,7 @@ protected:
 		
 	//----------------------------------------------------------------//
 	static int			_dimensionsOfLine		( lua_State* L );
+	static int			_getCharacterBounds		( lua_State* L );
 	static int			_getDefaultSize         ( lua_State* L );
 	static int			_getFilename			( lua_State* L );
 	static int			_getFlags				( lua_State* L );

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -81,7 +81,8 @@ protected:
 												 u32 lastChar, u32 startIndex);
 	void				BuildLine				(wchar_t* buffer, size_t bufferLength, u32 startIndex);
 	USRect				DimensionsOfLine		(cc8* text, float fontSize, FT_Vector **glyphPositions,
-												 FT_Glyph **glyphArray, FT_UInt *glyphNumber, FT_Int *maxDescender);
+												 FT_Glyph **glyphArray, FT_UInt *glyphNumber, FT_Int *maxDescender,
+												 FT_Int *maxAscender);
 	int					ComputeLineStart		(FT_UInt unicode, int lineIndex,
 												 int alignment, FT_Int imgWidth);
 	int					ComputeLineStartY		(int textHeight, FT_Int imgHeight, int vAlign);

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -124,7 +124,8 @@ public:
 												 float height, int hAlignment, int vAlignment,
 												 int wordbreak, bool autoFit, bool returnGlyphBounds,
 												 MOAILuaState& state);
-	MOAITexture*		RenderTextureSingleLine ( cc8* text, float fontSize, USRect *rect );
+	MOAITexture*		RenderTextureSingleLine ( cc8* text, float fontSize, USRect *rect,
+												 bool returnGlyphBounds, MOAILuaState& state );
 	
 };
 

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -23,7 +23,7 @@ class MOAITexture;
 struct MOAIFreeTypeTextLine {
 	int lineWidth;
 	u32 startIndex;
-	wchar_t* text;
+	u32* text;
 };
 
 //================================================================//
@@ -77,9 +77,9 @@ protected:
 	
 		
 	//----------------------------------------------------------------//
-	void				BuildLine				(wchar_t* buffer, size_t buf_len, int pen_x,
+	void				BuildLine				(u32* buffer, size_t buf_len, int pen_x,
 												 u32 lastChar, u32 startIndex);
-	void				BuildLine				(wchar_t* buffer, size_t bufferLength, u32 startIndex);
+	void				BuildLine				(u32* buffer, size_t bufferLength, u32 startIndex);
 	USRect				DimensionsOfLine		(cc8* text, float fontSize, FT_Vector **glyphPositions,
 												 FT_Glyph **glyphArray, FT_UInt *glyphNumber, FT_Int *maxDescender,
 												 FT_Int *maxAscender);
@@ -95,7 +95,7 @@ protected:
 												 int vAlign, bool returnGlyphBounds,
 												 MOAILuaState& state);
 	void				ResetBitmapData			();
-	int					WidthOfString			(wchar_t* buffer, size_t bufferLength);
+	int					WidthOfString			(u32* buffer, size_t bufferLength);
 		
 public:
 		
@@ -113,6 +113,7 @@ public:
 												 int wordbreak, int* basslineY);
 	void				Init					( cc8* filename );
 	static bool			IsWordBreak				(u32 character, int wordBreakMode);
+	static u32			LengthOfUTF8Sequence	(const u32 *sequence);
 	FT_Face				LoadFreeTypeFace		(FT_Library *library);
 						MOAIFreeTypeFont        ();
 						~MOAIFreeTypeFont		();
@@ -127,6 +128,8 @@ public:
 												 MOAILuaState& state);
 	MOAITexture*		RenderTextureSingleLine ( cc8* text, float fontSize, USRect *rect,
 												 bool returnGlyphBounds, MOAILuaState& state );
+	static u32			WideCharStringLength	(u32 *string);
+	
 	
 };
 

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -90,7 +90,8 @@ protected:
 	void				InitBitmapData			( u32 width, u32 height );
 	int					NumberOfLinesToDisplayText(cc8* text, FT_Int imageWidth, int wordBreakMode, bool generateLines);
 	void				RenderLines				( FT_Int imgWidth, FT_Int imgHeight, int hAlign,
-												 int vAlign);
+												 int vAlign, bool returnGlyphBounds,
+												 MOAILuaState& state);
 	void				ResetBitmapData			();
 	int					WidthOfString			(wchar_t* buffer, size_t bufferLength);
 		
@@ -105,6 +106,9 @@ public:
 	//----------------------------------------------------------------//
 		
 	USRect				DimensionsOfLine		(cc8* text, float fontSize);
+	USRect				GetCharacterBounds		(u32 characterIndex, cc8* text, float width,
+												 float height, int hAlignment, int vAlignment,
+												 int wordbreak, int* basslineY);
 	void				Init					( cc8* filename );
 	static bool			IsWordBreak				(u32 character, int wordBreakMode);
 	FT_Face				LoadFreeTypeFace		(FT_Library *library);
@@ -117,7 +121,8 @@ public:
 	void				RegisterLuaFuncs		( MOAILuaState& state );
 	MOAITexture*		RenderTexture			( cc8* text, float size, float width,
 												 float height, int hAlignment, int vAlignment,
-												 int wordbreak, bool autoFit );
+												 int wordbreak, bool autoFit, bool returnGlyphBounds,
+												 MOAILuaState& state);
 	MOAITexture*		RenderTextureSingleLine ( cc8* text, float fontSize, USRect *rect );
 	
 };


### PR DESCRIPTION
Isaac fixed some bugs with text getting cut off, and those are in here.  He also added a thing in renderTexture() and renderTextureSingleLine() that has it pass back glyph position information.  I'm using this in Pounce to figure out the X and Y coordinates of the blank on the rug.  :cat2:  I also added support for it to the latest version of Label.
