### PR TITLE
[FINAL] Optimized ProcessOptimalSize.

### DIFF
--- a/src/moaicore/MOAISim.cpp
+++ b/src/moaicore/MOAISim.cpp
@@ -326,6 +326,24 @@ int MOAISim::_getTaskSubscriber ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	isDebug
+ @text	Returns whether the runtime environment was built in debug or release mode.
+
+ @in		MOAIAction self
+ @out	bool true if in debug mode, false if in release mode.
+ */
+int MOAISim::_isDebug ( lua_State* L ) {
+
+#if DEBUG
+	bool isDebug = true;
+#else
+	bool isDebug = false;
+#endif
+
+	lua_pushboolean ( L, isDebug );
+	return 1;
+}
+//----------------------------------------------------------------//
 /**	@name	openWindow
 	@text	Opens a new window for the application to render on.  This must be called before any rendering can be done, and it must only be called once.
 
@@ -784,6 +802,7 @@ void MOAISim::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "getPerformance",				_getPerformance },
 		{ "getStep",					_getStep },
 		{ "getTaskSubscriber",			_getTaskSubscriber },
+		{ "isDebug",					_isDebug },
 		{ "openWindow",					_openWindow },
 		{ "pauseTimer",					_pauseTimer },
 		{ "reportHistogram",			_reportHistogram },

--- a/src/moaicore/MOAISim.h
+++ b/src/moaicore/MOAISim.h
@@ -97,6 +97,7 @@ private:
 	static int		_getPerformance				( lua_State* L );
 	static int		_getStep					( lua_State* L );
 	static int		_getTaskSubscriber			( lua_State* L );
+	static int		_isDebug					( lua_State* L );
 	static int		_openWindow					( lua_State* L );
 	static int		_pauseTimer					( lua_State* L );
 	static int		_reportHistogram			( lua_State* L );

--- a/src/moaicore/MOAITextRenderer.cpp
+++ b/src/moaicore/MOAITextRenderer.cpp
@@ -379,9 +379,9 @@ float MOAITextRenderer::ProcessOptimalSize(cc8 *text){
 		this->mProcessUpperBound = testedFontSize;
 	}
 
-	float nextFontSize = this->mProcessLowerBound + (this->mProcessUpperBound - this->mProcessLowerBound) / 2.0f;
-	nextFontSize -= fmodf(nextFontSize, this->mGranularity);
-	nextFontSize = fmaxf(nextFontSize, this->mMinFontSize);
+	float halfDifference = (this->mProcessUpperBound - this->mProcessLowerBound) / 2.0f;
+	halfDifference -= fmodf(halfDifference, this->mGranularity);
+	float nextFontSize = this->mProcessLowerBound + halfDifference;
 	const bool fontSizeChanged = nextFontSize != testedFontSize;
 
 	if (fontSizeChanged) {

--- a/src/moaicore/MOAITextRenderer.cpp
+++ b/src/moaicore/MOAITextRenderer.cpp
@@ -367,23 +367,25 @@ float MOAITextRenderer::ProcessOptimalSize(cc8 *text){
 		this->mProcessFontSize = this->mProcessUpperBound;
 		this->mProcessRunning = true;
 	}
-
-	this->mProcessFontSize = this->mProcessLowerBound + (this->mProcessUpperBound - this->mProcessLowerBound) / 2.0f;
-	this->mProcessFontSize -= fmodf(this->mProcessFontSize, this->mGranularity);
-
-	if(this->mProcessFontSize <= this->mMinFontSize)
+	else
 	{
-		this->mProcessRunning = false;
-		return this->mMinFontSize;
-	}
+		this->mProcessFontSize = this->mProcessLowerBound + (this->mProcessUpperBound - this->mProcessLowerBound) / 2.0f;
+		this->mProcessFontSize -= fmodf(this->mProcessFontSize, this->mGranularity);
 
-	if(this->TextFitsWithFontSize(text, this->mProcessFontSize))
-	{
-		this->mProcessRunning = false;
-		return this->mProcessFontSize;
-	}
+		if(this->mProcessFontSize <= this->mMinFontSize)
+		{
+			this->mProcessRunning = false;
+			return this->mMinFontSize;
+		}
 
-	this->mProcessUpperBound = this->mProcessFontSize - this->mGranularity;
+		if(this->TextFitsWithFontSize(text, this->mProcessFontSize))
+		{
+			this->mProcessRunning = false;
+			return this->mProcessFontSize;
+		}
+
+		this->mProcessUpperBound = this->mProcessFontSize - this->mGranularity;
+	}
 
 	return (float)PROCESSING_IN_PROGRESS;
 }

--- a/src/moaicore/MOAITextRenderer.cpp
+++ b/src/moaicore/MOAITextRenderer.cpp
@@ -384,9 +384,8 @@ float MOAITextRenderer::ProcessOptimalSize(cc8 *text){
 	nextFontSize = fmaxf(nextFontSize, this->mMinFontSize);
 	const bool fontSizeChanged = nextFontSize != testedFontSize;
 
-	this->mProcessNextCheckFontSize = nextFontSize;
-
 	if (fontSizeChanged) {
+		this->mProcessNextCheckFontSize = nextFontSize;
 		return (float)PROCESSING_IN_PROGRESS;
 	} else {
 		this->mProcessRunning = false;

--- a/src/moaicore/MOAITextRenderer.h
+++ b/src/moaicore/MOAITextRenderer.h
@@ -38,7 +38,7 @@ private:
 	bool			mProcessRunning;
 	float			mProcessLowerBound;
 	float			mProcessUpperBound;
-	float			mProcessFontSize;
+	float			mProcessNextCheckFontSize;
 
 	
 	static int			_processOptimalSize		( lua_State* L );

--- a/src/moaicore/MOAITextRenderer.h
+++ b/src/moaicore/MOAITextRenderer.h
@@ -34,10 +34,12 @@ private:
 	float			mMinFontSize;
 	bool			mForceSingleLine;
 	float			mGranularity;
-	bool			mRoundToInteger;
-	
-	bool			mFirstProcessRun;
-	
+
+	bool			mProcessRunning;
+	float			mProcessLowerBound;
+	float			mProcessUpperBound;
+	float			mProcessFontSize;
+
 	
 	static int			_processOptimalSize		( lua_State* L );
 	static int			_render					( lua_State* L );
@@ -53,7 +55,6 @@ private:
 	static int			_setMaxFontSize			( lua_State* L );
 	static int			_setMinFontSize			( lua_State* L );
 	static int			_setReturnGlyphBounds	( lua_State* L );
-	static int			_setRoundToInteger		( lua_State* L );
 	static int			_setWidth				( lua_State* L );
 	static int			_setWordBreak			( lua_State* L );
 	static int			_setLineSpacing			( lua_State* L );
@@ -68,6 +69,7 @@ public:
 	~MOAITextRenderer ();
 	
 	float				ProcessOptimalSize		(cc8 *text);
+	bool				TextFitsWithFontSize	(cc8 *text, float fontSize);
 	void				RegisterLuaClass		( MOAILuaState& state );
 	void				RegisterLuaFuncs		( MOAILuaState& state );
 };

--- a/src/moaicore/MOAITextRenderer.h
+++ b/src/moaicore/MOAITextRenderer.h
@@ -64,7 +64,8 @@ public:
 	DECL_LUA_FACTORY ( MOAITextRenderer )
 	
 	static const int PROCESSING_IN_PROGRESS = -1;
-	
+	static const int PROCESSING_FAILED      = -2;
+
 	MOAITextRenderer ();
 	~MOAITextRenderer ();
 	


### PR DESCRIPTION
There are two main parts to this PR:
1. Debug. This basically exposes the `DEBUG` compiler macro to LUA via MOAISim. Whatever compiler setting moai was built with is what MOAISim will return when you call `MOAISim.isDebug()`. This is not something we expect to use often, and no games should ever refer to it directly.
2. Optimal text sizing. This first checks the maximum font size for a fit, and then begins a binary search of the font size range. roundToInteger is no longer needed since granularity performs the same function and more. So if you pass in sensible defaults (at least for the max font size), you should see a sizable performance boost over the old code in the common case.
