### PR TITLE
[FINAL] MOAIParticlePexPlugin initializing properties

### DIFF
--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -572,6 +572,45 @@ int MOAIParticlePexPlugin::_load( lua_State* L ){
 // MOAIParticlePlugin
 //================================================================//
 
+void MOAIParticlePexPlugin::InitializeBasicRegisters( MOAIParticlePexPlugin &plugin ){
+	// start position
+	plugin.mStartXRegister = plugin.mSize++;
+	plugin.mStartYRegister = plugin.mSize++;
+	
+	if(plugin.mEmitterType == EMITTER_GRAVITY)
+	{
+		// gravity vectors
+		plugin.mDirectionXRegister = plugin.mSize++;
+		plugin.mDirectionYRegister = plugin.mSize++;
+	}
+	else
+	{
+		// rotation rate and radius
+		plugin.mRotPerSecondRegister = plugin.mSize++;
+		plugin.mRadialRegister = plugin.mSize++;
+	}
+}
+
+void MOAIParticlePexPlugin::InitializeEmitter(MOAIParticlePexPlugin& plugin){
+	
+	plugin.mEmissionRate =  1.0f / (plugin.mNumParticles / plugin.mLifespan );
+	plugin.mEmissionCount = 1;
+	if( plugin.mEmissionRate <  0.05 )
+	{
+		plugin.mEmissionCount = (u32)ceil( 0.05 / plugin.mEmissionRate );
+		plugin.mEmissionRate *= plugin.mEmissionCount;
+	}
+	
+	float minLifespan = plugin.mLifespan - plugin.mLifespanVariance;
+	if ( minLifespan < 0.0f ) minLifespan = 0.0f;
+	
+	plugin.mLifespanTerm[0] = minLifespan;
+	
+	float maxLifespan = plugin.mLifespan + plugin.mLifespanVariance;
+	
+	plugin.mLifespanTerm[1] = maxLifespan;
+}
+
 void MOAIParticlePexPlugin::InitializeProperties(){
 	// this does not initialize the mParticlePath.
 	
@@ -649,36 +688,10 @@ void MOAIParticlePexPlugin::InitializeProperties(){
 		this->mTanAccelRegister = this->mSize++;
 	}
 	
-	
-	// start position
-	this->mStartXRegister = this->mSize++;
-	this->mStartYRegister = this->mSize++;
-	
-	if(this->mEmitterType == EMITTER_GRAVITY)
-	{
-		// gravity vector
-		this->mDirectionXRegister = this->mSize++;
-		this->mDirectionYRegister = this->mSize++;
-	}
-	else
-	{
-		// rotation rate and radius
-		this->mRotPerSecondRegister = this->mSize++;
-		this->mRadialRegister = this->mSize++;
-	}
-	
+	MOAIParticlePexPlugin::InitializeBasicRegisters( *this );
+		
 	// set up emitter
-	this->mEmissionRate =  1.0f / (this->mNumParticles / this->mLifespan );
-	this->mEmissionCount = 1;
-	if( this->mEmissionRate <  0.05 )
-	{
-		this->mEmissionCount = (u32)ceil( 0.05 / this->mEmissionRate );
-		this->mEmissionRate *= this->mEmissionCount;
-	}
-	
-	this->mLifespanTerm[0] = this->mLifespan - this->mLifespanVariance < 0 ? 0 : this->mLifespan - this->mLifespanVariance;
-	this->mLifespanTerm[1] = this->mLifespan + this->mLifespanVariance;
-	
+	MOAIParticlePexPlugin::InitializeEmitter( *this );
 	
 }
 
@@ -851,31 +864,10 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 			
 		}
 		
-		plugin.mStartXRegister = plugin.mSize++;
-		plugin.mStartYRegister = plugin.mSize++;
-
-		if(plugin.mEmitterType == EMITTER_GRAVITY)
-		{		
-			plugin.mDirectionXRegister = plugin.mSize++;
-			plugin.mDirectionYRegister = plugin.mSize++;
-		}
-		else
-		{
-			plugin.mRotPerSecondRegister = plugin.mSize++;
-			plugin.mRadialRegister = plugin.mSize++;
-		}
-
+		MOAIParticlePexPlugin::InitializeBasicRegisters( plugin );
+		
 		// Set up emitter.
-		plugin.mEmissionRate =  1.0f / (plugin.mNumParticles / plugin.mLifespan );
-		plugin.mEmissionCount = 1;
-		if( plugin.mEmissionRate <  0.05 )
-		{
-			plugin.mEmissionCount = (u32)ceil( 0.05 / plugin.mEmissionRate );
-			plugin.mEmissionRate *= plugin.mEmissionCount;
-		}
-
-		plugin.mLifespanTerm[0] = plugin.mLifespan - plugin.mLifespanVariance < 0 ? 0 : plugin.mLifespan - plugin.mLifespanVariance;
-		plugin.mLifespanTerm[1] = plugin.mLifespan + plugin.mLifespanVariance;
+		MOAIParticlePexPlugin::InitializeEmitter( plugin );
 		
 	}
 }

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -749,7 +749,7 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 				}
 			else if(text == "finishParticleSize")
 				plugin.mFinishSize = (float)atof(attribute->Value());
