### PR TITLE
Feature/ike freetype optimize

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -999,8 +999,7 @@ MOAIFreeTypeFont::MOAIFreeTypeFont():
 	mBitmapWidth(0.0f),
 	mBitmapHeight(0.0f),
 	mGlyphArray( NULL ),
-	mAdvanceArray( NULL ),
-	mDebugCallCount( 0 ){
+	mAdvanceArray( NULL ){
 	
 	RTTI_BEGIN
 		RTTI_EXTEND( MOAILuaObject )
@@ -1498,7 +1497,6 @@ MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width,
 											 int hAlignment, int vAlignment, int wordbreak,
 											 bool autoFit, bool returnGlyphBounds, float lineSpacing, MOAILuaState& state){
 	UNUSED(autoFit);
-	++mDebugCallCount;
 	
 	// initialize library and face
 	this->AffirmFreeTypeFace();

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -39,7 +39,7 @@ static inline void deleteGlyphArray(FT_Glyph *const glyphs, const size_t element
 
 static inline size_t glyphsInText(cc8 *const text)
 {
-	return strlen(text);
+	return u8_strlen(text);
 }
 
 //================================================================//
@@ -1052,6 +1052,8 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 	size_t textLength = 0;
 	size_t lastTokenLength = 0;
 	
+	size_t glyphArrayIndex = 0;
+	
 	u32* textBuffer = NULL;
 	if (generateLines) {
 		textBuffer = (u32 *) calloc(strlen(text), sizeof(u32));
@@ -1087,6 +1089,12 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		}
 		
 		error = FT_Load_Char(face, unicode, FT_LOAD_DEFAULT);
+		
+		CHECK_ERROR(error);
+		
+		// store the glyph in mGlyphArray
+		error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
+		++glyphArrayIndex;
 		
 		CHECK_ERROR(error);
 		
@@ -1483,6 +1491,10 @@ MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width,
 	FT_Int imageWidth = (FT_Int)width;
 	FT_Int imageHeight = (FT_Int)height;
 	
+	// initialize mGlyphArray
+	size_t glyphArraySize = glyphsInText(text);
+	this->mGlyphArray = new FT_Glyph [ glyphArraySize ];
+	
 	// create the image data buffer
 	this->InitBitmapData(imageWidth, imageHeight);
 	
@@ -1500,6 +1512,9 @@ MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width,
 	// create a texture from the image
 	MOAITexture *texture = new MOAITexture();
 	texture->Init(bitmapImg, "");
+	
+	// clean up the glyph array
+	deleteGlyphArray(this->mGlyphArray, glyphArraySize);
 	
 	return texture;
 }

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1538,6 +1538,10 @@ MOAITexture* MOAIFreeTypeFont::RenderTexture(cc8 *text, float size, float width,
 	// clean up the advance array
 	delete [] this->mAdvanceArray;
 	
+	// set member variable arrays to NULL
+	this->mGlyphArray = NULL;
+	this->mAdvanceArray = NULL;
+	
 	return texture;
 }
 

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1067,13 +1067,13 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 	int n = 0;
 	while ( (unicode = u8_nextchar(text, &n) ) ) {
 		
-		startIndex = (u32) lineIndex; //( (int)glyphArrayIndex - rewindCount); //lineIndex;
+		startIndex = (u32) lineIndex;
 		
 		// handle new line
 		if (unicode == '\n'){
 			numberOfLines++;
 			penX = penXReset;
-			lineIndex = tokenIndex = glyphArrayIndex; //n - 1;
+			lineIndex = tokenIndex = glyphArrayIndex;
 			tokenN = n;
 			textLength = lastTokenLength = 0;
 			if (generateLines) {
@@ -1087,7 +1087,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		}
 		// handle word breaking characters
 		else if ( MOAIFreeTypeFont::IsWordBreak(unicode, wordBreakMode) ){
-			tokenIndex = glyphArrayIndex; //n;
+			tokenIndex = glyphArrayIndex;
 			tokenN = n;
 			lastTokenLength = textLength;
 			lastTokenCh = lastCh;
@@ -1143,7 +1143,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 				numberOfLines++;
 				textLength = 0;
 				penX = penXReset;
-				lineIndex = tokenIndex = glyphArrayIndex; //n - 1;
+				lineIndex = tokenIndex = glyphArrayIndex;
 			}
 			else{ // WORD_BREAK_NONE and other modes
 				if (tokenIndex != lineIndex) {
@@ -1168,7 +1168,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 						
 					}
 					// set the rewind count for skipping glyphs already loaded.
-					rewindCount =  (glyphArrayIndex - tokenIndex) - 2; //(n - tokenIndex) - 1;
+					rewindCount =  (glyphArrayIndex - tokenIndex) - 2; 
 					// set n back to the last index
 					n = tokenN;
 					// get the character after token index and update n
@@ -1182,7 +1182,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 					//advance to next line
 					numberOfLines++;
 					penX = penXReset;
-					lineIndex = tokenIndex = glyphArrayIndex - (rewindCount + 1); //n - 1;
+					lineIndex = tokenIndex = glyphArrayIndex - (rewindCount + 1);
 					
 					// reset text length and last token length
 					textLength = lastTokenLength = 0;
@@ -1196,7 +1196,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 						// advance to next line
 						numberOfLines++;
 						penX = penXReset;
-						lineIndex = tokenIndex = glyphArrayIndex; //n - 1;
+						lineIndex = tokenIndex = glyphArrayIndex;
 					}
 					else{
 						// we don't words broken up when calculating optimal size

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1670,12 +1670,9 @@ int MOAIFreeTypeFont::WidthOfString(u32* buffer, size_t bufferLength, u32 startI
 	int totalWidth = 0;
 	FT_Face face = this->mFreeTypeFace;
 	
-	//FT_Error error;
 	
-	//FT_GlyphSlot  slot = face->glyph;
 	FT_UInt previousGlyphIndex = 0;
 	
-	//FT_Glyph* glyphs = new FT_Glyph [bufferLength];
 	FT_Pos* xPositions = new FT_Pos [bufferLength];
 	
 	FT_Pos penX = 0;
@@ -1696,15 +1693,7 @@ int MOAIFreeTypeFont::WidthOfString(u32* buffer, size_t bufferLength, u32 startI
 		}
 		
 		xPositions[n] = (FT_Pos)penX;
-		/*
-		error = FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT);
-		CHECK_ERROR(error);
 		
-		error = FT_Get_Glyph(face->glyph, &glyphs[n]);
-		CHECK_ERROR(error);
-		*/
-		
-		//penX += (slot->advance.x >> 6);
 		penX += (this->mAdvanceArray[index].x >> 6);
 		
 		previousGlyphIndex = glyphIndex;
@@ -1721,7 +1710,6 @@ int MOAIFreeTypeFont::WidthOfString(u32* buffer, size_t bufferLength, u32 startI
 	for (size_t n = 0; n < bufferLength; n++) {
 		u32 index = n + startIndex;
 		
-		//FT_Glyph_Get_CBox( glyphs[n], FT_GLYPH_BBOX_PIXELS, &glyphBoundingBox);
 		FT_Glyph_Get_CBox( this->mGlyphArray[index], FT_GLYPH_BBOX_PIXELS, &glyphBoundingBox);
 		
 		glyphBoundingBox.xMin += xPositions[n];
@@ -1748,7 +1736,6 @@ int MOAIFreeTypeFont::WidthOfString(u32* buffer, size_t bufferLength, u32 startI
 	
 	totalWidth = (int)(boundingBox.xMax - boundingBox.xMin);
 	
-	//deleteGlyphArray(glyphs, bufferLength);
 	delete [] xPositions;
 	
 	return	totalWidth;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -997,7 +997,8 @@ MOAIFreeTypeFont::MOAIFreeTypeFont():
 	mFreeTypeFace( NULL ),
     mBitmapData( NULL ),
 	mBitmapWidth(0.0f),
-	mBitmapHeight(0.0f){
+	mBitmapHeight(0.0f),
+	mGlyphArray( NULL ){
 	
 	RTTI_BEGIN
 		RTTI_EXTEND( MOAILuaObject )

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1071,7 +1071,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		if (unicode == '\n'){
 			numberOfLines++;
 			penX = penXReset;
-			lineIndex = tokenIndex = n;
+			lineIndex = tokenIndex = n - 1;
 			textLength = lastTokenLength = 0;
 			if (generateLines) {
 				this->BuildLine(textBuffer, textLength, startIndex);
@@ -1139,7 +1139,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 				numberOfLines++;
 				textLength = 0;
 				penX = penXReset;
-				lineIndex = tokenIndex = n;
+				lineIndex = tokenIndex = n - 1;
 			}
 			else{ // WORD_BREAK_NONE and other modes
 				if (tokenIndex != lineIndex) {
@@ -1178,7 +1178,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 					//advance to next line
 					numberOfLines++;
 					penX = penXReset;
-					lineIndex = tokenIndex = n;
+					lineIndex = tokenIndex = n - 1;
 					
 					// reset text length and last token length
 					textLength = lastTokenLength = 0;
@@ -1192,7 +1192,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 						// advance to next line
 						numberOfLines++;
 						penX = penXReset;
-						lineIndex = tokenIndex = n;
+						lineIndex = tokenIndex = n - 1;
 					}
 					else{
 						// we don't words broken up when calculating optimal size

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -64,6 +64,11 @@ protected:
 	std::vector<MOAIFreeTypeTextLine> mLineVector;
 	
 	FT_Glyph* mGlyphArray;
+	FT_Vector* mAdvanceArray;
+	
+	// A member variable used for determining which call to a method generated an error.
+	// TODO: remove it in final product
+	u32 mDebugCallCount; 
 		
 	//----------------------------------------------------------------//
 	static int			_dimensionsOfLine		( lua_State* L );
@@ -98,7 +103,7 @@ protected:
 												 int vAlign, bool returnGlyphBounds, float lineSpacing,
 												 MOAILuaState& state);
 	void				ResetBitmapData			();
-	int					WidthOfString			(u32* buffer, size_t bufferLength);
+	int					WidthOfString			(u32* buffer, size_t bufferLength, u32 startIndex = 0);
 	
 	
 	

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -65,10 +65,6 @@ protected:
 	
 	FT_Glyph* mGlyphArray;
 	FT_Vector* mAdvanceArray;
-	
-	// A member variable used for determining which call to a method generated an error.
-	// TODO: remove it in final product
-	u32 mDebugCallCount; 
 		
 	//----------------------------------------------------------------//
 	static int			_dimensionsOfLine		( lua_State* L );

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -62,6 +62,8 @@ protected:
 	u32 mBitmapHeight;
 	
 	std::vector<MOAIFreeTypeTextLine> mLineVector;
+	
+	FT_Glyph* mGlyphArray;
 		
 	//----------------------------------------------------------------//
 	static int			_dimensionsOfLine		( lua_State* L );


### PR DESCRIPTION
This branch should remove some calls to FT_Load_Glyph() when using MOAIFreeTypeFont::_renderTexture() and reduce the amount of time needed to execute that method.

TODO:
- [x] test in Instruments.
