### PR TITLE
[FINAL] MOAIFreeTypeFont: fixed clipped letters when using returned value of processOptimalSize

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1130,8 +1130,13 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		}
 		
 		// test for first character of line to adjust penX
+		
 		if (textLength == 0) {
 			penX += -((face->glyph->metrics.horiBearingX) >> 6);
+			// make sure value of penX does not go below zero
+			if (penX < 0){
+				penX = 0;
+			}
 		}
 		
 		// determine if penX is outside the bounds of the box


### PR DESCRIPTION
Isaac wrote a description in here, but it was confusing out of context (Sorry, Isaac!).  So I (Aaron) will try to explain.

When we first started using `MOAIFreeTypeFont` there were lots of problems with text getting cut off.  :hocho:   After several revisions we've eliminated almost all of them, but very rarely, there's still a case where `optimalSize()` returns a value that is too big, and one or two pixels will get cut off on either side.  Isaac hasn't been working on text in a few months, but when I isolated this problem and sent him a repro case, he was kind enough to come up with a fix.  I've spent all morning testing it in a test game I wrote and running it through all of our actual games.  I'm confident that it fixes the problem.

Here are some before and after screenshots from Up:
![domestic_before](https://cloud.githubusercontent.com/assets/1683575/2904841/6d83654e-d5ff-11e3-89ec-07551ecf0ed9.png)
![domestic_after](https://cloud.githubusercontent.com/assets/1683575/2904835/63dcc86e-d5ff-11e3-9039-e678f8abfe05.png)

And Squares:
![rescind_before](https://cloud.githubusercontent.com/assets/1683575/2904849/7de0dd4a-d5ff-11e3-8a20-3ab21ba90849.png)
![rescind_after](https://cloud.githubusercontent.com/assets/1683575/2904854/81ef3288-d5ff-11e3-85f0-9966c4120951.png)

Thanks for your help, Isaac!  :cake: 
