### PR TITLE
Fixed FreeType error

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1103,12 +1103,17 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 			--rewindCount;
 		}
 		else{
-			// store the glyph in mGlyphArray
-			error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
-			CHECK_ERROR(error);
+			if (this->mGlyphArray) {
+				// store the glyph in mGlyphArray
+				error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
+				CHECK_ERROR(error);
+			}
 			
-			// store the advance in mAdvanceArray
-			this->mAdvanceArray[glyphArrayIndex] = face->glyph->advance;
+			if (this->mAdvanceArray) {
+				// store the advance in mAdvanceArray
+				this->mAdvanceArray[glyphArrayIndex] = face->glyph->advance;
+			}
+			
 			
 			++glyphArrayIndex;
 		}


### PR DESCRIPTION
I fixed the error in `MOAIFreeTypeFont::NumberOfLinesToDisplayText()` that was caused by an uninitialized member variable.  This happened when `MOAITextRenderer::_processOptimalSize()` was called.
