### PR TITLE
[FINAL] MOAIFrameBuffer: Expose the number of times that a frame buffer has rendered to Lua

### DIFF
--- a/src/moaicore/MOAIFrameBuffer.cpp
+++ b/src/moaicore/MOAIFrameBuffer.cpp
@@ -238,6 +238,13 @@ int MOAIFrameBuffer::_setRenderTable ( lua_State* L ) {
 	return 0;
 }
 
+//----------------------------------------------------------------//
+int MOAIFrameBuffer::_getRenderCount( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIFrameBuffer, "U" )
+	lua_pushnumber ( L, self->mRenderCounter );
+	return 1;
+}
+
 //================================================================//
 // MOAIFrameBuffer
 //================================================================//
@@ -317,6 +324,7 @@ void MOAIFrameBuffer::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "getRenderTable",				_getRenderTable },
 		{ "grabNextFrame",				_grabNextFrame },
 		{ "setRenderTable",				_setRenderTable },
+		{ "getRenderCount",				_getRenderCount },
 		{ NULL, NULL }
 	};
 

--- a/src/moaicore/MOAIFrameBuffer.h
+++ b/src/moaicore/MOAIFrameBuffer.h
@@ -80,6 +80,7 @@ protected:
 	static int		_getPerformanceDrawCount    ( lua_State* L );
 	static int		_getRenderTable				( lua_State* L );
 	static int		_setRenderTable				( lua_State* L );
+	static int		_getRenderCount				( lua_State* L );
 
 	//----------------------------------------------------------------//
 	void			RenderTable					( MOAILuaState& state, int idx );


### PR DESCRIPTION
Expose `mRenderCounter` with the Lua method `getRenderCount`... so that we can make `MOAIFrameBufferTexture`s stop rendering after one frame.  :movie_camera: 
