### PR TITLE
AKU.cpp: removed call to AKUFinalize on exit.

### DIFF
--- a/src/aku/AKU.cpp
+++ b/src/aku/AKU.cpp
@@ -19,10 +19,6 @@ void AKUSetFunc_##funcname ( AKU##funcname##Func func ) { if ( gContext ) gConte
 //================================================================//
 
 //----------------------------------------------------------------//
-static void _cleanup () {
-
-	AKUFinalize ();
-}
 
 //================================================================//
 // AKUContext
@@ -109,7 +105,6 @@ AKUContextID AKUCreateContext () {
 	if ( gSysInit ) {
 		moaicore::SystemInit ();
 		gContextMap = new ContextMap;
-		atexit ( _cleanup );
 		gSysInit = false;
 	}
 


### PR DESCRIPTION
This was crashing somewhere because of a failed assertion, but it was really 
hard to debug the exact reasons for it. In any case, there is no need to clear
out that memory since the process is going away.
