### PR TITLE
[FINAL] Fixes reference to SFMT in case-sensitive compilers

### DIFF
--- a/src/moaicore/MOAIMath.cpp
+++ b/src/moaicore/MOAIMath.cpp
@@ -5,7 +5,7 @@
 #include <moaicore/MOAIMath.h>
 
 extern "C" {
-	#include <sfmt.h>
+	#include <SFMT.h>
 }
 
 //================================================================//


### PR DESCRIPTION
This was one of a couple of changes I needed to make to get the build working on my Linux machine.  Apparently the cpp compiler is case sensitive in my environment.
