### PR TITLE
Fixed issues with new lines that caused runtime errors in MOAIFreeTypeFont

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1074,13 +1074,36 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 			penX = penXReset;
 			lineIndex = tokenIndex = glyphArrayIndex;
 			tokenN = n;
-			textLength = lastTokenLength = 0;
+			
 			if (generateLines) {
 				this->BuildLine(textBuffer, textLength, startIndex);
 				
 				error = FT_Load_Char(face, unicode, FT_LOAD_DEFAULT);
 				CHECK_ERROR(error);
+				
+				if (rewindCount > 0){
+					--rewindCount;
+				}
+				else{
+					if (this->mGlyphArray) {
+						// store the glyph in mGlyphArray
+						error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
+						CHECK_ERROR(error);
+					}
+					
+					if (this->mAdvanceArray) {
+						// store the advance in mAdvanceArray
+						this->mAdvanceArray[glyphArrayIndex] = face->glyph->advance;
+					}
+					
+					
+					++glyphArrayIndex;
+				}
+				
+				
 			}
+			
+			textLength = lastTokenLength = 0;
 			
 			continue;
 		}
@@ -1147,7 +1170,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 				numberOfLines++;
 				textLength = 0;
 				penX = penXReset;
-				lineIndex = tokenIndex = glyphArrayIndex;
+				lineIndex = tokenIndex = glyphArrayIndex -1;
 			}
 			else{ // WORD_BREAK_NONE and other modes
 				if (tokenIndex != lineIndex) {
@@ -1200,7 +1223,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 						// advance to next line
 						numberOfLines++;
 						penX = penXReset;
-						lineIndex = tokenIndex = glyphArrayIndex;
+						lineIndex = tokenIndex = glyphArrayIndex - 1;
 					}
 					else{
 						// we don't words broken up when calculating optimal size

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1085,18 +1085,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 					--rewindCount;
 				}
 				else{
-					if (this->mGlyphArray) {
-						// store the glyph in mGlyphArray
-						error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
-						CHECK_ERROR(error);
-					}
-					
-					if (this->mAdvanceArray) {
-						// store the advance in mAdvanceArray
-						this->mAdvanceArray[glyphArrayIndex] = face->glyph->advance;
-					}
-					
-					
+					this->StoreGlyphAndAdvanceAtIndex(glyphArrayIndex);
 					++glyphArrayIndex;
 				}
 				
@@ -1126,18 +1115,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 			--rewindCount;
 		}
 		else{
-			if (this->mGlyphArray) {
-				// store the glyph in mGlyphArray
-				error = FT_Get_Glyph(face->glyph, &this->mGlyphArray[glyphArrayIndex]);
-				CHECK_ERROR(error);
-			}
-			
-			if (this->mAdvanceArray) {
-				// store the advance in mAdvanceArray
-				this->mAdvanceArray[glyphArrayIndex] = face->glyph->advance;
-			}
-			
-			
+			this->StoreGlyphAndAdvanceAtIndex(glyphArrayIndex);
 			++glyphArrayIndex;
 		}
 		
@@ -1210,6 +1188,14 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 					numberOfLines++;
 					penX = penXReset;
 					lineIndex = tokenIndex = glyphArrayIndex - (rewindCount + 1);
+					
+					if (rewindCount < 0) {
+						// put character in glyph array if rewindCount is negative
+						this->StoreGlyphAndAdvanceAtIndex(glyphArrayIndex);
+						
+						++glyphArrayIndex;
+						
+					}
 					
 					// reset text length and last token length
 					textLength = lastTokenLength = 0;
@@ -1698,6 +1684,18 @@ void MOAIFreeTypeFont::SetCharacterSize(float fontSize){
 	CHECK_ERROR(error);
 }
 
+
+void MOAIFreeTypeFont::StoreGlyphAndAdvanceAtIndex(size_t index){
+	FT_Error error;
+	if (this->mGlyphArray) {
+		error = FT_Get_Glyph(this->mFreeTypeFace->glyph, &this->mGlyphArray[index]);
+		CHECK_ERROR(error);
+	}
+	
+	if (this->mAdvanceArray) {
+		this->mAdvanceArray[index] = this->mFreeTypeFace->glyph->advance;
+	}
+}
 
 // this method assumes that the font size has been set by FT_Set_Size
 int MOAIFreeTypeFont::WidthOfString(u32* buffer, size_t bufferLength, u32 startIndex){

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1581,7 +1581,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	FT_UInt numGlyphs;
 	FT_Error error;
 	
-	const size_t maxGlyphs = glyphsInText(text);
+	const size_t maxGlyphs = strlen(text);
 	
 	FT_Int maxDescender;
 	FT_Int maxAscender;

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -99,6 +99,7 @@ protected:
 												 int vAlign, bool returnGlyphBounds, float lineSpacing,
 												 MOAILuaState& state);
 	void				ResetBitmapData			();
+	void				StoreGlyphAndAdvanceAtIndex		(size_t index);
 	int					WidthOfString			(u32* buffer, size_t bufferLength, u32 startIndex = 0);
 	
 	

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -81,7 +81,7 @@ protected:
 	void				BuildLine				(u32* buffer, size_t buf_len, int pen_x,
 												 u32 lastChar, u32 startIndex);
 	void				BuildLine				(u32* buffer, size_t bufferLength, u32 startIndex);
-	int					ComputeLineStart		(FT_UInt unicode, int lineIndex,
+	int					ComputeLineStart		(FT_UInt unicode, size_t lineIndex,
 												 int alignment, FT_Int imageWidth);
 	int					ComputeLineStartY		(int textHeight, FT_Int imageHeight, int vAlign);
 	USRect				DimensionsOfLine		(cc8* text, float fontSize, FT_Vector **glyphPositions,


### PR DESCRIPTION
I fixed issues regarding newline characters in strings so that the whole string gets displayed and there aren't any errors when freeing the glyph array.  I also fixed the handling of the word break mode WORD_BREAK_CHAR and the case in WORD_BREAK_NONE where the token is too long to fit on a single line.

I did an analysis with the Leaks Instrument and found nothing on the Leaks graph on all six runs.  The Allocations graph shows a spike during loop where MOAITextRenderer::_render() is called up to 5000 times.  After the spike, the graph falls and settles at a level between 15 and 20 MB.  If the loop is short (as in 50 times), the graph settles near the maximum, but a lower number of live bytes.