-			else if(text == "FinishParticleSizeVariance")
+			else if(text == "finishParticleSizeVariance")
 			{
 				plugin.mFinishSizeVariance = (float)atof(attribute->Value());
 				if(plugin.mFinishSizeVariance != 0)

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -515,6 +515,20 @@ int MOAIParticlePexPlugin::_getTextureName( lua_State* L ){
 }
 
 //----------------------------------------------------------------//
+/** @name	initializeProperties
+	@text	Initialize the particle plugin properties set in the load method.
+ 
+	@in		MOAIParticlePexPlugin self
+	@out	nil
+*/
+
+int MOAIParticlePexPlugin::_initializeProperties( lua_State *L ){
+	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
+	self->InitializeProperties();
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /**	@name	load
 	@text	Create a particle plugin from an XML file
 	
@@ -545,6 +559,111 @@ int MOAIParticlePexPlugin::_load( lua_State* L ){
 //================================================================//
 // MOAIParticlePlugin
 //================================================================//
+
+void MOAIParticlePexPlugin::InitializeProperties(){
+	// this does not initialize the mParticlePath.
+	
+	
+	this->mSize = 0;
+	
+	// angle
+	if (this->mAngleVariance != 0){
+		this->mAngleRegister = this->mSize++;
+	}
+	
+	// finish color
+	for (int i = 0; i < 4; i++) {
+		if (this->mFinishColorVariance[i] != 0) {
+			this->mFinishColorRegister[i] = this->mSize++;
+		}
+	}
+	
+	// finish particle size
+	if (this->mFinishSizeVariance != 0) {
+		this->mFinishSizeRegister = this->mSize++;
+	}
+	
+	// maxRadius
+	if (this->mMaxRadiusVariance != 0) {
+		this->mMaxRadiusRegister = this->mSize++;
+	}
+	
+	// particleLifespan
+	if (this->mLifespanVariance != 0) {
+		this->mLifespanRegister = this->mSize++;
+	}
+	
+	// radialAcceleration
+	if (this->mRadialAccelVariance != 0){
+		this->mRadialAccelRegister = this->mSize++;
+	}
+	
+	// rotationEnd
+	if (this->mRotEndVariance != 0){
+		this->mRotEndRegister = this->mSize++;
+	}
+	
+	// rotationStart
+	if (this->mRotStartVariance != 0){
+		this->mRotStartRegister = this->mSize++;
+	}
+	
+	// speed
+	if (this->mSpeedVariance != 0) {
+		this->mSpeedRegister = this->mSize++;
+	}
+	
+	// startColor
+	for (int i = 0; i < 4; i++) {
+		if (this->mStartColorVariance[i] != 0) {
+			this->mStartColorRegister[i] = this->mSize++;
+		}
+	}
+	
+	
+	// startParticleSize
+	if (this->mStartSizeVariance != 0) {
+		this->mStartSizeRegister = this->mSize++;
+	}
+	
+	
+	// tangentialAcceleration
+	if (this->mTanAccelVariance != 0){
+		this->mTanAccelRegister = this->mSize++;
+	}
+	
+	
+	// start position
+	this->mStartXRegister = this->mSize++;
+	this->mStartYRegister = this->mSize++;
+	
+	if(this->mEmitterType == EMITTER_GRAVITY)
+	{
+		// gravity vector
+		this->mDirectionXRegister = this->mSize++;
+		this->mDirectionYRegister = this->mSize++;
+	}
+	else
+	{
+		// rotation rate and radius
+		this->mRotPerSecondRegister = this->mSize++;
+		this->mRadialRegister = this->mSize++;
+	}
+	
+	// set up emitter
+	this->mEmissionRate =  1.0f / (this->mNumParticles / this->mLifespan );
+	this->mEmissionCount = 1;
+	if( this->mEmissionRate <  0.05 )
+	{
+		this->mEmissionCount = (u32)ceil( 0.05 / this->mEmissionRate );
+		this->mEmissionRate *= this->mEmissionCount;
+	}
+	
+	this->mLifespanTerm[0] = this->mLifespan - this->mLifespanVariance < 0 ? 0 : this->mLifespan - this->mLifespanVariance;
+	this->mLifespanTerm[1] = this->mLifespan + this->mLifespanVariance;
+	
+	
+}
 
 
 void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node )
@@ -1298,6 +1417,7 @@ void MOAIParticlePexPlugin::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "getTangentalAccelerationVariance",	_getTangentalAccelerationVariance },
 		{ "setTangentalAccelerationVariance",	_setTangentalAccelerationVariance },
 		{ "getTextureName",						_getTextureName },
+		{ "initializeProperties",				_initializeProperties },
 		{ NULL, NULL }
 	};
 

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -32,7 +32,7 @@
 // lua
 //================================================================//
 
-int MOAIParticlePexPlugin::_getAngle( lua_State* L ){
+int MOAIParticlePexPlugin::_getAngle( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mAngle );
 	return 1;
@@ -44,7 +44,7 @@ int MOAIParticlePexPlugin::_setAngle ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getAngleVariance( lua_State* L ){
+int MOAIParticlePexPlugin::_getAngleVariance( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mAngleVariance );
 	return 1;
@@ -56,7 +56,7 @@ int MOAIParticlePexPlugin::_setAngleVariance ( lua_State* L ) {
 	return 0;
 }
 
-int	MOAIParticlePexPlugin::_getBlendMode( lua_State* L ){
+int	MOAIParticlePexPlugin::_getBlendMode( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mBlendFuncSrc );
 	lua_pushnumber ( state, self->mBlendFuncDst );
@@ -70,7 +70,7 @@ int MOAIParticlePexPlugin::_setBlendMode ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getDuration( lua_State* L ){
+int MOAIParticlePexPlugin::_getDuration( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mDuration );
 	return 1;
@@ -82,13 +82,13 @@ int MOAIParticlePexPlugin::_setDuration ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getEmission( lua_State* L ){
+int MOAIParticlePexPlugin::_getEmission( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mEmissionCount );
 	return 1;
 }
 
-int MOAIParticlePexPlugin::_getEmitterType( lua_State* L ){
+int MOAIParticlePexPlugin::_getEmitterType( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mEmitterType );
 	return 1;
@@ -100,7 +100,7 @@ int MOAIParticlePexPlugin::_setEmitterType ( lua_State* L ) {
 	return 0;
 }
 
-int	MOAIParticlePexPlugin::_getFinishColor ( lua_State* L ){
+int	MOAIParticlePexPlugin::_getFinishColor ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mFinishColor[0] );
 	lua_pushnumber ( state, self->mFinishColor[1] );
@@ -118,7 +118,7 @@ int MOAIParticlePexPlugin::_setFinishColor ( lua_State* L ) {
 	return 0;
 }
 
-int	MOAIParticlePexPlugin::_getFinishColorVariance ( lua_State* L ){
+int	MOAIParticlePexPlugin::_getFinishColorVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mFinishColorVariance[0] );
 	lua_pushnumber ( state, self->mFinishColorVariance[1] );
@@ -136,7 +136,7 @@ int MOAIParticlePexPlugin::_setFinishColorVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getFinishParticleSize ( lua_State* L ){
+int MOAIParticlePexPlugin::_getFinishParticleSize ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mFinishSize );
 	return 1;
@@ -148,7 +148,7 @@ int MOAIParticlePexPlugin::_setFinishParticleSize ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getFinishParticleSizeVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getFinishParticleSizeVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mFinishSizeVariance );
 	return 1;
@@ -160,13 +160,13 @@ int MOAIParticlePexPlugin::_setFinishParticleSizeVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getFrequency( lua_State* L ){
+int MOAIParticlePexPlugin::_getFrequency( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mEmissionRate );
 	return 1;
 }
 
-int MOAIParticlePexPlugin::_getGravity( lua_State* L ){
+int MOAIParticlePexPlugin::_getGravity( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mGravity[0] );
 	lua_pushnumber ( state, self->mGravity[1] );
@@ -180,14 +180,14 @@ int MOAIParticlePexPlugin::_setGravity ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getLifespan		( lua_State* L ){
+int MOAIParticlePexPlugin::_getLifespan		( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mLifespanTerm[0] );
 	lua_pushnumber ( state, self->mLifespanTerm[1] );
 	return 2;
 }
 
-int MOAIParticlePexPlugin::_getMaxParticles ( lua_State* L ){
+int MOAIParticlePexPlugin::_getMaxParticles ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mNumParticles );
 	return 1;
@@ -199,7 +199,7 @@ int MOAIParticlePexPlugin::_setMaxParticles ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getMaxRadius ( lua_State* L ){
+int MOAIParticlePexPlugin::_getMaxRadius ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mMaxRadius );
 	return 1;
@@ -211,7 +211,7 @@ int MOAIParticlePexPlugin::_setMaxRadius ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getMaxRadiusVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getMaxRadiusVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mMaxRadiusVariance );
 	return 1;
@@ -223,7 +223,7 @@ int MOAIParticlePexPlugin::_setMaxRadiusVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getMinRadius ( lua_State* L ){
+int MOAIParticlePexPlugin::_getMinRadius ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mMinRadius );
 	return 1;
@@ -235,7 +235,7 @@ int MOAIParticlePexPlugin::_setMinRadius ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getMinRadiusVariance ( lua_State *L ){
+int MOAIParticlePexPlugin::_getMinRadiusVariance ( lua_State *L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mMinRadiusVariance );
 	return 1;
@@ -247,7 +247,7 @@ int MOAIParticlePexPlugin::_setMinRadiusVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getParticleLifespan ( lua_State* L ){
+int MOAIParticlePexPlugin::_getParticleLifespan ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mLifespan );
 	return 1;
@@ -271,7 +271,7 @@ int MOAIParticlePexPlugin::_setParticleLifespanVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRadialAcceleration ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRadialAcceleration ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRadialAcceleration );
 	return 1;
@@ -283,7 +283,7 @@ int MOAIParticlePexPlugin::_setRadialAcceleration ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRadialAccelVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRadialAccelVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRadialAccelVariance );
 	return 1;
@@ -304,7 +304,7 @@ int MOAIParticlePexPlugin::_getRect( lua_State* L ){
 	return 4;
 }
 
-int MOAIParticlePexPlugin::_getRotatePerSecond ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRotatePerSecond ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRotPerSecond );
 	return 1;
@@ -316,7 +316,7 @@ int MOAIParticlePexPlugin::_setRotatePerSecond ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRotatePerSecondVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRotatePerSecondVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRotPerSecondVariance );
 	return 1;
@@ -328,7 +328,7 @@ int MOAIParticlePexPlugin::_setRotatePerSecondVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRotationEnd ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRotationEnd ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRotEnd );
 	return 1;
@@ -340,7 +340,7 @@ int MOAIParticlePexPlugin::_setRotationEnd ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRotationEndVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRotationEndVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRotEndVariance );
 	return 1;
@@ -352,7 +352,7 @@ int MOAIParticlePexPlugin::_setRotationEndVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRotationStart ( lua_State* L ){
+int MOAIParticlePexPlugin::_getRotationStart ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mRotStart );
 	return 1;
@@ -364,19 +364,19 @@ int MOAIParticlePexPlugin::_setRotationStart ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getRotationStartVariance( lua_State *L ){
+int MOAIParticlePexPlugin::_getRotationStartVariance( lua_State *L ) {
 	MOAI_LUA_SETUP( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber( state, self->mRotStartVariance );
 	return 1;
 }
 
-int MOAIParticlePexPlugin::_setRotationStartVariance( lua_State *L ){
+int MOAIParticlePexPlugin::_setRotationStartVariance( lua_State *L ) {
 	MOAI_LUA_SETUP( MOAIParticlePexPlugin, "UN" )
 	self->mRotStartVariance = state.GetValue < float >( 2, 0 );
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getSourcePosition ( lua_State* L ){
+int MOAIParticlePexPlugin::_getSourcePosition ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mSourcePos[0] );
 	lua_pushnumber ( state, self->mSourcePos[1] );
@@ -390,7 +390,7 @@ int MOAIParticlePexPlugin::_setSourcePosition ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getSourcePositionVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getSourcePositionVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mSourcePosVariance[0] );
 	lua_pushnumber ( state, self->mSourcePosVariance[1] );
@@ -404,7 +404,7 @@ int MOAIParticlePexPlugin::_setSourcePositionVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getSpeed ( lua_State* L ){
+int MOAIParticlePexPlugin::_getSpeed ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mSpeed );
 	return 1;
@@ -416,7 +416,7 @@ int MOAIParticlePexPlugin::_setSpeed ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getSpeedVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getSpeedVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mSpeedVariance );
 	return 1;
@@ -428,7 +428,7 @@ int MOAIParticlePexPlugin::_setSpeedVariance ( lua_State* L ) {
 	return 0;
 }
 
-int	MOAIParticlePexPlugin::_getStartColor ( lua_State* L ){
+int	MOAIParticlePexPlugin::_getStartColor ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mStartColor[0] );
 	lua_pushnumber ( state, self->mStartColor[1] );
@@ -446,7 +446,7 @@ int MOAIParticlePexPlugin::_setStartColor ( lua_State* L ) {
 	return 0;
 }
 
-int	MOAIParticlePexPlugin::_getStartColorVariance ( lua_State* L ){
+int	MOAIParticlePexPlugin::_getStartColorVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mStartColorVariance[0] );
 	lua_pushnumber ( state, self->mStartColorVariance[1] );
@@ -464,7 +464,7 @@ int MOAIParticlePexPlugin::_setStartColorVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getStartParticleSize ( lua_State* L ){
+int MOAIParticlePexPlugin::_getStartParticleSize ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mStartSize );
 	return 1;
@@ -488,7 +488,7 @@ int MOAIParticlePexPlugin::_setStartParticleSizeVariance ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getTangentalAcceleration ( lua_State* L ){
+int MOAIParticlePexPlugin::_getTangentalAcceleration ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mTanAccel );
 	return 1;
@@ -500,7 +500,7 @@ int MOAIParticlePexPlugin::_setTangentalAcceleration ( lua_State* L ) {
 	return 0;
 }
 
-int MOAIParticlePexPlugin::_getTangentalAccelerationVariance ( lua_State* L ){
+int MOAIParticlePexPlugin::_getTangentalAccelerationVariance ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mTanAccelVariance );
 	return 1;
@@ -519,7 +519,7 @@ int MOAIParticlePexPlugin::_setTangentalAccelerationVariance ( lua_State* L ) {
 	@in		MOAIParticlePlugin self
 	@out	string textureName
 */
-int MOAIParticlePexPlugin::_getTextureName( lua_State* L ){
+int MOAIParticlePexPlugin::_getTextureName( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 
 		lua_pushstring( state, self->mTextureName);
@@ -534,7 +534,7 @@ int MOAIParticlePexPlugin::_getTextureName( lua_State* L ){
 	@out	nil
 */
 
-int MOAIParticlePexPlugin::_initializeProperties( lua_State *L ){
+int MOAIParticlePexPlugin::_initializeProperties( lua_State *L ) {
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	self->InitializeProperties();
 	return 0;
@@ -547,7 +547,7 @@ int MOAIParticlePexPlugin::_initializeProperties( lua_State *L ){
 	@in		String file to load
 	@out	MOAIParticlePexPlugin - The plugin object that has been initialized with XML's data
 */
-int MOAIParticlePexPlugin::_load( lua_State* L ){
+int MOAIParticlePexPlugin::_load( lua_State* L ) {
 
 	MOAILuaState state ( L );										
 	if ( !state.CheckParams ( 1, "S" )) {							
@@ -572,37 +572,36 @@ int MOAIParticlePexPlugin::_load( lua_State* L ){
 // MOAIParticlePlugin
 //================================================================//
 
-void MOAIParticlePexPlugin::InitializeBasicRegisters( MOAIParticlePexPlugin &plugin ){
+void MOAIParticlePexPlugin::InitializeBasicRegisters( MOAIParticlePexPlugin &plugin ) {
 	// start position
 	plugin.mStartXRegister = plugin.mSize++;
 	plugin.mStartYRegister = plugin.mSize++;
 	
-	if(plugin.mEmitterType == EMITTER_GRAVITY)
-	{
+	if ( plugin.mEmitterType == EMITTER_GRAVITY ) {
 		// gravity vectors
 		plugin.mDirectionXRegister = plugin.mSize++;
 		plugin.mDirectionYRegister = plugin.mSize++;
 	}
-	else
-	{
+	else {
 		// rotation rate and radius
 		plugin.mRotPerSecondRegister = plugin.mSize++;
 		plugin.mRadialRegister = plugin.mSize++;
 	}
 }
 
-void MOAIParticlePexPlugin::InitializeEmitter(MOAIParticlePexPlugin& plugin){
+void MOAIParticlePexPlugin::InitializeEmitter(MOAIParticlePexPlugin& plugin) {
 	
 	plugin.mEmissionRate =  1.0f / (plugin.mNumParticles / plugin.mLifespan );
 	plugin.mEmissionCount = 1;
-	if( plugin.mEmissionRate <  0.05 )
-	{
+	if( plugin.mEmissionRate <  0.05 ) {
 		plugin.mEmissionCount = (u32)ceil( 0.05 / plugin.mEmissionRate );
 		plugin.mEmissionRate *= plugin.mEmissionCount;
 	}
 	
 	float minLifespan = plugin.mLifespan - plugin.mLifespanVariance;
-	if ( minLifespan < 0.0f ) minLifespan = 0.0f;
+	if ( minLifespan < 0.0f ) {
+		minLifespan = 0.0f;
+	}
 	
 	plugin.mLifespanTerm[0] = minLifespan;
 	
@@ -611,14 +610,14 @@ void MOAIParticlePexPlugin::InitializeEmitter(MOAIParticlePexPlugin& plugin){
 	plugin.mLifespanTerm[1] = maxLifespan;
 }
 
-void MOAIParticlePexPlugin::InitializeProperties(){
+void MOAIParticlePexPlugin::InitializeProperties() {
 	// this does not initialize the mParticlePath.
 	
 	
 	this->mSize = 0;
 	
 	// angle
-	if (this->mAngleVariance != 0){
+	if (this->mAngleVariance != 0) {
 		this->mAngleRegister = this->mSize++;
 	}
 	
@@ -650,17 +649,17 @@ void MOAIParticlePexPlugin::InitializeProperties(){
 	}
 	
 	// radialAcceleration
-	if (this->mRadialAccelVariance != 0){
+	if (this->mRadialAccelVariance != 0) {
 		this->mRadialAccelRegister = this->mSize++;
 	}
 	
 	// rotationEnd
-	if (this->mRotEndVariance != 0){
+	if (this->mRotEndVariance != 0) {
 		this->mRotEndRegister = this->mSize++;
 	}
 	
 	// rotationStart
-	if (this->mRotStartVariance != 0){
+	if (this->mRotStartVariance != 0) {
 		this->mRotStartRegister = this->mSize++;
 	}
 	
@@ -684,7 +683,7 @@ void MOAIParticlePexPlugin::InitializeProperties(){
 	
 	
 	// tangentialAcceleration
-	if (this->mTanAccelVariance != 0){
+	if (this->mTanAccelVariance != 0) {
 		this->mTanAccelRegister = this->mSize++;
 	}
 	
@@ -696,8 +695,7 @@ void MOAIParticlePexPlugin::InitializeProperties(){
 }
 
 
-void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node )
-{
+void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node ) {
 	if ( !node ) return;
 	
 	plugin.mParticlePath = filename;
@@ -718,146 +716,172 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 			STLString text = childElement->Value ();
 			TiXmlAttribute* attribute = childElement->FirstAttribute ();
 			int i = 0;
-			if(!attribute || !text || text == "")
+			if (!attribute || !text || text == "")
 				continue;
 
-			if(text == "angle")
+			if (text == "angle") {
 				plugin.mAngle = (float)atof(attribute->Value());
-			else if(text == "angleVariance")
-			{
-				plugin.mAngleVariance = (float)atof(attribute->Value());
-				if(plugin.mAngleVariance != 0)
-					plugin.mAngleRegister = plugin.mSize++;
 			}
-			else if(text == "blendFuncSource")
+			else if (text == "angleVariance") {
+				plugin.mAngleVariance = (float)atof(attribute->Value());
+				if (plugin.mAngleVariance != 0) {
+					plugin.mAngleRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "blendFuncSource") {
 				plugin.mBlendFuncSrc = atoi(attribute->Value());
-			else if(text == "blendFuncDestination")
+			}
+			else if (text == "blendFuncDestination") {
 				plugin.mBlendFuncDst = atoi(attribute->Value());
-			else if(text == "duration")
+			}
+			else if (text == "duration") {
 				plugin.mDuration = (float)atof(attribute->Value());
-			else if(text == "emitterType")
+			}
+			else if (text == "emitterType") {
 				plugin.mEmitterType = (EmitterType)atoi(attribute->Value());
-			else if(text == "finishColor")
+			}
+			else if (text == "finishColor") {
 				for ( ; attribute; attribute = attribute->Next (), i++) {
 					plugin.mFinishColor[i] = (float)atof(attribute->Value());
 				}
-			else if(text == "finishColorVariance")
+			}
+			else if (text == "finishColorVariance") {
 				for ( ; attribute; attribute = attribute->Next (), i++) {
 					plugin.mFinishColorVariance[i] = (float)atof(attribute->Value());
-					if(plugin.mFinishColorVariance[i] != 0)
+					if (plugin.mFinishColorVariance[i] != 0) {
 						plugin.mFinishColorRegister[i] = plugin.mSize++;
+					}
 				}
-			else if(text == "finishParticleSize")
-				plugin.mFinishSize = (float)atof(attribute->Value());
-			else if(text == "finishParticleSizeVariance")
-			{
-				plugin.mFinishSizeVariance = (float)atof(attribute->Value());
-				if(plugin.mFinishSizeVariance != 0)
-						plugin.mFinishSizeRegister = plugin.mSize++;
 			}
-			else if(text == "gravity")
+			else if (text == "finishParticleSize") {
+				plugin.mFinishSize = (float)atof(attribute->Value());
+			}
+			else if (text == "finishParticleSizeVariance") {
+				plugin.mFinishSizeVariance = (float)atof(attribute->Value());
+				if (plugin.mFinishSizeVariance != 0) {
+						plugin.mFinishSizeRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "gravity") {
 				for ( ; attribute; attribute = attribute->Next (), i++) {
 					plugin.mGravity[i] = (float)atof(attribute->Value());
 				}
-			else if(text == "maxParticles")
-				plugin.mNumParticles = atoi(attribute->Value());
-			else if(text == "maxRadius")
-				plugin.mMaxRadius = (float)atof(attribute->Value());
-			else if(text == "maxRadiusVariance")
-			{
-				plugin.mMaxRadiusVariance = (float)atof(attribute->Value());
-				if(plugin.mMaxRadiusVariance != 0)
-						plugin.mMaxRadiusRegister = plugin.mSize++;
 			}
-			else if(text == "minRadius")
+			else if (text == "maxParticles") {
+				plugin.mNumParticles = atoi(attribute->Value());
+			}
+			else if (text == "maxRadius") {
+				plugin.mMaxRadius = (float)atof(attribute->Value());
+			}
+			else if( text == "maxRadiusVariance") {
+				plugin.mMaxRadiusVariance = (float)atof(attribute->Value());
+				if (plugin.mMaxRadiusVariance != 0) {
+						plugin.mMaxRadiusRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "minRadius") {
 				plugin.mMinRadius = (float)atof(attribute->Value());
-			else if(text == "minRadiusVariance")
+			}
+			else if (text == "minRadiusVariance")
 			{
 				plugin.mMinRadiusVariance = (float)atof(attribute->Value());
-				if (plugin.mMinRadiusVariance != 0)
+				if (plugin.mMinRadiusVariance != 0) {
 						plugin.mMinRadiusRegister = plugin.mSize++;
+				}
 			}
-			else if(text == "particleLifeSpan")
+			else if (text == "particleLifeSpan") {
 				plugin.mLifespan = (float)atof(attribute->Value());
-			else if(text == "particleLifespanVariance")
-			{
+			}
+			else if (text == "particleLifespanVariance") {
 				plugin.mLifespanVariance = (float)atof(attribute->Value());
-				if(plugin.mLifespanVariance != 0)
+				if (plugin.mLifespanVariance != 0) {
 						plugin.mLifespanRegister = plugin.mSize++;
+				}
 			}
-			else if(text == "radialAcceleration")
+			else if (text == "radialAcceleration") {
 				plugin.mRadialAcceleration = (float)atof(attribute->Value());
-			else if(text == "radialAccelVariance")
-			{
-				plugin.mRadialAccelVariance = (float)atof(attribute->Value());
-				if(plugin.mRadialAccelVariance != 0)
-						plugin.mRadialAccelRegister = plugin.mSize++;
 			}
-			else if(text == "rotatePerSecond")
+			else if (text == "radialAccelVariance") {
+				plugin.mRadialAccelVariance = (float)atof(attribute->Value());
+				if (plugin.mRadialAccelVariance != 0) {
+						plugin.mRadialAccelRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "rotatePerSecond") {
 				plugin.mRotPerSecond = (float)atof(attribute->Value());
-			else if(text == "rotatePerSecondVariance")
-			{
+			}
+			else if (text == "rotatePerSecondVariance") {
 				plugin.mRotPerSecondVariance = (float)atof(attribute->Value());
 			}
-			else if(text == "rotationEnd")
+			else if (text == "rotationEnd") {
 				plugin.mRotEnd = (float)atof(attribute->Value());
-			else if(text == "rotationEndVariance")
-			{
+			}
+			else if (text == "rotationEndVariance") {
 				plugin.mRotEndVariance = (float)atof(attribute->Value());
-				if(plugin.mRotEndVariance != 0)
+				if (plugin.mRotEndVariance != 0) {
 						plugin.mRotEndRegister = plugin.mSize++;
+				}
 			}
-			else if(text == "rotationStart")
+			else if (text == "rotationStart") {
 				plugin.mRotStart = (float)atof(attribute->Value());
-			else if(text == "rotationStartVariance")
-			{
-				plugin.mRotStartVariance = (float)atof(attribute->Value());
-				if(plugin.mRotStartVariance != 0)
-						plugin.mRotStartRegister = plugin.mSize++;
 			}
-			else if(text == "sourcePosition")
+			else if (text == "rotationStartVariance") {
+				plugin.mRotStartVariance = (float)atof(attribute->Value());
+				if (plugin.mRotStartVariance != 0) {
+						plugin.mRotStartRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "sourcePosition") {
 				for ( ; attribute; attribute = attribute->Next (), i++) {
 						plugin.mSourcePos[i] = (float)atof(attribute->Value());
 					}
-			else if(text == "sourcePositionVariance")
+			}
+			else if (text == "sourcePositionVariance") {
 				for ( ; attribute; attribute = attribute->Next (), i++) {
 						plugin.mSourcePosVariance[i] = (float)atof(attribute->Value());
 					}
-			else if(text == "speed")
+			}
+			else if (text == "speed") {
 				plugin.mSpeed = (float)atof(attribute->Value());
-			else if(text == "speedVariance")
-			{
+			}
+			else if (text == "speedVariance") {
 				plugin.mSpeedVariance = (float)atof(attribute->Value());
-				if(plugin.mSpeedVariance != 0)
+				if (plugin.mSpeedVariance != 0) {
 					plugin.mSpeedRegister = plugin.mSize++;
+				}
 			}
-			else if(text == "startColor")
-					for ( ; attribute; attribute = attribute->Next (), i++) {
-						plugin.mStartColor[i] = (float)atof(attribute->Value());
+			else if (text == "startColor") {
+				for ( ; attribute; attribute = attribute->Next (), i++) {
+					plugin.mStartColor[i] = (float)atof(attribute->Value());
+				}
+			}
+			else if (text == "startColorVariance") {
+				for ( ; attribute; attribute = attribute->Next (), i++) {
+					plugin.mStartColorVariance[i] = (float)atof(attribute->Value());
+					if (plugin.mStartColorVariance[i] != 0) {
+						plugin.mStartColorRegister[i] = plugin.mSize++;
 					}
-			else if(text == "startColorVariance")
-					for ( ; attribute; attribute = attribute->Next (), i++) {
-						plugin.mStartColorVariance[i] = (float)atof(attribute->Value());
-						if(plugin.mStartColorVariance[i] != 0)
-							plugin.mStartColorRegister[i] = plugin.mSize++;
-					}
-			else if(text == "startParticleSize")
+				}
+			}
+			else if (text == "startParticleSize") {
 				plugin.mStartSize = (float)atof(attribute->Value());
-			else if(text == "startParticleSizeVariance")
-			{
+			}
+			else if (text == "startParticleSizeVariance") {
 				plugin.mStartSizeVariance = (float)atof(attribute->Value());
-				if(plugin.mStartSizeVariance != 0)
+				if(plugin.mStartSizeVariance != 0) {
 					plugin.mStartSizeRegister = plugin.mSize++;
+				}
 			}
-			else if(text == "tangentialAcceleration")
+			else if (text == "tangentialAcceleration") {
 				plugin.mTanAccel = (float)atof(attribute->Value());
-			else if(text == "tangentialAccelVariance")
-			{
-				plugin.mTanAccelVariance = (float)atof(attribute->Value());
-				if(plugin.mTanAccelVariance != 0)
-					plugin.mTanAccelRegister = plugin.mSize++;
 			}
-			else if(text == "texture") {
+			else if (text == "tangentialAccelVariance") {
+				plugin.mTanAccelVariance = (float)atof(attribute->Value());
+				if (plugin.mTanAccelVariance != 0) {
+					plugin.mTanAccelRegister = plugin.mSize++;
+				}
+			}
+			else if (text == "texture") {
 				plugin.mTextureName = absDirPath;
 				plugin.mTextureName.append ( attribute->Value ());
 			}
@@ -872,61 +896,49 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 	}
 }
 
-void MOAIParticlePexPlugin::_initGravityScript( float* particle, float* registers)
-{
+void MOAIParticlePexPlugin::_initGravityScript( float* particle, float* registers) {
 	// Set colors.
-	for(int i = 0; i < 4; i++)
-	{
+	for (int i = 0; i < 4; i++) {
 
-		if(mStartColorRegister[i] > -1 )
-		{
+		if (mStartColorRegister[i] > -1) {
 			float minVal = mStartColor[i] - mStartColorVariance[i] < 0 ? 0 : mStartColor[i] - mStartColorVariance[i];	
 			registers[mStartColorRegister[i]] = USFloat::Rand (minVal,  mStartColor[i] + mStartColorVariance[i] );
 		}	
 
-			
-		if(this->mFinishColorRegister[i]  > -1 )
-		{
+		if (this->mFinishColorRegister[i]  > -1) {
 			float minVal = mFinishColor[i] - mFinishColorVariance[i] < 0 ? 0 : mFinishColor[i] - mFinishColorVariance[i];	
 			registers[mFinishColorRegister[i]] =USFloat::Rand (minVal,  mFinishColor[i] + mFinishColorVariance[i] );
 		}
 			
 	}
 
-	if(mStartSizeRegister > -1)
-	{
+	if (mStartSizeRegister > -1) {
 		float minVal = mStartSize - mStartSizeVariance < 0 ? 0 :  mStartSize - mStartSizeVariance;
 		registers[mStartSizeRegister] = USFloat::Rand (minVal,  mStartSize + mStartSizeVariance);
 	}
 
 			
-	if(mFinishSizeRegister > -1)
-	{
+	if (mFinishSizeRegister > -1) {
 		float minVal = mFinishSize - mFinishSizeVariance < 0 ? 0 :  mFinishSize - mFinishSizeVariance;
 		registers[mFinishSizeRegister] = USFloat::Rand (minVal,  mFinishSize + mFinishSizeVariance);
 	}
 
-	if(mRotStartRegister > -1 )
+	if (mRotStartRegister > -1 ) {
 		registers[mRotStartRegister] = USFloat::Rand (mRotStart-mRotStartVariance, mRotStart+mRotStartVariance);
-	
+	}
 
-	if(mRotEndRegister > -1)
+	if (mRotEndRegister > -1) {
 		registers[mRotStartRegister] = USFloat::Rand (mRotEnd-mRotEndVariance, mRotEnd+mRotEndVariance);
-
+	}
 
 	float angleStartDeg;
-	if(mAngleRegister > -1)
-	{
-
+	if (mAngleRegister > -1) {
 		float randAngle = USFloat::Rand (mAngle - mAngleVariance, mAngle + mAngleVariance);
 		angleStartDeg = (float)(atan2 ( particle[MOAIParticle::PARTICLE_DY], particle[MOAIParticle::PARTICLE_DX] ) * R2D) + randAngle;
 		particle[MOAIParticle::PARTICLE_DX] = (float)Cos(angleStartDeg * (float)D2R);
 		particle[MOAIParticle::PARTICLE_DY] = (float)Sin(angleStartDeg * (float)D2R);
-		
-
 	}
-	else
-	{
+	else {
 		angleStartDeg = (float)(atan2 ( particle[MOAIParticle::PARTICLE_DY], particle[MOAIParticle::PARTICLE_DX] ) * R2D) + mAngle;
 		particle[MOAIParticle::PARTICLE_DX] = (float)Cos(angleStartDeg * (float)D2R);
 		particle[MOAIParticle::PARTICLE_DY] = (float)Sin(angleStartDeg * (float)D2R);
@@ -934,14 +946,12 @@ void MOAIParticlePexPlugin::_initGravityScript( float* particle, float* register
 
 	
 	// Set initial speed
-	if(mSpeedRegister > -1)
-	{
+	if (mSpeedRegister > -1) {
 		registers[mSpeedRegister] = USFloat::Rand(mSpeed - mSpeedVariance, mSpeed + mSpeedVariance);
 		registers[mDirectionXRegister] = particle[MOAIParticle::PARTICLE_DX] * registers[mSpeedRegister];
 		registers[mDirectionYRegister] = particle[MOAIParticle::PARTICLE_DY] * registers[mSpeedRegister];
 	}
-	else
-	{
+	else {
 		registers[mDirectionXRegister] = particle[MOAIParticle::PARTICLE_DX] * mSpeed;
 		registers[mDirectionYRegister] = particle[MOAIParticle::PARTICLE_DY] * mSpeed;
 	}
@@ -949,61 +959,54 @@ void MOAIParticlePexPlugin::_initGravityScript( float* particle, float* register
 	registers[mStartXRegister] = particle[MOAIParticle::PARTICLE_X];
 	registers[mStartYRegister] = particle[MOAIParticle::PARTICLE_Y];
 	
-	if(mRadialAccelRegister > -1)
+	if (mRadialAccelRegister > -1) {
 		registers[mRadialAccelRegister] = USFloat::Rand(mRadialAcceleration - mRadialAccelVariance, mRadialAcceleration + mRadialAccelVariance);
-
+	}
 	
-	if(mTanAccelRegister > -1)
+	if (mTanAccelRegister > -1) {
 		registers[mTanAccelRegister] = USFloat::Rand(mTanAccel - mTanAccelVariance, mTanAccel + mTanAccelVariance);
-
+	}
 }
 		
-void MOAIParticlePexPlugin::_initRadialScript( float* particle, float* registers)
-{
+void MOAIParticlePexPlugin::_initRadialScript( float* particle, float* registers) {
 
 	// Set colors.
-	for(int i = 0; i < 4; i++)
-	{
+	for (int i = 0; i < 4; i++) {
 
-		if(mStartColorRegister[i] > -1 )
-		{
+		if (mStartColorRegister[i] > -1 ) {
 			float minVal = mStartColor[i] - mStartColorVariance[i] < 0 ? 0 : mStartColor[i] - mStartColorVariance[i];	
 			registers[mStartColorRegister[i]] = USFloat::Rand (minVal,  mStartColor[i] + mStartColorVariance[i] );
 		}	
 
 			
-		if(this->mFinishColorRegister[i]  > -1 )
-		{
+		if (this->mFinishColorRegister[i]  > -1 ) {
 			float minVal = mFinishColor[i] - mFinishColorVariance[i] < 0 ? 0 : mFinishColor[i] - mFinishColorVariance[i];	
 			registers[mFinishColorRegister[i]] =USFloat::Rand (minVal,  mFinishColor[i] + mFinishColorVariance[i] );
 		}
 			
 	}
 
-	if(mStartSizeRegister > -1)
-	{
+	if (mStartSizeRegister > -1) {
 		float minVal = mStartSize - mStartSizeVariance < 0 ? 0 :  mStartSize - mStartSizeVariance;
 		registers[mStartSizeRegister] = USFloat::Rand (minVal,  mStartSize + mStartSizeVariance);
 	}
 
 			
-	if(mFinishSizeRegister > -1)
-	{
+	if (mFinishSizeRegister > -1) {
 		float minVal = mFinishSize - mFinishSizeVariance < 0 ? 0 :  mFinishSize - mFinishSizeVariance;
 		registers[mFinishSizeRegister] = USFloat::Rand (minVal,  mFinishSize + mFinishSizeVariance);
 	}
 
-	if(mRotStartRegister > -1 )
+	if (mRotStartRegister > -1 ) {
 		registers[mRotStartRegister] = USFloat::Rand (mRotStart-mRotStartVariance, mRotStart+mRotStartVariance);
-	
+	}
 
-	if(mRotEndRegister > -1)
+	if (mRotEndRegister > -1) {
 		registers[mRotStartRegister] = USFloat::Rand (mRotEnd-mRotEndVariance, mRotEnd+mRotEndVariance);
-
+	}
 
 	float angleStartDeg;
-	if(mAngleRegister > -1)
-	{
+	if (mAngleRegister > -1) {
 
 		float randAngle = USFloat::Rand (mAngle - mAngleVariance, mAngle + mAngleVariance);
 		particle[MOAIParticle::PARTICLE_DX] = Cos(randAngle * (float)D2R);
@@ -1011,50 +1014,44 @@ void MOAIParticlePexPlugin::_initRadialScript( float* particle, float* registers
 		angleStartDeg = randAngle;
 
 	}
-	else
-	{
+	else {
 		particle[MOAIParticle::PARTICLE_DX] = Cos(mAngle * (float)D2R);
 		particle[MOAIParticle::PARTICLE_DY] = Sin(mAngle * (float)D2R);
 		angleStartDeg = mAngle;
 	}
 	
-	if( mRotPerSecondVariance != 0)
-	{
+	if ( mRotPerSecondVariance != 0) {
 		float randVal =  USFloat::Rand (mRotPerSecond - mRotPerSecondVariance, mRotPerSecond + mRotPerSecondVariance);
 		registers[mRotPerSecondRegister] = randVal;		
 	}
-	else
+	else {
 		registers[mRotPerSecondRegister] = mRotPerSecond;
-
+	}
 
 	registers[mStartXRegister] = particle[MOAIParticle::PARTICLE_X];
 	registers[mStartYRegister] = particle[MOAIParticle::PARTICLE_Y];
 
-	if( mMaxRadiusRegister > -1 )
-	{
+	if( mMaxRadiusRegister > -1 ) {
 		registers[mMaxRadiusRegister] = USFloat::Rand (mMaxRadius - mMaxRadiusVariance, mMaxRadius + mMaxRadiusVariance);
 		particle[MOAIParticle::PARTICLE_X] += Cos(angleStartDeg * (float)D2R) * registers[mMaxRadiusRegister];
 		particle[MOAIParticle::PARTICLE_Y] += Sin(angleStartDeg * (float)D2R) * registers[mMaxRadiusRegister];
 	}
-	else
-	{
+	else {
 		particle[MOAIParticle::PARTICLE_X] += Cos(angleStartDeg * (float)D2R) * mMaxRadius;
 		particle[MOAIParticle::PARTICLE_Y] += Sin(angleStartDeg * (float)D2R) * mMaxRadius;
 	}
 	
-	if( mMinRadiusRegister > -1 ){
+	if( mMinRadiusRegister > -1 ) {
 		registers[mMinRadiusRegister] = USFloat::Rand (mMinRadius - mMinRadiusVariance, mMinRadius + mMinRadiusVariance);
 	}
 
 	registers[mRadialRegister] = angleStartDeg;	
 }
 
-void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1, float term )
-{
+void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1, float term ) {
 	// Set colors.
 	float sVal, eVal;
-	for(int i = 0; i < 4; i++)
-	{
+	for(int i = 0; i < 4; i++) {
 			
 		if(mStartColorRegister[i] > -1 )
 			sVal = registers[mStartColorRegister[i]];
@@ -1066,8 +1063,7 @@ void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* regi
 		else
 			eVal = mFinishColor[i];
 
-		switch(i)
-		{
+		switch (i) {
 		case 0:
 			sprite->mRed = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 			break;
@@ -1083,77 +1079,79 @@ void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* regi
 		}
 	}
 
-	if(mStartSizeRegister > -1 )
+	if (mStartSizeRegister > -1 ) {
 		sVal = registers[mStartSizeRegister];
-	else
+	}
+	else {
 		sVal = mStartSize;
+	}
 
-	if(mFinishSizeRegister > -1 )
+	if (mFinishSizeRegister > -1 ) {
 		eVal = registers[mFinishSizeRegister];
-	else
+	}
+	else {
 		eVal = mFinishSize;
+	}
 
-	if(sVal != eVal)
-	{
+	if (sVal != eVal) {
 		sprite->mXScl = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 		sprite->mYScl = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 	}
-	else
-	{
+	else {
 		sprite->mXScl = sVal;
 		sprite->mYScl = sVal;
 	}
 
 
-	if(mRotStartRegister > -1 )
+	if (mRotStartRegister > -1 ) {
 		sVal = registers[mRotStartRegister];
-	else
+	}
+	else {
 		sVal = mRotStart;
+	}
 
-	if(mRotEndRegister > -1 )
+	if (mRotEndRegister > -1 ) {
 		eVal = registers[mRotEndRegister];
-	else
+	}
+	else {
 		eVal = mRotEnd;
+	}
 
-	if( sVal != eVal)
+	if ( sVal != eVal) {
 		sprite->mZRot = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
-	else
+	}
+	else {
 		sprite->mZRot = sVal;
-
+	}
+	
 	float moveX = 0;
 	float moveY = 0;
 
 	particle[MOAIParticle::PARTICLE_X] = particle[MOAIParticle::PARTICLE_X] - registers[mStartXRegister];
 	particle[MOAIParticle::PARTICLE_Y] = particle[MOAIParticle::PARTICLE_Y] - registers[mStartYRegister];
 
-	if(mRadialAcceleration != 0 || mRadialAccelVariance != 0 || 
-		mTanAccel != 0 || mTanAccelVariance != 0)
-	{
+	if (mRadialAcceleration != 0 || mRadialAccelVariance != 0 || 
+		mTanAccel != 0 || mTanAccelVariance != 0) {
 		float xVal, yVal;
 		float denom = Sqrt( (particle[MOAIParticle::PARTICLE_X] * particle[MOAIParticle::PARTICLE_X]) +
 								(particle[MOAIParticle::PARTICLE_Y] * particle[MOAIParticle::PARTICLE_Y]) );
 
 		// Set radial acceleration
-		if( mRadialAcceleration != 0 || mRadialAccelVariance != 0)
-		{
-			if(denom)
-			{
+		if (mRadialAcceleration != 0 || mRadialAccelVariance != 0) {
+			if (denom) {
 				xVal = (float)( particle[MOAIParticle::PARTICLE_X] / denom );
 				yVal = (float)( particle[MOAIParticle::PARTICLE_Y] / denom );
 			}
-			else
-			{
+			else {
 				xVal = 0;
 				yVal = 0;
 			}
 	
-			if( mRadialAccelRegister > -1)
-			{
+			if ( mRadialAccelRegister > -1) {
 				xVal *= registers[mRadialAccelRegister];
 				yVal *= registers[mRadialAccelRegister];
 			}
-			else
-			{
+			else {
 				xVal *= mRadialAcceleration;
 				yVal *= mRadialAcceleration;
 			}
@@ -1162,27 +1160,22 @@ void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* regi
 		}
 
 		// Set tangential acceleration
-		if(mTanAccel != 0 || mTanAccelVariance != 0)
-		{
-			if(denom)
-			{
+		if(mTanAccel != 0 || mTanAccelVariance != 0) {
+			if (denom) {
 				xVal = (float)( particle[MOAIParticle::PARTICLE_X] / denom );
 				yVal = (float)( particle[MOAIParticle::PARTICLE_Y] / denom );
 			}
-			else
-			{
+			else {
 				xVal = 0;
 				yVal = 0;
 			}
 
 			float yNewVal = xVal;
-			if( mTanAccelRegister > -1)
-			{
+			if ( mTanAccelRegister > -1) {
 				xVal = -yVal * registers[mTanAccelRegister];
 				yVal = yNewVal * registers[mTanAccelRegister];
 			}
-			else
-			{
+			else {
 				xVal = -yVal * mTanAccel;
 				yVal = yNewVal * mTanAccel;
 			}
@@ -1217,25 +1210,26 @@ void MOAIParticlePexPlugin::_renderGravityScript		( float* particle, float* regi
 	sprite->mGfxID = 1;
 	
 }
-void MOAIParticlePexPlugin::_renderRadialScript( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1, float term)
-{
+void MOAIParticlePexPlugin::_renderRadialScript( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1, float term) {
 	// Set colors.
 	float sVal, eVal;
-	for(int i = 0; i < 4; i++)
-	{
+	for (int i = 0; i < 4; i++) {
 			
-		if(mStartColorRegister[i] > -1 )
+		if (mStartColorRegister[i] > -1 ) {
 			sVal = registers[mStartColorRegister[i]];
-		else
+		}
+		else {
 			sVal = mStartColor[i];
+		}
 
-		if(mFinishColorRegister[i] > -1 )
+		if (mFinishColorRegister[i] > -1 ) {
 			eVal = registers[mFinishColorRegister[i]];
-		else
+		}
+		else {
 			eVal = mFinishColor[i];
+		}
 
-		switch(i)
-		{
+		switch (i) {
 		case 0:
 			sprite->mRed = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 			break;
@@ -1251,56 +1245,68 @@ void MOAIParticlePexPlugin::_renderRadialScript( float* particle, float* registe
 		}
 	}
 
-	if(mStartSizeRegister > -1 )
+	if (mStartSizeRegister > -1 ) {
 		sVal = registers[mStartSizeRegister];
-	else
+	}
+	else {
 		sVal = mStartSize;
+	}
 
-	if(mFinishSizeRegister > -1 )
+	if (mFinishSizeRegister > -1 ) {
 		eVal = registers[mFinishSizeRegister];
-	else
+	}
+	else {
 		eVal = mFinishSize;
-
-	if(sVal != eVal)
-	{
+	}
+	
+	if (sVal != eVal) {
 		sprite->mXScl = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 		sprite->mYScl = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 	}
-	else
-	{
+	else {
 		sprite->mXScl = sVal;
 		sprite->mYScl = sVal;
 	}
 
 
-	if(mRotStartRegister > -1 )
+	if (mRotStartRegister > -1) {
 		sVal = registers[mRotStartRegister];
-	else
+	}
+	else {
 		sVal = mRotStart;
+	}
 
-	if(mRotEndRegister > -1 )
+	if (mRotEndRegister > -1) {
 		eVal = registers[mRotEndRegister];
-	else
+	}
+	else {
 		eVal = mRotEnd;
+	}
 
 
-	if( sVal != eVal)
+	if (sVal != eVal) {
 		sprite->mZRot = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
-	else
+	}
+	else {
 		sprite->mZRot = sVal;
+	}
 
 	
 	registers[mRadialRegister] += registers[mRotPerSecondRegister] * ((t1 - t0)*term);
 
-	if(mMaxRadiusRegister > -1)
+	if(mMaxRadiusRegister > -1) {
 		sVal = registers[mMaxRadiusRegister];
-	else
+	}
+	else {
 		sVal = mMaxRadius;
+	}
 	
-	if(mMinRadiusRegister > -1)
+	if (mMinRadiusRegister > -1) {
 		eVal = registers[mMinRadiusRegister];
-	else
+	}
+	else {
 		eVal = mMinRadius;
+	}
 	float magVal = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 	
 	particle[MOAIParticle::PARTICLE_X] = registers[mStartXRegister] - Cos(registers[mRadialRegister] * (float)D2R) * magVal;
@@ -1311,19 +1317,22 @@ void MOAIParticlePexPlugin::_renderRadialScript( float* particle, float* registe
 
 }
 
-void  MOAIParticlePexPlugin::OnInit ( float* particle, float* registers)
-{
-	if(mEmitterType == EMITTER_GRAVITY)
+void  MOAIParticlePexPlugin::OnInit ( float* particle, float* registers) {
+	if (mEmitterType == EMITTER_GRAVITY) {
 		_initGravityScript( particle, registers);
-	else
+	}
+	else {
 		_initRadialScript( particle, registers);
+	}
 }
-void  MOAIParticlePexPlugin::OnRender ( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1,  float term)
-{
-	if(mEmitterType == EMITTER_GRAVITY)
+
+void  MOAIParticlePexPlugin::OnRender ( float* particle, float* registers, AKUParticleSprite* sprite, float t0, float t1,  float term) {
+	if(mEmitterType == EMITTER_GRAVITY){
 		_renderGravityScript( particle, registers, sprite, t0, t1, term);
-	else
+	}
+	else {
 		_renderRadialScript( particle, registers, sprite, t0, t1, term);
+	}
 }
 
 //----------------------------------------------------------------//
@@ -1338,7 +1347,7 @@ MOAIParticlePexPlugin::MOAIParticlePexPlugin () :
 	mTanAccelRegister(-1),
 	mRotStartRegister(-1),
 	mRotEndRegister(-1),
-	mSpeedRegister(-1){
+	mSpeedRegister(-1) {
 
 	memset(mStartColorRegister, -1, sizeof(mStartColorRegister));
 	memset(mFinishColorRegister, -1,sizeof(mFinishColorRegister));

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -352,6 +352,18 @@ int MOAIParticlePexPlugin::_setRotationStart ( lua_State* L ) {
 	return 0;
 }
 
+int MOAIParticlePexPlugin::_getRotationStartVariance( lua_State *L ){
+	MOAI_LUA_SETUP( MOAIParticlePexPlugin, "U" )
+	lua_pushnumber( state, self->mRotStartVariance );
+	return 1;
+}
+
+int MOAIParticlePexPlugin::_setRotationStartVariance( lua_State *L ){
+	MOAI_LUA_SETUP( MOAIParticlePexPlugin, "UN" )
+	self->mRotStartVariance = state.GetValue < float >( 2, 0 );
+	return 0;
+}
+
 int MOAIParticlePexPlugin::_getSourcePosition ( lua_State* L ){
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mSourcePos[0] );
@@ -1263,6 +1275,8 @@ void MOAIParticlePexPlugin::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "setRotationEndVariance",				_setRotationEndVariance },
 		{ "getRotationStart",					_getRotationStart },
 		{ "setRotationStart",					_setRotationStart },
+		{ "getRotationStartVariance",			_getRotationStartVariance },
+		{ "setRotationStartVariance",			_setRotationStartVariance },
 		{ "getSourcePosition",					_getSourcePosition },
 		{ "setSourcePosition",					_setSourcePosition },
 		{ "getSourcePositionVariance",			_getSourcePositionVariance },

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -235,6 +235,18 @@ int MOAIParticlePexPlugin::_setMinRadius ( lua_State* L ) {
 	return 0;
 }
 
+int MOAIParticlePexPlugin::_getMinRadiusVariance ( lua_State *L ){
+	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
+	lua_pushnumber ( state, self->mMinRadiusVariance );
+	return 1;
+}
+
+int MOAIParticlePexPlugin::_setMinRadiusVariance ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "UN" )
+	self->mMinRadiusVariance = state.GetValue < float >( 2, 0 );
+	return 0;
+}
+
 int MOAIParticlePexPlugin::_getParticleLifespan ( lua_State* L ){
 	MOAI_LUA_SETUP ( MOAIParticlePexPlugin, "U" )
 	lua_pushnumber ( state, self->mLifespan );
@@ -1376,6 +1388,8 @@ void MOAIParticlePexPlugin::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "setMaxRadiusVariance",				_setMaxRadiusVariance },
 		{ "getMinRadius",						_getMinRadius },
 		{ "setMinRadius",						_setMinRadius },
+		{ "getMinRadiusVariance",				_getMinRadiusVariance },
+		{ "setMinRadiusVariance",				_setMinRadiusVariance },
 		{ "getParticleLifespan",				_getParticleLifespan },
 		{ "setParticleLifespan",				_setParticleLifespan },
 		{ "getParticleLifespanVariance",		_getParticleLifespanVariance },

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -758,7 +758,6 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 			}
 			else if(text == "minRadius")
 				plugin.mMinRadius = (float)atof(attribute->Value());
-			// TODO: affirm that the property name really is "minRadiusVariance" in a modern exported PEX file.
 			else if(text == "minRadiusVariance")
 			{
 				plugin.mMinRadiusVariance = (float)atof(attribute->Value());

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -1309,6 +1309,7 @@ MOAIParticlePexPlugin::MOAIParticlePexPlugin () :
 	mStartSizeRegister(-1),
 	mFinishSizeRegister(-1),
 	mMaxRadiusRegister(-1),
+	mMinRadiusRegister(-1),
 	mRadialAccelRegister(-1),
 	mTanAccelRegister(-1),
 	mRotStartRegister(-1),

--- a/src/moaicore/MOAIParticlePexPlugin.cpp
+++ b/src/moaicore/MOAIParticlePexPlugin.cpp
@@ -600,6 +600,11 @@ void MOAIParticlePexPlugin::InitializeProperties(){
 		this->mMaxRadiusRegister = this->mSize++;
 	}
 	
+	// minRadius
+	if (this->mMinRadiusVariance != 0) {
+		this->mMinRadiusRegister = this->mSize++;
+	}
+	
 	// particleLifespan
 	if (this->mLifespanVariance != 0) {
 		this->mLifespanRegister = this->mSize++;
@@ -753,6 +758,13 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 			}
 			else if(text == "minRadius")
 				plugin.mMinRadius = (float)atof(attribute->Value());
+			// TODO: affirm that the property name really is "minRadiusVariance" in a modern exported PEX file.
+			else if(text == "minRadiusVariance")
+			{
+				plugin.mMinRadiusVariance = (float)atof(attribute->Value());
+				if (plugin.mMinRadiusVariance != 0)
+						plugin.mMinRadiusRegister = plugin.mSize++;
+			}
 			else if(text == "particleLifeSpan")
 				plugin.mLifespan = (float)atof(attribute->Value());
 			else if(text == "particleLifespanVariance")
@@ -1038,6 +1050,10 @@ void MOAIParticlePexPlugin::_initRadialScript( float* particle, float* registers
 		particle[MOAIParticle::PARTICLE_X] += Cos(angleStartDeg * (float)D2R) * mMaxRadius;
 		particle[MOAIParticle::PARTICLE_Y] += Sin(angleStartDeg * (float)D2R) * mMaxRadius;
 	}
+	
+	if( mMinRadiusRegister > -1 ){
+		registers[mMinRadiusRegister] = USFloat::Rand (mMinRadius - mMinRadiusVariance, mMinRadius + mMinRadiusVariance);
+	}
 
 	registers[mRadialRegister] = angleStartDeg;	
 }
@@ -1289,7 +1305,12 @@ void MOAIParticlePexPlugin::_renderRadialScript( float* particle, float* registe
 		sVal = registers[mMaxRadiusRegister];
 	else
 		sVal = mMaxRadius;
-	float magVal = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, mMinRadius, t1 );
+	
+	if(mMinRadiusRegister > -1)
+		eVal = registers[mMinRadiusRegister];
+	else
+		eVal = mMinRadius;
+	float magVal = USInterpolate::Interpolate ( USInterpolate::kLinear, sVal, eVal, t1 );
 	
 	particle[MOAIParticle::PARTICLE_X] = registers[mStartXRegister] - Cos(registers[mRadialRegister] * (float)D2R) * magVal;
     particle[MOAIParticle::PARTICLE_Y] = registers[mStartYRegister] - Sin(registers[mRadialRegister] * (float)D2R) * magVal;

--- a/src/moaicore/MOAIParticlePexPlugin.h
+++ b/src/moaicore/MOAIParticlePexPlugin.h
@@ -162,6 +162,8 @@ private:
 	static int		_setRotationEndVariance				( lua_State* L );
 	static int		_getRotationStart					( lua_State* L );
 	static int		_setRotationStart					( lua_State* L );
+	static int		_getRotationStartVariance			( lua_State* L );
+	static int		_setRotationStartVariance			( lua_State* L );
 	static int		_getSourcePosition					( lua_State* L );
 	static int		_setSourcePosition					( lua_State* L );
 	static int		_getSourcePositionVariance			( lua_State* L );

--- a/src/moaicore/MOAIParticlePexPlugin.h
+++ b/src/moaicore/MOAIParticlePexPlugin.h
@@ -193,6 +193,8 @@ private:
 	static int		_initializeProperties				( lua_State* L );
 	static int		_load								( lua_State* L );
 
+	static void     InitializeBasicRegisters    ( MOAIParticlePexPlugin& plugin );
+	static void		InitializeEmitter			( MOAIParticlePexPlugin& plugin );
 	void			InitializeProperties		();
 	static void		Parse						( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node );
 	

--- a/src/moaicore/MOAIParticlePexPlugin.h
+++ b/src/moaicore/MOAIParticlePexPlugin.h
@@ -62,6 +62,8 @@ private:
 	s32	  mMaxRadiusRegister;
 	
 	float mMinRadius;
+	float mMinRadiusVariance;
+	s32   mMinRadiusRegister;
 	
 	float mRadialAcceleration;
 	float mRadialAccelVariance;

--- a/src/moaicore/MOAIParticlePexPlugin.h
+++ b/src/moaicore/MOAIParticlePexPlugin.h
@@ -145,6 +145,8 @@ private:
 	static int		_setMaxRadiusVariance				( lua_State* L );
 	static int		_getMinRadius						( lua_State* L );
 	static int		_setMinRadius						( lua_State* L );
+	static int		_getMinRadiusVariance				( lua_State* L );
+	static int		_setMinRadiusVariance				( lua_State* L );
 	static int		_getParticleLifespan				( lua_State* L );
 	static int		_setParticleLifespan				( lua_State* L );
 	static int		_getParticleLifespanVariance		( lua_State* L );

--- a/src/moaicore/MOAIParticlePexPlugin.h
+++ b/src/moaicore/MOAIParticlePexPlugin.h
@@ -186,8 +186,10 @@ private:
 	static int		_setTangentalAccelerationVariance	( lua_State* L );
 
 	static int		_getTextureName						( lua_State* L );
+	static int		_initializeProperties				( lua_State* L );
 	static int		_load								( lua_State* L );
 
+	void			InitializeProperties		();
 	static void		Parse						( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node );
 	
 	void			_initGravityScript			( float* particle, float* registers );


### PR DESCRIPTION
I added accessor methods for two missing properties.  I added handling for minimum radius variance, since that attribute appears in Particle Designer.  It might not have been in Particle Designer when the class MOAIParticlePexPlugin was first written.  In addition, I added a method named initializeProperties() to do some of the work that load() does when setting up the registers and the read-only properties.

I verified the name of the element corresponding to minimum radius variance in a PEX file exported from a licensed copy of Particle Designer 2.0.5.4.  It is "minRadiusVariance", just like I had it in the `Parse()` method.
## TODO:
- [x] Verify the name of the element for minimum radius variance in a PEX file exported from a licensed copy of Particle Designer.
