### PR TITLE
[FINAL] Added "character" entry to glyph tables in MOAIFreeTypeFont

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -488,7 +488,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, bool return
 		
         
         // create wide character string version of text.
-		u32 *wideString = (u32 *)calloc(maxGlyphs + 1, sizeof(u32));
+		u32 *wideString = new u32[maxGlyphs + 1]; //(u32 *)calloc(maxGlyphs + 1, sizeof(u32));
 		u8_toucs(wideString, maxGlyphs, (char *)text, -1);
 		
 		
@@ -527,7 +527,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, bool return
 		delete [] positions;
 		deleteGlyphArray(glyphs, numGlyphs);
 		
-		free(wideString);
+		delete [] wideString; //free(wideString);
 		return rect;
 	}
 	else{
@@ -1340,10 +1340,13 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 void MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(USRect rect, int *baseline, u32 index,  MOAILuaState &state, u32 wideChar){
 	
 	// a mutable C-string long enough to hold four characters and the null character at the end
-	char utf8String[5];
+	static const size_t NUMBER_OF_CHARACTERS_IN_UTF8_CHARACTER = 4,
+						STRING_SIZE = NUMBER_OF_CHARACTERS_IN_UTF8_CHARACTER + 1;
+	
+	char utf8String[STRING_SIZE];
 	
 	// set all five C-string characters to the null character.
-	memset(utf8String, 0, 5 * sizeof(char));
+	memset(utf8String, 0, STRING_SIZE * sizeof(char));
 	
 	// convert the wide character parameter to a utf-8 string and get the encoding length
 	int charLength = u8_wc_toutf8(utf8String, wideChar);
@@ -1620,9 +1623,9 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	
 	u32 tableIndex;
 	u32 tableSize = numGlyphs;
-	u32 *wideString;
+	u32 *wideString = NULL;
 	if (returnGlyphBounds) {
-		wideString = (u32*)calloc(numGlyphs + 1, sizeof(u32));
+		wideString = new u32[numGlyphs + 1]; //(u32*)calloc(numGlyphs + 1, sizeof(u32));
 		
 		u8_toucs(wideString, numGlyphs + 1, (char *)text, -1);
 		// create main table with enough elements for the number of glyphs
@@ -1691,10 +1694,9 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	delete [] positions;
 	deleteGlyphArray(glyphs, numGlyphs);
 	
-	if (returnGlyphBounds) {
-		free(wideString);
-	}
 	
+	delete [] wideString; 
+	wideString = NULL;
 	
 	// turn the data buffer to an image
 	MOAIImage bitmapImg;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -513,7 +513,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, bool return
 				glyphRect.Init(left, bottom, left + bit->bitmap.width, bottom + bit->bitmap.rows);
 				int baselineY = maxAscender;
 				
-				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, &baselineY, tableIndex, state);
+				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, &baselineY, tableIndex, state, -1); // TODO: Find way to include character data
 				
 				FT_Done_Glyph(image);
 			}
@@ -773,7 +773,7 @@ USRect MOAIFreeTypeFont::DimensionsWithMaxWidth(cc8 *text, float fontSize, float
 				USRect glyphRect;
 				glyphRect.Init(xOffset, yOffset, xOffset + bitmap.width, yOffset + bitmap.rows);
 				
-				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(rect, NULL, lineIndex, state);
+				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(rect, NULL, lineIndex, state, text_ptr[i2]);
 				
 				// step to next glyph
 				pen_x += (face->glyph->metrics.horiAdvance >> 6);
@@ -1489,7 +1489,7 @@ void MOAIFreeTypeFont::RenderLines(FT_Int imageWidth, FT_Int imageHeight, int hA
 				USRect glyphRect;
 				glyphRect.Init(xOffset, yOffset, xOffset + bitmap.width, yOffset + bitmap.rows);
 				
-				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, NULL, lineIndex, state);
+				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, NULL, lineIndex, state, text_ptr[i2]);
 				
 			}
 			
@@ -1668,7 +1668,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 				glyphRect.Init(left, bottom, left + bit->bitmap.width, bottom + bit->bitmap.rows);
 				int baselineY = maxAscender;
 				
