### PR TITLE
[FINAL] Added missing param for line spacing

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -187,6 +187,7 @@ int MOAIFreeTypeFont::_optimalSize(lua_State *L){
 	
 	params.granularity = state.GetValue < float > (9, 1.0f);
 	params.roundToInteger = state.GetValue < bool > (10, true);
+	params.lineSpacing = state.GetValue < float > (11, 1.0f);
 	
 	
 	


### PR DESCRIPTION
Fix for lineSpacing param not being assigned when trying to calculate optimal size for a font.
