### PR TITLE
[FINAL] Method in MOAISim to set loop mode fixed

### DIFF
--- a/src/moaicore/MOAISim.cpp
+++ b/src/moaicore/MOAISim.cpp
@@ -532,7 +532,18 @@ int MOAISim::_setLongDelayThreshold ( lua_State* L ) {
 */
 int MOAISim::_setLoopFlags ( lua_State* L ) {
 	MOAILuaState state ( L );
-	MOAISim::Get ().mLoopFlags = state.GetValue < u32 >( 1, 0 );
+	MOAISim::Get ().mLoopFlags |= state.GetValue < u32 >( 1, 0 );
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/**	@name	setLoopFlagFixed
+ @text	Set Loop Flags to MOAISim.LOOP_FLAGS_FIXED
+ @out	nil
+ */
+int MOAISim::_setLoopFlagFixed ( lua_State* L ) {
+	MOAILuaState state ( L );
+	MOAISim::Get ().mLoopFlags = LOOP_FLAGS_FIXED;
 	return 0;
 }
 
@@ -814,6 +825,7 @@ void MOAISim::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "setListener",				&MOAIGlobalEventSource::_setListener < MOAISim > },
 		{ "setLongDelayThreshold",		_setLongDelayThreshold },
 		{ "setLoopFlags",				_setLoopFlags },
+		{ "setLoopFlagFixed",			_setLoopFlagFixed },
 		{ "setLuaAllocLogEnabled",		_setLuaAllocLogEnabled },
 		{ "setStep",					_setStep },
 		{ "setStepMultiplier",			_setStepMultiplier },

--- a/src/moaicore/MOAISim.h
+++ b/src/moaicore/MOAISim.h
@@ -108,6 +108,7 @@ private:
 	static int		_setLeakTrackingEnabled		( lua_State* L );
 	static int		_setLongDelayThreshold		( lua_State* L );
 	static int		_setLoopFlags				( lua_State* L );
+	static int		_setLoopFlagFixed			( lua_State* L );
 	static int		_setLuaAllocLogEnabled		( lua_State* L );
 	static int		_setStep					( lua_State* L );
 	static int		_setStepMultiplier			( lua_State* L );


### PR DESCRIPTION
Seems that removing the OR operator in the setter of the loop flags caused Achilles Mobile to run slowly on the emulator so I've placed it back and created a new method to set the loop mode to fixed. Only called from Achilles Desktop
