### PR TITLE
[FINAL] optimal size clean up revert

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1302,7 +1302,6 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 		CHECK_ERROR(error);
 		
 		// compute maximum number of lines allowed at font size.
-		// forceSingleLine sets this value to one if true.
 		lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
 		maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
 		numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -935,6 +935,15 @@ int MOAIFreeTypeFont::GetMaxLinesInArea(u32 lineHeight, float lineSpacing, bool 
 	return maxLines;
 }
 
+bool MOAIFreeTypeFont::IsTextLargerThanArea(cc8* text, FT_Int imageWidth, int wordBreakMode, bool generateLines,
+											float lineSpacing, bool forceSingleLine, float areaHeight) {
+
+	int numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordBreakMode, false);
+	int maxLines = this->GetMaxLinesInArea(this->GetLineHeight(), lineSpacing, forceSingleLine, areaHeight);
+	
+	return (numLines > maxLines || numLines < 0);
+}
+
 void MOAIFreeTypeFont::Init(cc8 *filename) {
 	if ( USFileSys::CheckFileExists ( filename ) ) {
 		this->mFilename = USFileSys::GetAbsoluteFilePath ( filename );
@@ -1277,8 +1286,6 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 									  0);
 	CHECK_ERROR(error);
 	
-	int maxLines = 0;
-	
 	float lowerBoundSize = minFontSize;
 	float upperBoundSize = maxFontSize + 1.0f;
 	
@@ -1290,7 +1297,6 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 	
 	
 	const FT_Int imageWidth = (FT_Int)width;
-	const int numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
 	
 	// test size
 	float testSize = (lowerBoundSize + upperBoundSize) / 2.0f;
@@ -1305,10 +1311,9 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 								 0);
 		CHECK_ERROR(error);
 		
-		// compute maximum number of lines allowed at font size.
-		maxLines = this->GetMaxLinesInArea(this->GetLineHeight(), lineSpacing, forceSingleLine, height);
+		bool isTooLarge = this->IsTextLargerThanArea(text, imageWidth, wordbreak, false, lineSpacing, forceSingleLine, height);
 		
-		if (numLines > maxLines || numLines < 0){ // failure case
+		if (isTooLarge){ // failure case
 			// adjust upper bound downward
 			upperBoundSize = testSize;
 		}
@@ -1339,10 +1344,9 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 							 0);
 	CHECK_ERROR(error);
 
-	// compute maximum number of lines allowed at font size.
-	maxLines = this->GetMaxLinesInArea(this->GetLineHeight(), lineSpacing, forceSingleLine, height);
+	bool isTooLarge = this->IsTextLargerThanArea(text, imageWidth, wordbreak, false, lineSpacing, forceSingleLine, height);
 	
-	if (numLines > maxLines || numLines < 0){ // failure case, which DOES happen rarely
+	if (isTooLarge){ // failure case, which DOES happen rarely
 		// decrement return value by one
 		testSize = testSize - 1.0f;
 		

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1272,6 +1272,8 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 									  0);
 	CHECK_ERROR(error);
 	
+	int numLines = 0;
+	
 	float lowerBoundSize = minFontSize;
 	float upperBoundSize = maxFontSize + 1.0f;
 	
@@ -1287,13 +1289,6 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 	// test size
 	float testSize = (lowerBoundSize + upperBoundSize) / 2.0f;
 
-	// compute maximum number of lines allowed at font size.
-	// forceSingleLine sets this value to one if true.
-	const FT_Pos lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
-	const int maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
-
-	const int numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
-
 	// the minimum difference between upper and lower bound sizes before the binary search stops.
 	do{
 		// set character size to test size
@@ -1303,6 +1298,13 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 								 DPI,
 								 0);
 		CHECK_ERROR(error);
+		
+		// compute maximum number of lines allowed at font size.
+		// forceSingleLine sets this value to one if true.
+		FT_Pos lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
+		int maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
+		
+		numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
 		
 		if (numLines > maxLines || numLines < 0){ // failure case
 			// adjust upper bound downward
@@ -1335,6 +1337,13 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 							 0);
 	CHECK_ERROR(error);
 
+	// compute maximum number of lines allowed at font size.
+	// forceSingleLine sets this value to one if true.
+	FT_Pos lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
+	int maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
+	
+	numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
+	
 	if (numLines > maxLines || numLines < 0){ // failure case, which DOES happen rarely
 		// decrement return value by one
 		testSize = testSize - 1.0f;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1272,6 +1272,8 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 									  0);
 	CHECK_ERROR(error);
 	
+	FT_Pos lineHeight = 0;
+	int maxLines = 0;
 	int numLines = 0;
 	
 	float lowerBoundSize = minFontSize;
@@ -1301,9 +1303,8 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 		
 		// compute maximum number of lines allowed at font size.
 		// forceSingleLine sets this value to one if true.
-		FT_Pos lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
-		int maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
-		
+		lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
+		maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
 		numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
 		
 		if (numLines > maxLines || numLines < 0){ // failure case
@@ -1338,10 +1339,8 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 	CHECK_ERROR(error);
 
 	// compute maximum number of lines allowed at font size.
-	// forceSingleLine sets this value to one if true.
-	FT_Pos lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
-	int maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
-	
+	lineHeight = ((u32)(face->size->metrics.height >> 6) * lineSpacing);
+	maxLines = (forceSingleLine && (height / lineHeight) > 1)? 1 : (height / lineHeight);
 	numLines = this->NumberOfLinesToDisplayText(text, imageWidth, wordbreak, false);
 	
 	if (numLines > maxLines || numLines < 0){ // failure case, which DOES happen rarely

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1277,7 +1277,6 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 									  0);
 	CHECK_ERROR(error);
 	
-	FT_Pos lineHeight = 0;
 	int maxLines = 0;
 	
 	float lowerBoundSize = minFontSize;

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -112,6 +112,7 @@ public:
 												 MOAILuaState& state);
 	float				EstimatedMaxFontSize	(float height, float inputSize);
 	FT_Int				GetLineHeight			();
+	int					GetMaxLinesInArea		(u32 lineHeight, float lineSpacing, bool forceSingleLine, float areaHeight);
 	void				Init					( cc8* filename );
 	bool				IsFreeTypeInitialized	();
 	static bool			IsWordBreak				(u32 character, int wordBreakMode);

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -113,6 +113,8 @@ public:
 	float				EstimatedMaxFontSize	(float height, float inputSize);
 	FT_Int				GetLineHeight			();
 	int					GetMaxLinesInArea		(u32 lineHeight, float lineSpacing, bool forceSingleLine, float areaHeight);
+	bool				IsTextLargerThanArea	(cc8* text, FT_Int imageWidth, int wordBreakMode, bool generateLines,
+												 float lineSpacing, bool forceSingleLine, float areaHeight);
 	void				Init					( cc8* filename );
 	bool				IsFreeTypeInitialized	();
 	static bool			IsWordBreak				(u32 character, int wordBreakMode);


### PR DESCRIPTION
During https://github.com/mindsnacks/moai-dev/pull/47, an attempt was made to clean up a small amount of duplicated code. It turns out that the second occurrence of the code wasn't actually redundant so this reverts the change made in PR 47. (Details: the variable `lineHeight` was assumed to never change within the do while loop so was moved out...turns out the `FT_Set_Char_Size` made non-obvious changes to `face` per iteration)