-				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, &baselineY, tableIndex, state);
+				MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(glyphRect, &baselineY, tableIndex, state, -1); // TODO: Find way to include character data
 				
 			}
 			

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1331,9 +1331,23 @@ float MOAIFreeTypeFont::OptimalSize(const MOAIOptimalSizeParameters& params ){
 }
 
 //----------------------------------------------------------------//
-void MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(USRect rect, int *baseline, u32 index,  MOAILuaState &state){
+void MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(USRect rect, int *baseline, u32 index,  MOAILuaState &state, u32 wideChar){
+	
+	// a mutable C-string long enough to hold four characters and the null character at the end
+	char utf8String[5];
+	
+	// set all five C-string characters to the null character.
+	memset(utf8String, 0, 5 * sizeof(char));
+	
+	// convert the wide character parameter to a utf-8 string and get the encoding length
+	int charLength = u8_wc_toutf8(utf8String, wideChar);
+	
 	
 	int elements = ( baseline != NULL ) ? 5 : 4;
+	
+	if (charLength > 0) {
+		elements += 1;
+	}
 	
 	// create a table with the appropiate number of elements
 	lua_createtable(state, elements, 0);
@@ -1358,6 +1372,12 @@ void MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(USRect rect, int *baseline,
 	if (baseline) {
 		state.Push( *baseline );
 		lua_setfield(state, -2, "baselineY");
+	}
+	
+	// push character
+	if (charLength > 0) {
+		state.Push(utf8String);
+		lua_setfield(state, -2, "character");
 	}
 	
 	// set index

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -488,7 +488,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, bool return
 		
         
         // create wide character string version of text.
-		u32 *wideString = new u32[maxGlyphs + 1]; //(u32 *)calloc(maxGlyphs + 1, sizeof(u32));
+		u32 *wideString = new u32[maxGlyphs + 1];
 		u8_toucs(wideString, maxGlyphs, (char *)text, -1);
 		
 		
@@ -1346,7 +1346,7 @@ void MOAIFreeTypeFont::PushRectAndBaselineToLuaTable(USRect rect, int *baseline,
 	char utf8String[STRING_SIZE];
 	
 	// set all five C-string characters to the null character.
-	memset(utf8String, 0, STRING_SIZE * sizeof(char));
+	memset(utf8String, 0, sizeof(utf8String));
 	
 	// convert the wide character parameter to a utf-8 string and get the encoding length
 	int charLength = u8_wc_toutf8(utf8String, wideChar);
@@ -1624,10 +1624,11 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	u32 tableIndex;
 	u32 tableSize = numGlyphs;
 	u32 *wideString = NULL;
+	
 	if (returnGlyphBounds) {
-		wideString = new u32[numGlyphs + 1]; //(u32*)calloc(numGlyphs + 1, sizeof(u32));
-		
+		wideString = new u32[numGlyphs + 1];
 		u8_toucs(wideString, numGlyphs + 1, (char *)text, -1);
+		
 		// create main table with enough elements for the number of glyphs
 		lua_createtable(state, tableSize, 0);
 	}

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -527,7 +527,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, bool return
 		delete [] positions;
 		deleteGlyphArray(glyphs, numGlyphs);
 		
-		delete [] wideString; //free(wideString);
+		delete [] wideString;
 		return rect;
 	}
 	else{

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -94,7 +94,7 @@ protected:
 	void				GenerateLines			( FT_Int imageWidth, cc8* text, int wordBreak);
 	void				InitBitmapData			( u32 width, u32 height );
 	static int			NewPropFromFittedTexture( MOAILuaState& state, bool singleLine);
-	static void			PushRectAndBaselineToLuaTable	(USRect rect, int *baseline, u32 index, MOAILuaState &state);
+	static void			PushRectAndBaselineToLuaTable	(USRect rect, int *baseline, u32 index, MOAILuaState &state, u32 wideChar = 0);
 	void				RenderLines				( FT_Int imageWidth, FT_Int imageHeight, int hAlign,
 												 int vAlign, bool returnGlyphBounds, float lineSpacing,
 												 MOAILuaState& state);


### PR DESCRIPTION
I added a new entry to glyph tables representing the glyph character at the index along with the bounds and the baseline.  I tested it out with strings containing multi-byte characters and it seems to work correctly.
