### PR TITLE
[FINAL] MOAIFreeTypeFont: Fix NumberOfLinesToDisplayText()

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1064,6 +1064,13 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 	size_t glyphArrayIndex = 0;
 	int rewindCount = 0;
 	
+	// initialize mGlyphArray
+	size_t glyphArraySize = glyphsInText(text);
+	this->mGlyphArray = new FT_Glyph [ glyphArraySize ];
+
+	// initialize mAdvanceArray
+	this->mAdvanceArray = new FT_Vector [ glyphArraySize ];
+
 	u32* textBuffer = NULL;
 	if (generateLines) {
 		textBuffer = (u32 *) calloc(strlen(text), sizeof(u32));
@@ -1248,6 +1255,16 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		free(textBuffer);
 	}
 	
+	// clean up the glyph array
+	deleteGlyphArray(this->mGlyphArray, glyphArraySize);
+
+	// clean up the advance array
+	delete [] this->mAdvanceArray;
+
+	// set member variable arrays to NULL
+	this->mGlyphArray = NULL;
+	this->mAdvanceArray = NULL;
+
 	return numberOfLines;
 }
 

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1186,7 +1186,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 							 !MOAIFont::IsWhitespace(wordBreakCharacter)){
 						// test to see if the word break character is being cut off
 						if (unicode == wordBreakCharacter && n == tokenIndex) {
-							return -1;
+							goto failed;
 						}
 						
 					}
@@ -1231,8 +1231,7 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 					}
 					else{
 						// we don't words broken up when calculating optimal size
-						// return a failure code that is less than zero
-						return -1;
+						goto failed;
 					}
 				}
 			}
@@ -1254,7 +1253,12 @@ int MOAIFreeTypeFont::NumberOfLinesToDisplayText(cc8 *text, FT_Int imageWidth,
 		this->BuildLine(textBuffer, textLength, startIndex);
 		free(textBuffer);
 	}
-	
+
+	goto success;
+
+failed:
+	numberOfLines = -1; // a return value < 0 indicates an error condition.
+success:
 	// clean up the glyph array
 	deleteGlyphArray(this->mGlyphArray, glyphArraySize);
 


### PR DESCRIPTION
`NumberOfLinesToDisplayText()` would always crash if called outside of a render function because `mGlyphArray` and `mAdvanceArray` are explicitly created and cleared by `RenderTexture()`

This PR adds the initialization and teardown to `NumberOfLinesToDisplayText()`
