### PR TITLE
[FINAL] Add tvOS targets

### DIFF
--- a/src/moaiext-tvos/moaiext-tvos.h
+++ b/src/moaiext-tvos/moaiext-tvos.h
@@ -1,0 +1,18 @@
+//
+//  moaiext-tvos.h
+//  libmoai
+//
+//  Created by Aaron Barrett on 11/3/15.
+//
+//
+
+
+#import <moaiext-iphone/NSArray+MOAILib.h>
+#import <moaiext-iphone/NSData+MOAILib.h>
+#import <moaiext-iphone/NSDate+MOAILib.h>
+#import <moaiext-iphone/NSDictionary+MOAILib.h>
+#import <moaiext-iphone/NSError+MOAILib.h>
+#import <moaiext-iphone/NSNumber+MOAILib.h>
+#import <moaiext-iphone/NSObject+MOAILib.h>
+#import <moaiext-iphone/NSString+MOAILib.h>
+

--- a/src/uslscore/pch.h
+++ b/src/uslscore/pch.h
@@ -28,10 +28,8 @@ extern "C" {
 using namespace std;
 
 // stream
-#include <fstream>
 #include <iostream>
 #include <iomanip>
-#include <fstream>
 #include <sstream>
 
 //----------------------------------------------------------------//

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -2562,7 +2562,6 @@
 		EB9EDF4F1BE9421B00E8938F /* USStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5F213564BC8000ADC60 /* USStream.cpp */; };
 		EB9EDF501BE9421B00E8938F /* USZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5FB13564BC8000ADC60 /* USZip.cpp */; };
 		EB9EDF511BE9421B00E8938F /* USZipFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5FD13564BC8000ADC60 /* USZipFile.cpp */; };
-		EB9EDF521BE9421B00E8938F /* AKU-iphone.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD1D0BA313599FD200802A3C /* AKU-iphone.mm */; };
 		EB9EDF531BE9421B00E8938F /* MOAIEventSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEB91421360A78800AAC558 /* MOAIEventSource.cpp */; };
 		EB9EDF541BE9421B00E8938F /* MOAIImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEB91441360A78800AAC558 /* MOAIImage.cpp */; };
 		EB9EDF551BE9421B00E8938F /* MOAICameraAnchor2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FA4CB138589C4007FD20C /* MOAICameraAnchor2D.cpp */; };
@@ -9668,7 +9667,6 @@
 				EB9EDF4F1BE9421B00E8938F /* USStream.cpp in Sources */,
 				EB9EDF501BE9421B00E8938F /* USZip.cpp in Sources */,
 				EB9EDF511BE9421B00E8938F /* USZipFile.cpp in Sources */,
-				EB9EDF521BE9421B00E8938F /* AKU-iphone.mm in Sources */,
 				EB9EDF531BE9421B00E8938F /* MOAIEventSource.cpp in Sources */,
 				EB9EDF541BE9421B00E8938F /* MOAIImage.cpp in Sources */,
 				EB9EDF551BE9421B00E8938F /* MOAICameraAnchor2D.cpp in Sources */,

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -2240,14 +2240,12 @@
 		EB9EDE0C1BE9421B00E8938F /* USVec3D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F913564BC8000ADC60 /* USVec3D.h */; };
 		EB9EDE0D1BE9421B00E8938F /* USZip.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5FC13564BC8000ADC60 /* USZip.h */; };
 		EB9EDE0E1BE9421B00E8938F /* USZipFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5FE13564BC8000ADC60 /* USZipFile.h */; };
-		EB9EDE0F1BE9421B00E8938F /* AKU-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1D0BA213599FD200802A3C /* AKU-iphone.h */; };
 		EB9EDE101BE9421B00E8938F /* MOAIEventSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEB91431360A78800AAC558 /* MOAIEventSource.h */; };
 		EB9EDE111BE9421B00E8938F /* MOAIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEB91451360A78800AAC558 /* MOAIImage.h */; };
 		EB9EDE121BE9421B00E8938F /* MOAIEaseSineInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70433118761E630057E450 /* MOAIEaseSineInOut.h */; };
 		EB9EDE131BE9421B00E8938F /* MOAICameraAnchor2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 031FA4CC138589C4007FD20C /* MOAICameraAnchor2D.h */; };
 		EB9EDE141BE9421B00E8938F /* MOAICameraFitter2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 031FA4CE138589C4007FD20C /* MOAICameraFitter2D.h */; };
 		EB9EDE151BE9421B00E8938F /* MOAIDeckRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 039C283C138EDAB300A3A780 /* MOAIDeckRemapper.h */; };
-		EB9EDE161BE9421B00E8938F /* moaiext-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECA1398BA6200AB0420 /* moaiext-iphone.h */; };
 		EB9EDE171BE9421B00E8938F /* MOAIEaseExponentialIn.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70433718761FBD0057E450 /* MOAIEaseExponentialIn.h */; };
 		EB9EDE181BE9421B00E8938F /* NSArray+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECD1398BA6200AB0420 /* NSArray+MOAILib.h */; };
 		EB9EDE191BE9421B00E8938F /* NSData+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECF1398BA6200AB0420 /* NSData+MOAILib.h */; };
@@ -2361,15 +2359,8 @@
 		EB9EDE851BE9421B00E8938F /* MOAIUrlMgrNaCl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BA08E151949C50002E925 /* MOAIUrlMgrNaCl.h */; };
 		EB9EDE861BE9421B00E8938F /* MOAIRenderable.h in Headers */ = {isa = PBXBuildFile; fileRef = 077D500C1519A4A1003DFC89 /* MOAIRenderable.h */; };
 		EB9EDE871BE9421B00E8938F /* MOAIRenderMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 077D500E1519A4A1003DFC89 /* MOAIRenderMgr.h */; };
-		EB9EDE881BE9421B00E8938F /* USUnique.h in Headers */ = {isa = PBXBuildFile; fileRef = CD19AA07151AF7E2006A1F9D /* USUnique.h */; };
 		EB9EDE891BE9421B00E8938F /* MOAICrittercismIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9A41AB5151AAA5400650276 /* MOAICrittercismIOS.h */; };
-		EB9EDE8A1BE9421B00E8938F /* MOAINotificationsIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1DFC151AD5B4005F39B7 /* MOAINotificationsIOS.h */; };
-		EB9EDE8B1BE9421B00E8938F /* MOAIAppIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C611151B146F0009D47D /* MOAIAppIOS.h */; };
-		EB9EDE8C1BE9421B00E8938F /* MOAIDialogIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C615151B146F0009D47D /* MOAIDialogIOS.h */; };
-		EB9EDE8D1BE9421B00E8938F /* MOAIWebViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C628151B17540009D47D /* MOAIWebViewDelegate.h */; };
-		EB9EDE8E1BE9421B00E8938F /* MOAIGameCenterIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1E54151C7D71005F39B7 /* MOAIGameCenterIOS.h */; };
 		EB9EDE8F1BE9421B00E8938F /* MOAIEaseSimpleOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D49735118725EC400D46882 /* MOAIEaseSimpleOut.h */; };
-		EB9EDE901BE9421B00E8938F /* MOAIWebViewIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1E58151C8578005F39B7 /* MOAIWebViewIOS.h */; };
 		EB9EDE911BE9421B00E8938F /* MOAIKeyboardIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CD91E3FE15252E2F00AE1883 /* MOAIKeyboardIOS.h */; };
 		EB9EDE921BE9421B00E8938F /* AKU-adcolony.h in Headers */ = {isa = PBXBuildFile; fileRef = E98DBDD11537A33100514387 /* AKU-adcolony.h */; };
 		EB9EDE931BE9421B00E8938F /* AKU-chartboost.h in Headers */ = {isa = PBXBuildFile; fileRef = E98DBDD31537A33100514387 /* AKU-chartboost.h */; };
@@ -2400,7 +2391,6 @@
 		EB9EDEAC1BE9421B00E8938F /* USStreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5729A1575713C00A486AB /* USStreamReader.h */; };
 		EB9EDEAD1BE9421B00E8938F /* USBase64Encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572A81575714B00A486AB /* USBase64Encoder.h */; };
 		EB9EDEAE1BE9421B00E8938F /* MOAIGridDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572AE1575717000A486AB /* MOAIGridDeck2D.h */; };
-		EB9EDEAF1BE9421B00E8938F /* MOAIMoviePlayerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */; };
 		EB9EDEB01BE9421B00E8938F /* MOAIHashWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0755162515A6CA2B00161409 /* MOAIHashWriter.h */; };
 		EB9EDEB11BE9421B00E8938F /* USHexWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703C816127FFD002D0D27 /* USHexWriter.h */; };
 		EB9EDEB21BE9421B00E8938F /* USHashWriterAdler32.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703CC16128038002D0D27 /* USHashWriterAdler32.h */; };
@@ -2425,7 +2415,6 @@
 		EB9EDEC51BE9421B00E8938F /* MOAIMutex_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3316AE312A009B9C29 /* MOAIMutex_posix.h */; };
 		EB9EDEC61BE9421B00E8938F /* MOAIMutex_win32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3516AE312A009B9C29 /* MOAIMutex_win32.h */; };
 		EB9EDEC71BE9421B00E8938F /* MOAIMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3716AE312A009B9C29 /* MOAIMutex.h */; };
-		EB9EDEC81BE9421B00E8938F /* MOAITakeCameraListener.h in Headers */ = {isa = PBXBuildFile; fileRef = EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */; };
 		EB9EDEC91BE9421B00E8938F /* MOAIMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D64916D8021D00C172D2 /* MOAIMath.h */; };
 		EB9EDECA1BE9421B00E8938F /* MOAIFrameBufferTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D67116D8025000C172D2 /* MOAIFrameBufferTexture.h */; };
 		EB9EDECB1BE9421B00E8938F /* MOAIAnimCurveCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */; };
@@ -2666,14 +2655,7 @@
 		EB9EDFB81BE9421B00E8938F /* MOAIUrlMgrNaCl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075BA08D151949C50002E925 /* MOAIUrlMgrNaCl.cpp */; };
 		EB9EDFB91BE9421B00E8938F /* MOAIRenderable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 077D500B1519A4A1003DFC89 /* MOAIRenderable.cpp */; };
 		EB9EDFBA1BE9421B00E8938F /* MOAIRenderMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 077D500D1519A4A1003DFC89 /* MOAIRenderMgr.cpp */; };
-		EB9EDFBB1BE9421B00E8938F /* USUnique_linux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD19AA06151AF7E2006A1F9D /* USUnique_linux.cpp */; };
 		EB9EDFBC1BE9421B00E8938F /* MOAICrittercismIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9A41AB6151AAA5400650276 /* MOAICrittercismIOS.mm */; };
-		EB9EDFBD1BE9421B00E8938F /* MOAINotificationsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1DFD151AD5B4005F39B7 /* MOAINotificationsIOS.mm */; };
-		EB9EDFBE1BE9421B00E8938F /* MOAIAppIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C612151B146F0009D47D /* MOAIAppIOS.mm */; };
-		EB9EDFBF1BE9421B00E8938F /* MOAIDialogIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C616151B146F0009D47D /* MOAIDialogIOS.mm */; };
-		EB9EDFC01BE9421B00E8938F /* MOAIWebViewDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C629151B17540009D47D /* MOAIWebViewDelegate.mm */; };
-		EB9EDFC11BE9421B00E8938F /* MOAIGameCenterIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E55151C7D71005F39B7 /* MOAIGameCenterIOS.mm */; };
-		EB9EDFC21BE9421B00E8938F /* MOAIWebViewIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */; };
 		EB9EDFC31BE9421B00E8938F /* MOAIKeyboardIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD91E3FF15252E2F00AE1883 /* MOAIKeyboardIOS.mm */; };
 		EB9EDFC41BE9421B00E8938F /* AKU-adcolony.mm in Sources */ = {isa = PBXBuildFile; fileRef = E98DBDD21537A33100514387 /* AKU-adcolony.mm */; };
 		EB9EDFC51BE9421B00E8938F /* AKU-chartboost.mm in Sources */ = {isa = PBXBuildFile; fileRef = E98DBDD41537A33100514387 /* AKU-chartboost.mm */; };
@@ -2703,7 +2685,6 @@
 		EB9EDFDD1BE9421B00E8938F /* USStreamReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572991575713C00A486AB /* USStreamReader.cpp */; };
 		EB9EDFDE1BE9421B00E8938F /* USBase64Encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572A71575714A00A486AB /* USBase64Encoder.cpp */; };
 		EB9EDFDF1BE9421B00E8938F /* MOAIGridDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572AD1575717000A486AB /* MOAIGridDeck2D.cpp */; };
-		EB9EDFE01BE9421B00E8938F /* MOAIMoviePlayerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */; };
 		EB9EDFE11BE9421B00E8938F /* MOAIHashWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0755162415A6CA2B00161409 /* MOAIHashWriter.cpp */; };
 		EB9EDFE21BE9421B00E8938F /* USHashWriterAdler32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703CB16128038002D0D27 /* USHashWriterAdler32.cpp */; };
 		EB9EDFE31BE9421B00E8938F /* USHashWriterCRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703CD16128038002D0D27 /* USHashWriterCRC32.cpp */; };
@@ -2730,7 +2711,6 @@
 		EB9EDFF81BE9421B00E8938F /* MOAIMutex_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3216AE312A009B9C29 /* MOAIMutex_posix.cpp */; };
 		EB9EDFF91BE9421B00E8938F /* MOAIMutex_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3416AE312A009B9C29 /* MOAIMutex_win32.cpp */; };
 		EB9EDFFA1BE9421B00E8938F /* MOAIMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3616AE312A009B9C29 /* MOAIMutex.cpp */; };
-		EB9EDFFB1BE9421B00E8938F /* MOAITakeCameraListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */; };
 		EB9EDFFC1BE9421B00E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
 		EB9EDFFD1BE9421B00E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
 		EB9EDFFE1BE9421B00E8938F /* MOAIEaseLinear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D497348187258FA00D46882 /* MOAIEaseLinear.cpp */; };
@@ -3208,6 +3188,9 @@
 		EB9EE1EE1BE9424500E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
 		EB9EE1EF1BE9424500E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
 		EB9EE1F01BE9424500E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
+		EB9EE1F61BE94DA900E8938F /* AKU-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1D0BA213599FD200802A3C /* AKU-iphone.h */; };
+		EB9EE1F71BE94DB500E8938F /* AKU-iphone.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD1D0BA313599FD200802A3C /* AKU-iphone.mm */; };
+		EB9EE1F81BE94DC800E8938F /* moaiext-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECA1398BA6200AB0420 /* moaiext-iphone.h */; };
 		EBC495FA184D21840059FBDE /* MOAITextRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B45A8BEA1829A95C00D2B255 /* MOAITextRenderer.cpp */; };
 		EBC495FB184D21880059FBDE /* MOAITextRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = B45A8BEB1829A95C00D2B255 /* MOAITextRenderer.h */; };
 		F00D616E18C00F1E00625DA9 /* sha1_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9691846ACCF0031F295 /* sha1_one.c */; };
@@ -7680,17 +7663,16 @@
 				EB9EDE0C1BE9421B00E8938F /* USVec3D.h in Headers */,
 				EB9EDE0D1BE9421B00E8938F /* USZip.h in Headers */,
 				EB9EDE0E1BE9421B00E8938F /* USZipFile.h in Headers */,
-				EB9EDE0F1BE9421B00E8938F /* AKU-iphone.h in Headers */,
 				EB9EDE101BE9421B00E8938F /* MOAIEventSource.h in Headers */,
 				EB9EDE111BE9421B00E8938F /* MOAIImage.h in Headers */,
 				EB9EDE121BE9421B00E8938F /* MOAIEaseSineInOut.h in Headers */,
 				EB9EDE131BE9421B00E8938F /* MOAICameraAnchor2D.h in Headers */,
 				EB9EDE141BE9421B00E8938F /* MOAICameraFitter2D.h in Headers */,
 				EB9EDE151BE9421B00E8938F /* MOAIDeckRemapper.h in Headers */,
-				EB9EDE161BE9421B00E8938F /* moaiext-iphone.h in Headers */,
 				EB9EDE171BE9421B00E8938F /* MOAIEaseExponentialIn.h in Headers */,
 				EB9EDE181BE9421B00E8938F /* NSArray+MOAILib.h in Headers */,
 				EB9EDE191BE9421B00E8938F /* NSData+MOAILib.h in Headers */,
+				EB9EE1F61BE94DA900E8938F /* AKU-iphone.h in Headers */,
 				EB9EDE1A1BE9421B00E8938F /* MOAIEaseLinear.h in Headers */,
 				EB9EDE1B1BE9421B00E8938F /* NSDate+MOAILib.h in Headers */,
 				EB9EDE1C1BE9421B00E8938F /* NSDictionary+MOAILib.h in Headers */,
@@ -7736,6 +7718,7 @@
 				EB9EDE441BE9421B00E8938F /* MOAIBox2DRevoluteJoint.h in Headers */,
 				EB9EDE451BE9421B00E8938F /* MOAIBox2DWeldJoint.h in Headers */,
 				EB9EDE461BE9421B00E8938F /* MOAIAttrOp.h in Headers */,
+				EB9EE1F81BE94DC800E8938F /* moaiext-iphone.h in Headers */,
 				EB9EDE471BE9421B00E8938F /* MOAIBox2DRopeJoint.h in Headers */,
 				EB9EDE481BE9421B00E8938F /* MOAIBox2DWheelJoint.h in Headers */,
 				EB9EDE491BE9421B00E8938F /* MOAIEaseElasticBase.h in Headers */,
@@ -7801,15 +7784,8 @@
 				EB9EDE851BE9421B00E8938F /* MOAIUrlMgrNaCl.h in Headers */,
 				EB9EDE861BE9421B00E8938F /* MOAIRenderable.h in Headers */,
 				EB9EDE871BE9421B00E8938F /* MOAIRenderMgr.h in Headers */,
-				EB9EDE881BE9421B00E8938F /* USUnique.h in Headers */,
 				EB9EDE891BE9421B00E8938F /* MOAICrittercismIOS.h in Headers */,
-				EB9EDE8A1BE9421B00E8938F /* MOAINotificationsIOS.h in Headers */,
-				EB9EDE8B1BE9421B00E8938F /* MOAIAppIOS.h in Headers */,
-				EB9EDE8C1BE9421B00E8938F /* MOAIDialogIOS.h in Headers */,
-				EB9EDE8D1BE9421B00E8938F /* MOAIWebViewDelegate.h in Headers */,
-				EB9EDE8E1BE9421B00E8938F /* MOAIGameCenterIOS.h in Headers */,
 				EB9EDE8F1BE9421B00E8938F /* MOAIEaseSimpleOut.h in Headers */,
-				EB9EDE901BE9421B00E8938F /* MOAIWebViewIOS.h in Headers */,
 				EB9EDE911BE9421B00E8938F /* MOAIKeyboardIOS.h in Headers */,
 				EB9EDE921BE9421B00E8938F /* AKU-adcolony.h in Headers */,
 				EB9EDE931BE9421B00E8938F /* AKU-chartboost.h in Headers */,
@@ -7840,7 +7816,6 @@
 				EB9EDEAC1BE9421B00E8938F /* USStreamReader.h in Headers */,
 				EB9EDEAD1BE9421B00E8938F /* USBase64Encoder.h in Headers */,
 				EB9EDEAE1BE9421B00E8938F /* MOAIGridDeck2D.h in Headers */,
-				EB9EDEAF1BE9421B00E8938F /* MOAIMoviePlayerIOS.h in Headers */,
 				EB9EDEB01BE9421B00E8938F /* MOAIHashWriter.h in Headers */,
 				EB9EDEB11BE9421B00E8938F /* USHexWriter.h in Headers */,
 				EB9EDEB21BE9421B00E8938F /* USHashWriterAdler32.h in Headers */,
@@ -7865,7 +7840,6 @@
 				EB9EDEC51BE9421B00E8938F /* MOAIMutex_posix.h in Headers */,
 				EB9EDEC61BE9421B00E8938F /* MOAIMutex_win32.h in Headers */,
 				EB9EDEC71BE9421B00E8938F /* MOAIMutex.h in Headers */,
-				EB9EDEC81BE9421B00E8938F /* MOAITakeCameraListener.h in Headers */,
 				EB9EDEC91BE9421B00E8938F /* MOAIMath.h in Headers */,
 				EB9EDECA1BE9421B00E8938F /* MOAIFrameBufferTexture.h in Headers */,
 				EB9EDECB1BE9421B00E8938F /* MOAIAnimCurveCustom.h in Headers */,
@@ -9575,6 +9549,7 @@
 				EB9EDEF31BE9421B00E8938F /* MOAITextStyle.cpp in Sources */,
 				EB9EDEF41BE9421B00E8938F /* MOAITextStyler.cpp in Sources */,
 				EB9EDEF51BE9421B00E8938F /* MOAIEaseSineOut.cpp in Sources */,
+				EB9EE1F71BE94DB500E8938F /* AKU-iphone.mm in Sources */,
 				EB9EDEF61BE9421B00E8938F /* MOAIGlyphCache.cpp in Sources */,
 				EB9EDEF71BE9421B00E8938F /* MOAIGlyphCacheBase.cpp in Sources */,
 				EB9EDEF81BE9421B00E8938F /* MOAIGlyphCachePage.cpp in Sources */,
@@ -9771,14 +9746,7 @@
 				EB9EDFB81BE9421B00E8938F /* MOAIUrlMgrNaCl.cpp in Sources */,
 				EB9EDFB91BE9421B00E8938F /* MOAIRenderable.cpp in Sources */,
 				EB9EDFBA1BE9421B00E8938F /* MOAIRenderMgr.cpp in Sources */,
-				EB9EDFBB1BE9421B00E8938F /* USUnique_linux.cpp in Sources */,
 				EB9EDFBC1BE9421B00E8938F /* MOAICrittercismIOS.mm in Sources */,
-				EB9EDFBD1BE9421B00E8938F /* MOAINotificationsIOS.mm in Sources */,
-				EB9EDFBE1BE9421B00E8938F /* MOAIAppIOS.mm in Sources */,
-				EB9EDFBF1BE9421B00E8938F /* MOAIDialogIOS.mm in Sources */,
-				EB9EDFC01BE9421B00E8938F /* MOAIWebViewDelegate.mm in Sources */,
-				EB9EDFC11BE9421B00E8938F /* MOAIGameCenterIOS.mm in Sources */,
-				EB9EDFC21BE9421B00E8938F /* MOAIWebViewIOS.mm in Sources */,
 				EB9EDFC31BE9421B00E8938F /* MOAIKeyboardIOS.mm in Sources */,
 				EB9EDFC41BE9421B00E8938F /* AKU-adcolony.mm in Sources */,
 				EB9EDFC51BE9421B00E8938F /* AKU-chartboost.mm in Sources */,
@@ -9808,7 +9776,6 @@
 				EB9EDFDD1BE9421B00E8938F /* USStreamReader.cpp in Sources */,
 				EB9EDFDE1BE9421B00E8938F /* USBase64Encoder.cpp in Sources */,
 				EB9EDFDF1BE9421B00E8938F /* MOAIGridDeck2D.cpp in Sources */,
-				EB9EDFE01BE9421B00E8938F /* MOAIMoviePlayerIOS.mm in Sources */,
 				EB9EDFE11BE9421B00E8938F /* MOAIHashWriter.cpp in Sources */,
 				EB9EDFE21BE9421B00E8938F /* USHashWriterAdler32.cpp in Sources */,
 				EB9EDFE31BE9421B00E8938F /* USHashWriterCRC32.cpp in Sources */,
@@ -9835,7 +9802,6 @@
 				EB9EDFF81BE9421B00E8938F /* MOAIMutex_posix.cpp in Sources */,
 				EB9EDFF91BE9421B00E8938F /* MOAIMutex_win32.cpp in Sources */,
 				EB9EDFFA1BE9421B00E8938F /* MOAIMutex.cpp in Sources */,
-				EB9EDFFB1BE9421B00E8938F /* MOAITakeCameraListener.mm in Sources */,
 				EB9EDFFC1BE9421B00E8938F /* MOAIMath.cpp in Sources */,
 				EB9EDFFD1BE9421B00E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
 				EB9EDFFE1BE9421B00E8938F /* MOAIEaseLinear.cpp in Sources */,

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -2122,6 +2122,1093 @@
 		EB70434718761FDE0057E450 /* MOAIEaseExponentialInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70434318761FDE0057E450 /* MOAIEaseExponentialInOut.h */; };
 		EB92A50816B6671000FC326E /* MOAITakeCameraListener.h in Headers */ = {isa = PBXBuildFile; fileRef = EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */; };
 		EB92A50916B6671000FC326E /* MOAITakeCameraListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */; };
+		EB9EDD991BE9421B00E8938F /* md5_locl.h in Headers */ = {isa = PBXBuildFile; fileRef = F055A9871846B1810031F295 /* md5_locl.h */; };
+		EB9EDD9A1BE9421B00E8938F /* md5.h in Headers */ = {isa = PBXBuildFile; fileRef = F055A9881846B1810031F295 /* md5.h */; };
+		EB9EDD9B1BE9421B00E8938F /* ldo.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49004B141AB6EC00913D80 /* ldo.h */; };
+		EB9EDD9C1BE9421B00E8938F /* sha_locl.h in Headers */ = {isa = PBXBuildFile; fileRef = F055A9641846ACA90031F295 /* sha_locl.h */; };
+		EB9EDD9D1BE9421B00E8938F /* sha.h in Headers */ = {isa = PBXBuildFile; fileRef = F055A9491846ABF40031F295 /* sha.h */; };
+		EB9EDD9E1BE9421B00E8938F /* AKU.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E4F413564BC7000ADC60 /* AKU.h */; };
+		EB9EDD9F1BE9421B00E8938F /* USRhombus.h in Headers */ = {isa = PBXBuildFile; fileRef = E91A4C9B151829070008F1A5 /* USRhombus.h */; };
+		EB9EDDA01BE9421B00E8938F /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E4F813564BC7000ADC60 /* pch.h */; };
+		EB9EDDA11BE9421B00E8938F /* MOAIAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E4FB13564BC7000ADC60 /* MOAIAction.h */; };
+		EB9EDDA21BE9421B00E8938F /* MOAIAnim.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E4FD13564BC7000ADC60 /* MOAIAnim.h */; };
+		EB9EDDA31BE9421B00E8938F /* MOAIEaseExponentialInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70434318761FDE0057E450 /* MOAIEaseExponentialInOut.h */; };
+		EB9EDDA41BE9421B00E8938F /* MOAIAnimCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E4FF13564BC7000ADC60 /* MOAIAnimCurve.h */; };
+		EB9EDDA51BE9421B00E8938F /* MOAIBlocker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50113564BC7000ADC60 /* MOAIBlocker.h */; };
+		EB9EDDA61BE9421B00E8938F /* MOAIBox2DArbiter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50313564BC7000ADC60 /* MOAIBox2DArbiter.h */; };
+		EB9EDDA71BE9421B00E8938F /* MOAIBox2DBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50513564BC7000ADC60 /* MOAIBox2DBody.h */; };
+		EB9EDDA81BE9421B00E8938F /* MOAIBox2DDebugDraw.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50713564BC7000ADC60 /* MOAIBox2DDebugDraw.h */; };
+		EB9EDDA91BE9421B00E8938F /* MOAIBox2DFixture.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50913564BC7000ADC60 /* MOAIBox2DFixture.h */; };
+		EB9EDDAA1BE9421B00E8938F /* MOAIBox2DJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50B13564BC7000ADC60 /* MOAIBox2DJoint.h */; };
+		EB9EDDAB1BE9421B00E8938F /* MOAIBox2DWorld.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50D13564BC7000ADC60 /* MOAIBox2DWorld.h */; };
+		EB9EDDAC1BE9421B00E8938F /* MOAIButtonSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E50F13564BC7000ADC60 /* MOAIButtonSensor.h */; };
+		EB9EDDAD1BE9421B00E8938F /* MOAIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51113564BC7000ADC60 /* MOAIColor.h */; };
+		EB9EDDAE1BE9421B00E8938F /* MOAICompassSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51313564BC7000ADC60 /* MOAICompassSensor.h */; };
+		EB9EDDAF1BE9421B00E8938F /* moaicore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51613564BC7000ADC60 /* moaicore.h */; };
+		EB9EDDB01BE9421B00E8938F /* MOAICp.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51813564BC7000ADC60 /* MOAICp.h */; };
+		EB9EDDB11BE9421B00E8938F /* MOAIEaseBackInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851D9C1873DED9009DF1C4 /* MOAIEaseBackInOut.h */; };
+		EB9EDDB21BE9421B00E8938F /* MOAIEaseSimpleIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D49734D18725B5600D46882 /* MOAIEaseSimpleIn.h */; };
+		EB9EDDB31BE9421B00E8938F /* MOAICpArbiter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51A13564BC7000ADC60 /* MOAICpArbiter.h */; };
+		EB9EDDB41BE9421B00E8938F /* MOAICpBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51C13564BC7000ADC60 /* MOAICpBody.h */; };
+		EB9EDDB51BE9421B00E8938F /* MOAIEaseBackBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851D8A1873DAB7009DF1C4 /* MOAIEaseBackBase.h */; };
+		EB9EDDB61BE9421B00E8938F /* MOAIEaseSineIn.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70432518761BDE0057E450 /* MOAIEaseSineIn.h */; };
+		EB9EDDB71BE9421B00E8938F /* MOAICpConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E51E13564BC7000ADC60 /* MOAICpConstraint.h */; };
+		EB9EDDB81BE9421B00E8938F /* MOAICpDebugDraw.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52013564BC7000ADC60 /* MOAICpDebugDraw.h */; };
+		EB9EDDB91BE9421B00E8938F /* MOAICpShape.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52213564BC7000ADC60 /* MOAICpShape.h */; };
+		EB9EDDBA1BE9421B00E8938F /* MOAICpSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52413564BC7000ADC60 /* MOAICpSpace.h */; };
+		EB9EDDBB1BE9421B00E8938F /* MOAIDataBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52613564BC7000ADC60 /* MOAIDataBuffer.h */; };
+		EB9EDDBC1BE9421B00E8938F /* MOAIDebugLines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52A13564BC7000ADC60 /* MOAIDebugLines.h */; };
+		EB9EDDBD1BE9421B00E8938F /* MOAIDeck.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52C13564BC7000ADC60 /* MOAIDeck.h */; };
+		EB9EDDBE1BE9421B00E8938F /* MOAIEaseDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E53013564BC7000ADC60 /* MOAIEaseDriver.h */; };
+		EB9EDDBF1BE9421B00E8938F /* MOAIEaseType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E53213564BC7000ADC60 /* MOAIEaseType.h */; };
+		EB9EDDC01BE9421B00E8938F /* MOAIFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E53A13564BC7000ADC60 /* MOAIFont.h */; };
+		EB9EDDC11BE9421B00E8938F /* MOAIGfxQuad2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E53E13564BC7000ADC60 /* MOAIGfxQuad2D.h */; };
+		EB9EDDC21BE9421B00E8938F /* MOAIGfxQuadDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54013564BC7000ADC60 /* MOAIGfxQuadDeck2D.h */; };
+		EB9EDDC31BE9421B00E8938F /* MOAIGfxQuadListDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54213564BC7000ADC60 /* MOAIGfxQuadListDeck2D.h */; };
+		EB9EDDC41BE9421B00E8938F /* MOAIGrid.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54413564BC7000ADC60 /* MOAIGrid.h */; };
+		EB9EDDC51BE9421B00E8938F /* MOAIIndexBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54813564BC7000ADC60 /* MOAIIndexBuffer.h */; };
+		EB9EDDC61BE9421B00E8938F /* MOAIInputDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54A13564BC7000ADC60 /* MOAIInputDevice.h */; };
+		EB9EDDC71BE9421B00E8938F /* MOAIInputMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54C13564BC7000ADC60 /* MOAIInputMgr.h */; };
+		EB9EDDC81BE9421B00E8938F /* MOAIJoystickSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E54E13564BC7000ADC60 /* MOAIJoystickSensor.h */; };
+		EB9EDDC91BE9421B00E8938F /* MOAIKeyboardSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55013564BC7000ADC60 /* MOAIKeyboardSensor.h */; };
+		EB9EDDCA1BE9421B00E8938F /* MOAILayoutFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55613564BC7000ADC60 /* MOAILayoutFrame.h */; };
+		EB9EDDCB1BE9421B00E8938F /* MOAILocationSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55A13564BC7000ADC60 /* MOAILocationSensor.h */; };
+		EB9EDDCC1BE9421B00E8938F /* MOAILogMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55B13564BC7000ADC60 /* MOAILogMessages.h */; };
+		EB9EDDCD1BE9421B00E8938F /* MOAIEaseElasticInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7043131876030B0057E450 /* MOAIEaseElasticInOut.h */; };
+		EB9EDDCE1BE9421B00E8938F /* MOAILogMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55D13564BC7000ADC60 /* MOAILogMgr.h */; };
+		EB9EDDCF1BE9421B00E8938F /* MOAIMesh.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E55F13564BC7000ADC60 /* MOAIMesh.h */; };
+		EB9EDDD01BE9421B00E8938F /* MOAINode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E56113564BC7000ADC60 /* MOAINode.h */; };
+		EB9EDDD11BE9421B00E8938F /* MOAINodeMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E56313564BC7000ADC60 /* MOAINodeMgr.h */; };
+		EB9EDDD21BE9421B00E8938F /* MOAIParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E56513564BC7000ADC60 /* MOAIParser.h */; };
+		EB9EDDD31BE9421B00E8938F /* MOAIPartition.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57313564BC7000ADC60 /* MOAIPartition.h */; };
+		EB9EDDD41BE9421B00E8938F /* MOAIPartitionCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57513564BC7000ADC60 /* MOAIPartitionCell.h */; };
+		EB9EDDD51BE9421B00E8938F /* MOAIPartitionLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57713564BC7000ADC60 /* MOAIPartitionLevel.h */; };
+		EB9EDDD61BE9421B00E8938F /* MOAIPointerSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57913564BC7000ADC60 /* MOAIPointerSensor.h */; };
+		EB9EDDD71BE9421B00E8938F /* MOAIProp.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57B13564BC7000ADC60 /* MOAIProp.h */; };
+		EB9EDDD81BE9421B00E8938F /* MOAIScriptNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E57F13564BC7000ADC60 /* MOAIScriptNode.h */; };
+		EB9EDDD91BE9421B00E8938F /* MOAISensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58113564BC7000ADC60 /* MOAISensor.h */; };
+		EB9EDDDA1BE9421B00E8938F /* MOAISerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58313564BC7000ADC60 /* MOAISerializer.h */; };
+		EB9EDDDB1BE9421B00E8938F /* MOAIShader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58513564BC7000ADC60 /* MOAIShader.h */; };
+		EB9EDDDC1BE9421B00E8938F /* MOAISim.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58713564BC7000ADC60 /* MOAISim.h */; };
+		EB9EDDDD1BE9421B00E8938F /* MOAIEaseBackOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851D961873DDE6009DF1C4 /* MOAIEaseBackOut.h */; };
+		EB9EDDDE1BE9421B00E8938F /* MOAIStretchPatch2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58B13564BC8000ADC60 /* MOAIStretchPatch2D.h */; };
+		EB9EDDDF1BE9421B00E8938F /* MOAICCParticle.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F51FA11989EB00005F5779 /* MOAICCParticle.h */; };
+		EB9EDDE01BE9421B00E8938F /* MOAISurfaceDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58D13564BC8000ADC60 /* MOAISurfaceDeck2D.h */; };
+		EB9EDDE11BE9421B00E8938F /* MOAISurfaceSampler2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E58F13564BC8000ADC60 /* MOAISurfaceSampler2D.h */; };
+		EB9EDDE21BE9421B00E8938F /* MOAITextBox.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59113564BC8000ADC60 /* MOAITextBox.h */; };
+		EB9EDDE31BE9421B00E8938F /* MOAITexture.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59313564BC8000ADC60 /* MOAITexture.h */; };
+		EB9EDDE41BE9421B00E8938F /* MOAIEase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4973451872370F00D46882 /* MOAIEase.h */; };
+		EB9EDDE51BE9421B00E8938F /* MOAITileDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59713564BC8000ADC60 /* MOAITileDeck2D.h */; };
+		EB9EDDE61BE9421B00E8938F /* MOAITimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59913564BC8000ADC60 /* MOAITimer.h */; };
+		EB9EDDE71BE9421B00E8938F /* MOAITouchSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59B13564BC8000ADC60 /* MOAITouchSensor.h */; };
+		EB9EDDE81BE9421B00E8938F /* MOAITransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59D13564BC8000ADC60 /* MOAITransform.h */; };
+		EB9EDDE91BE9421B00E8938F /* MOAITransformBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E59F13564BC8000ADC60 /* MOAITransformBase.h */; };
+		EB9EDDEA1BE9421B00E8938F /* MOAIVertexBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5A113564BC8000ADC60 /* MOAIVertexBuffer.h */; };
+		EB9EDDEB1BE9421B00E8938F /* MOAIVertexFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5A313564BC8000ADC60 /* MOAIVertexFormat.h */; };
+		EB9EDDEC1BE9421B00E8938F /* MOAIViewport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5A513564BC8000ADC60 /* MOAIViewport.h */; };
+		EB9EDDED1BE9421B00E8938F /* MOAIXmlParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5A713564BC8000ADC60 /* MOAIXmlParser.h */; };
+		EB9EDDEE1BE9421B00E8938F /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5A913564BC8000ADC60 /* pch.h */; };
+		EB9EDDEF1BE9421B00E8938F /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5AC13564BC8000ADC60 /* pch.h */; };
+		EB9EDDF01BE9421B00E8938F /* STLArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5AD13564BC8000ADC60 /* STLArray.h */; };
+		EB9EDDF11BE9421B00E8938F /* STLIteration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5AE13564BC8000ADC60 /* STLIteration.h */; };
+		EB9EDDF21BE9421B00E8938F /* STLList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5AF13564BC8000ADC60 /* STLList.h */; };
+		EB9EDDF31BE9421B00E8938F /* STLMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5B013564BC8000ADC60 /* STLMap.h */; };
+		EB9EDDF41BE9421B00E8938F /* STLSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5B113564BC8000ADC60 /* STLSet.h */; };
+		EB9EDDF51BE9421B00E8938F /* STLString.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5B313564BC8000ADC60 /* STLString.h */; };
+		EB9EDDF61BE9421B00E8938F /* USAccessors.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5B413564BC8000ADC60 /* USAccessors.h */; };
+		EB9EDDF71BE9421B00E8938F /* USByteStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5B813564BC8000ADC60 /* USByteStream.h */; };
+		EB9EDDF81BE9421B00E8938F /* USDeviceTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5C113564BC8000ADC60 /* USDeviceTime.h */; };
+		EB9EDDF91BE9421B00E8938F /* USDirectoryItr.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5C513564BC8000ADC60 /* USDirectoryItr.h */; };
+		EB9EDDFA1BE9421B00E8938F /* USFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5C813564BC8000ADC60 /* USFactory.h */; };
+		EB9EDDFB1BE9421B00E8938F /* USFileStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5CC13564BC8000ADC60 /* USFileStream.h */; };
+		EB9EDDFC1BE9421B00E8938F /* USFileSys.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5CE13564BC8000ADC60 /* USFileSys.h */; };
+		EB9EDDFD1BE9421B00E8938F /* USFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5CF13564BC8000ADC60 /* USFloat.h */; };
+		EB9EDDFE1BE9421B00E8938F /* USLeanArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5D413564BC8000ADC60 /* USLeanArray.h */; };
+		EB9EDDFF1BE9421B00E8938F /* MOAIEaseExponentialOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70433D18761FCB0057E450 /* MOAIEaseExponentialOut.h */; };
+		EB9EDE001BE9421B00E8938F /* USLeanList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5D513564BC8000ADC60 /* USLeanList.h */; };
+		EB9EDE011BE9421B00E8938F /* USLeanPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5D613564BC8000ADC60 /* USLeanPool.h */; };
+		EB9EDE021BE9421B00E8938F /* USLeanStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5D713564BC8000ADC60 /* USLeanStack.h */; };
+		EB9EDE031BE9421B00E8938F /* USList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5D813564BC8000ADC60 /* USList.h */; };
+		EB9EDE041BE9421B00E8938F /* uslscore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5DA13564BC8000ADC60 /* uslscore.h */; };
+		EB9EDE051BE9421B00E8938F /* MOAIEaseCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4973691872793400D46882 /* MOAIEaseCustom.h */; };
+		EB9EDE061BE9421B00E8938F /* USMemStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5EB13564BC8000ADC60 /* USMemStream.h */; };
+		EB9EDE071BE9421B00E8938F /* USRect.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5EE13564BC8000ADC60 /* USRect.h */; };
+		EB9EDE081BE9421B00E8938F /* USStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F313564BC8000ADC60 /* USStream.h */; };
+		EB9EDE091BE9421B00E8938F /* USTypeID.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F613564BC8000ADC60 /* USTypeID.h */; };
+		EB9EDE0A1BE9421B00E8938F /* USUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F713564BC8000ADC60 /* USUnion.h */; };
+		EB9EDE0B1BE9421B00E8938F /* USVec2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F813564BC8000ADC60 /* USVec2D.h */; };
+		EB9EDE0C1BE9421B00E8938F /* USVec3D.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5F913564BC8000ADC60 /* USVec3D.h */; };
+		EB9EDE0D1BE9421B00E8938F /* USZip.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5FC13564BC8000ADC60 /* USZip.h */; };
+		EB9EDE0E1BE9421B00E8938F /* USZipFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E5FE13564BC8000ADC60 /* USZipFile.h */; };
+		EB9EDE0F1BE9421B00E8938F /* AKU-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1D0BA213599FD200802A3C /* AKU-iphone.h */; };
+		EB9EDE101BE9421B00E8938F /* MOAIEventSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEB91431360A78800AAC558 /* MOAIEventSource.h */; };
+		EB9EDE111BE9421B00E8938F /* MOAIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEB91451360A78800AAC558 /* MOAIImage.h */; };
+		EB9EDE121BE9421B00E8938F /* MOAIEaseSineInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70433118761E630057E450 /* MOAIEaseSineInOut.h */; };
+		EB9EDE131BE9421B00E8938F /* MOAICameraAnchor2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 031FA4CC138589C4007FD20C /* MOAICameraAnchor2D.h */; };
+		EB9EDE141BE9421B00E8938F /* MOAICameraFitter2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 031FA4CE138589C4007FD20C /* MOAICameraFitter2D.h */; };
+		EB9EDE151BE9421B00E8938F /* MOAIDeckRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 039C283C138EDAB300A3A780 /* MOAIDeckRemapper.h */; };
+		EB9EDE161BE9421B00E8938F /* moaiext-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECA1398BA6200AB0420 /* moaiext-iphone.h */; };
+		EB9EDE171BE9421B00E8938F /* MOAIEaseExponentialIn.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70433718761FBD0057E450 /* MOAIEaseExponentialIn.h */; };
+		EB9EDE181BE9421B00E8938F /* NSArray+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECD1398BA6200AB0420 /* NSArray+MOAILib.h */; };
+		EB9EDE191BE9421B00E8938F /* NSData+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECF1398BA6200AB0420 /* NSData+MOAILib.h */; };
+		EB9EDE1A1BE9421B00E8938F /* MOAIEaseLinear.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D497349187258FA00D46882 /* MOAIEaseLinear.h */; };
+		EB9EDE1B1BE9421B00E8938F /* NSDate+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ED11398BA6200AB0420 /* NSDate+MOAILib.h */; };
+		EB9EDE1C1BE9421B00E8938F /* NSDictionary+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ED31398BA6200AB0420 /* NSDictionary+MOAILib.h */; };
+		EB9EDE1D1BE9421B00E8938F /* NSError+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ED51398BA6200AB0420 /* NSError+MOAILib.h */; };
+		EB9EDE1E1BE9421B00E8938F /* NSNumber+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ED71398BA6200AB0420 /* NSNumber+MOAILib.h */; };
+		EB9EDE1F1BE9421B00E8938F /* NSObject+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ED91398BA6200AB0420 /* NSObject+MOAILib.h */; };
+		EB9EDE201BE9421B00E8938F /* NSString+MOAILib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06EDB1398BA6200AB0420 /* NSString+MOAILib.h */; };
+		EB9EDE211BE9421B00E8938F /* MOAIFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBC71171398C6E50016F98A /* MOAIFileSystem.h */; };
+		EB9EDE221BE9421B00E8938F /* USLog.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F7113A7FC79008337E7 /* USLog.h */; };
+		EB9EDE231BE9421B00E8938F /* MOAIJsonParser.h in Headers */ = {isa = PBXBuildFile; fileRef = CD62D6CB13A991BA002286EB /* MOAIJsonParser.h */; };
+		EB9EDE241BE9421B00E8938F /* MOAIEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 031BBA5B13B17BD80005ECE0 /* MOAIEnvironment.h */; };
+		EB9EDE251BE9421B00E8938F /* MOAIActionMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 033B1E5F13C4EC8A00CE21D2 /* MOAIActionMgr.h */; };
+		EB9EDE261BE9421B00E8938F /* MOAIMotionSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B2EC1313C503B400F8B3CF /* MOAIMotionSensor.h */; };
+		EB9EDE271BE9421B00E8938F /* MOAIDraw.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3DF13E37F3C000A9523 /* MOAIDraw.h */; };
+		EB9EDE281BE9421B00E8938F /* MOAIGfxDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3E313E37F3C000A9523 /* MOAIGfxDevice.h */; };
+		EB9EDE291BE9421B00E8938F /* MOAIGlyph.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3E513E37F3C000A9523 /* MOAIGlyph.h */; };
+		EB9EDE2A1BE9421B00E8938F /* MOAIGridSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3E713E37F3C000A9523 /* MOAIGridSpace.h */; };
+		EB9EDE2B1BE9421B00E8938F /* MOAIPvrHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3EA13E37F3C000A9523 /* MOAIPvrHeader.h */; };
+		EB9EDE2C1BE9421B00E8938F /* MOAIQuadBrush.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3EC13E37F3C000A9523 /* MOAIQuadBrush.h */; };
+		EB9EDE2D1BE9421B00E8938F /* MOAIShaderMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3EE13E37F3C000A9523 /* MOAIShaderMgr.h */; };
+		EB9EDE2E1BE9421B00E8938F /* MOAITileFlags.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3F413E37F3C000A9523 /* MOAITileFlags.h */; };
+		EB9EDE2F1BE9421B00E8938F /* MOAIVertexFormatMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEFB3F613E37F3C000A9523 /* MOAIVertexFormatMgr.h */; };
+		EB9EDE301BE9421B00E8938F /* MOAIBlendMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 07D1A89F13EDFD8300604979 /* MOAIBlendMode.h */; };
+		EB9EDE311BE9421B00E8938F /* MOAIFrameBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 07D1A8A113EDFD8300604979 /* MOAIFrameBuffer.h */; };
+		EB9EDE321BE9421B00E8938F /* MOAIDeck2DShader-fsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2913EE03E200CB9F35 /* MOAIDeck2DShader-fsh.h */; };
+		EB9EDE331BE9421B00E8938F /* MOAIDeck2DShader-vsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2A13EE03E200CB9F35 /* MOAIDeck2DShader-vsh.h */; };
+		EB9EDE341BE9421B00E8938F /* MOAIFontShader-fsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2B13EE03E200CB9F35 /* MOAIFontShader-fsh.h */; };
+		EB9EDE351BE9421B00E8938F /* MOAIFontShader-vsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2C13EE03E200CB9F35 /* MOAIFontShader-vsh.h */; };
+		EB9EDE361BE9421B00E8938F /* MOAILineShader-fsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2D13EE03E200CB9F35 /* MOAILineShader-fsh.h */; };
+		EB9EDE371BE9421B00E8938F /* MOAILineShader-vsh.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE0AB2E13EE03E200CB9F35 /* MOAILineShader-vsh.h */; };
+		EB9EDE381BE9421B00E8938F /* MOAIPartitionResultBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AF16BD13F45A0100E38D1D /* MOAIPartitionResultBuffer.h */; };
+		EB9EDE391BE9421B00E8938F /* MOAIPartitionResultMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AF16BF13F45A0100E38D1D /* MOAIPartitionResultMgr.h */; };
+		EB9EDE3A1BE9421B00E8938F /* MOAIEaseSineOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70432B18761D9A0057E450 /* MOAIEaseSineOut.h */; };
+		EB9EDE3B1BE9421B00E8938F /* MOAIScriptDeck.h in Headers */ = {isa = PBXBuildFile; fileRef = 66D967F914047A2500017919 /* MOAIScriptDeck.h */; };
+		EB9EDE3C1BE9421B00E8938F /* MOAIGfxResource.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF7130E141EBC5C00D650CA /* MOAIGfxResource.h */; };
+		EB9EDE3D1BE9421B00E8938F /* MOAIBox2DDistanceJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D0B1425DC2600BC33D4 /* MOAIBox2DDistanceJoint.h */; };
+		EB9EDE3E1BE9421B00E8938F /* MOAIBox2DFrictionJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D0D1425DC2600BC33D4 /* MOAIBox2DFrictionJoint.h */; };
+		EB9EDE3F1BE9421B00E8938F /* MOAIBox2DGearJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D0F1425DC2600BC33D4 /* MOAIBox2DGearJoint.h */; };
+		EB9EDE401BE9421B00E8938F /* MOAIBox2DMouseJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D131425DC2600BC33D4 /* MOAIBox2DMouseJoint.h */; };
+		EB9EDE411BE9421B00E8938F /* MOAIBox2DPrismaticJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D151425DC2600BC33D4 /* MOAIBox2DPrismaticJoint.h */; };
+		EB9EDE421BE9421B00E8938F /* MOAICCParticleSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F51F9A19898558005F5779 /* MOAICCParticleSystem.h */; };
+		EB9EDE431BE9421B00E8938F /* MOAIBox2DPulleyJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D171425DC2600BC33D4 /* MOAIBox2DPulleyJoint.h */; };
+		EB9EDE441BE9421B00E8938F /* MOAIBox2DRevoluteJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D191425DC2600BC33D4 /* MOAIBox2DRevoluteJoint.h */; };
+		EB9EDE451BE9421B00E8938F /* MOAIBox2DWeldJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBD3D1B1425DC2600BC33D4 /* MOAIBox2DWeldJoint.h */; };
+		EB9EDE461BE9421B00E8938F /* MOAIAttrOp.h in Headers */ = {isa = PBXBuildFile; fileRef = CDDA3DA41458D70700755FB4 /* MOAIAttrOp.h */; };
+		EB9EDE471BE9421B00E8938F /* MOAIBox2DRopeJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE4E146909ED00C86DF9 /* MOAIBox2DRopeJoint.h */; };
+		EB9EDE481BE9421B00E8938F /* MOAIBox2DWheelJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE50146909ED00C86DF9 /* MOAIBox2DWheelJoint.h */; };
+		EB9EDE491BE9421B00E8938F /* MOAIEaseElasticBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851DA21873E5ED009DF1C4 /* MOAIEaseElasticBase.h */; };
+		EB9EDE4A1BE9421B00E8938F /* MOAICanary.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8514693BC100990FE1 /* MOAICanary.h */; };
+		EB9EDE4B1BE9421B00E8938F /* MOAIDeserializer.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8714693BC100990FE1 /* MOAIDeserializer.h */; };
+		EB9EDE4C1BE9421B00E8938F /* MOAIGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8914693BC100990FE1 /* MOAIGlobals.h */; };
+		EB9EDE4D1BE9421B00E8938F /* MOAILua.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8C14693BC100990FE1 /* MOAILua.h */; };
+		EB9EDE4E1BE9421B00E8938F /* MOAILuaObject-impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8D14693BC100990FE1 /* MOAILuaObject-impl.h */; };
+		EB9EDE4F1BE9421B00E8938F /* MOAILuaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE8F14693BC100990FE1 /* MOAILuaObject.h */; };
+		EB9EDE501BE9421B00E8938F /* MOAIEaseElasticOut.h in Headers */ = {isa = PBXBuildFile; fileRef = EB70430D187601CC0057E450 /* MOAIEaseElasticOut.h */; };
+		EB9EDE511BE9421B00E8938F /* MOAILuaRef.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9114693BC100990FE1 /* MOAILuaRef.h */; };
+		EB9EDE521BE9421B00E8938F /* MOAIEaseSimpleBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4973551872608C00D46882 /* MOAIEaseSimpleBase.h */; };
+		EB9EDE531BE9421B00E8938F /* MOAILuaRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9314693BC100990FE1 /* MOAILuaRuntime.h */; };
+		EB9EDE541BE9421B00E8938F /* MOAILuaSharedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9414693BC100990FE1 /* MOAILuaSharedPtr.h */; };
+		EB9EDE551BE9421B00E8938F /* MOAILuaState-impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9514693BC100990FE1 /* MOAILuaState-impl.h */; };
+		EB9EDE561BE9421B00E8938F /* MOAILuaState.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9714693BC100990FE1 /* MOAILuaState.h */; };
+		EB9EDE571BE9421B00E8938F /* MOAILuaStateHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9914693BC100990FE1 /* MOAILuaStateHandle.h */; };
+		EB9EDE581BE9421B00E8938F /* MOAIObject.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9B14693BC100990FE1 /* MOAIObject.h */; };
+		EB9EDE591BE9421B00E8938F /* MOAIRtti.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9D14693BC100990FE1 /* MOAIRtti.h */; };
+		EB9EDE5A1BE9421B00E8938F /* MOAISerializerBase.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CE9F14693BC100990FE1 /* MOAISerializerBase.h */; };
+		EB9EDE5B1BE9421B00E8938F /* MOAISharedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CEA014693BC100990FE1 /* MOAISharedPtr.h */; };
+		EB9EDE5C1BE9421B00E8938F /* MOAIWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = CD18CEA314693BC100990FE1 /* MOAIWeakPtr.h */; };
+		EB9EDE5D1BE9421B00E8938F /* MOAIWheelSensor.h in Headers */ = {isa = PBXBuildFile; fileRef = 668E165814887A0A00897ED6 /* MOAIWheelSensor.h */; };
+		EB9EDE5E1BE9421B00E8938F /* MOAIGridPathGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 075110E2149AD7C3006C0B61 /* MOAIGridPathGraph.h */; };
+		EB9EDE5F1BE9421B00E8938F /* MOAIPathFinder.h in Headers */ = {isa = PBXBuildFile; fileRef = 075110E4149AD7C3006C0B61 /* MOAIPathFinder.h */; };
+		EB9EDE601BE9421B00E8938F /* MOAIPathGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 075110E6149AD7C3006C0B61 /* MOAIPathGraph.h */; };
+		EB9EDE611BE9421B00E8938F /* MOAIPathTerrainDeck.h in Headers */ = {isa = PBXBuildFile; fileRef = 075110E8149AD7C3006C0B61 /* MOAIPathTerrainDeck.h */; };
+		EB9EDE621BE9421B00E8938F /* MOAIEaseElasticIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851DA81873E760009DF1C4 /* MOAIEaseElasticIn.h */; };
+		EB9EDE631BE9421B00E8938F /* USAdapterInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7314B7A4A0006465CC /* USAdapterInfo.h */; };
+		EB9EDE641BE9421B00E8938F /* USAffine2D.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7414B7A4A0006465CC /* USAffine2D.h */; };
+		EB9EDE651BE9421B00E8938F /* USBinarySearch.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7514B7A4A0006465CC /* USBinarySearch.h */; };
+		EB9EDE661BE9421B00E8938F /* USBox.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7714B7A4A0006465CC /* USBox.h */; };
+		EB9EDE671BE9421B00E8938F /* USCgt.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7914B7A4A0006465CC /* USCgt.h */; };
+		EB9EDE681BE9421B00E8938F /* USColor.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7B14B7A4A0006465CC /* USColor.h */; };
+		EB9EDE691BE9421B00E8938F /* USCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7D14B7A4A0006465CC /* USCurve.h */; };
+		EB9EDE6A1BE9421B00E8938F /* USDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8214B7A4A0006465CC /* USDelegate.h */; };
+		EB9EDE6B1BE9421B00E8938F /* USDistance.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8514B7A4A0006465CC /* USDistance.h */; };
+		EB9EDE6C1BE9421B00E8938F /* USHexDump.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8714B7A4A0006465CC /* USHexDump.h */; };
+		EB9EDE6D1BE9421B00E8938F /* USInterpolate.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8914B7A4A0006465CC /* USInterpolate.h */; };
+		EB9EDE6E1BE9421B00E8938F /* USIntersect.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8B14B7A4A0006465CC /* USIntersect.h */; };
+		EB9EDE6F1BE9421B00E8938F /* USMathConsts.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8E14B7A4A0006465CC /* USMathConsts.h */; };
+		EB9EDE701BE9421B00E8938F /* USMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8F14B7A4A0006465CC /* USMatrix.h */; };
+		EB9EDE711BE9421B00E8938F /* USMatrix3x3.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9014B7A4A0006465CC /* USMatrix3x3.h */; };
+		EB9EDE721BE9421B00E8938F /* USMatrix4x4.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9114B7A4A0006465CC /* USMatrix4x4.h */; };
+		EB9EDE731BE9421B00E8938F /* USMercator.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9314B7A4A0006465CC /* USMercator.h */; };
+		EB9EDE741BE9421B00E8938F /* USParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9914B7A4A0006465CC /* USParser.h */; };
+		EB9EDE751BE9421B00E8938F /* USPlane.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9B14B7A4A0006465CC /* USPlane.h */; };
+		EB9EDE761BE9421B00E8938F /* USPolar.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9D14B7A4A0006465CC /* USPolar.h */; };
+		EB9EDE771BE9421B00E8938F /* USPolygon2D.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9E14B7A4A0006465CC /* USPolygon2D.h */; };
+		EB9EDE781BE9421B00E8938F /* USPolyScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9F14B7A4A0006465CC /* USPolyScanner.h */; };
+		EB9EDE791BE9421B00E8938F /* USQuad.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA114B7A4A0006465CC /* USQuad.h */; };
+		EB9EDE7A1BE9421B00E8938F /* USQuadCoord.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA314B7A4A0006465CC /* USQuadCoord.h */; };
+		EB9EDE7B1BE9421B00E8938F /* USRadixSort16.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA414B7A4A0006465CC /* USRadixSort16.h */; };
+		EB9EDE7C1BE9421B00E8938F /* USRadixSort32.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA514B7A4A0006465CC /* USRadixSort32.h */; };
+		EB9EDE7D1BE9421B00E8938F /* USSurface2D.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA714B7A4A0006465CC /* USSurface2D.h */; };
+		EB9EDE7E1BE9421B00E8938F /* USSyntaxNode.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DA914B7A4A0006465CC /* USSyntaxNode.h */; };
+		EB9EDE7F1BE9421B00E8938F /* USSyntaxScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAB14B7A4A0006465CC /* USSyntaxScanner.h */; };
+		EB9EDE801BE9421B00E8938F /* USTrig.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB514B7A4A0006465CC /* USTrig.h */; };
+		EB9EDE811BE9421B00E8938F /* USTypedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB714B7A4A0006465CC /* USTypedPtr.h */; };
+		EB9EDE821BE9421B00E8938F /* USXmlReader.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB914B7A4A0006465CC /* USXmlReader.h */; };
+		EB9EDE831BE9421B00E8938F /* MOAIAudioSampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 66459FB91511641F0075BF13 /* MOAIAudioSampler.h */; };
+		EB9EDE841BE9421B00E8938F /* MOAIHttpTaskNaCl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BA08A151949C50002E925 /* MOAIHttpTaskNaCl.h */; };
+		EB9EDE851BE9421B00E8938F /* MOAIUrlMgrNaCl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BA08E151949C50002E925 /* MOAIUrlMgrNaCl.h */; };
+		EB9EDE861BE9421B00E8938F /* MOAIRenderable.h in Headers */ = {isa = PBXBuildFile; fileRef = 077D500C1519A4A1003DFC89 /* MOAIRenderable.h */; };
+		EB9EDE871BE9421B00E8938F /* MOAIRenderMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = 077D500E1519A4A1003DFC89 /* MOAIRenderMgr.h */; };
+		EB9EDE881BE9421B00E8938F /* USUnique.h in Headers */ = {isa = PBXBuildFile; fileRef = CD19AA07151AF7E2006A1F9D /* USUnique.h */; };
+		EB9EDE891BE9421B00E8938F /* MOAICrittercismIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9A41AB5151AAA5400650276 /* MOAICrittercismIOS.h */; };
+		EB9EDE8A1BE9421B00E8938F /* MOAINotificationsIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1DFC151AD5B4005F39B7 /* MOAINotificationsIOS.h */; };
+		EB9EDE8B1BE9421B00E8938F /* MOAIAppIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C611151B146F0009D47D /* MOAIAppIOS.h */; };
+		EB9EDE8C1BE9421B00E8938F /* MOAIDialogIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C615151B146F0009D47D /* MOAIDialogIOS.h */; };
+		EB9EDE8D1BE9421B00E8938F /* MOAIWebViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF2C628151B17540009D47D /* MOAIWebViewDelegate.h */; };
+		EB9EDE8E1BE9421B00E8938F /* MOAIGameCenterIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1E54151C7D71005F39B7 /* MOAIGameCenterIOS.h */; };
+		EB9EDE8F1BE9421B00E8938F /* MOAIEaseSimpleOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D49735118725EC400D46882 /* MOAIEaseSimpleOut.h */; };
+		EB9EDE901BE9421B00E8938F /* MOAIWebViewIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CA1E58151C8578005F39B7 /* MOAIWebViewIOS.h */; };
+		EB9EDE911BE9421B00E8938F /* MOAIKeyboardIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = CD91E3FE15252E2F00AE1883 /* MOAIKeyboardIOS.h */; };
+		EB9EDE921BE9421B00E8938F /* AKU-adcolony.h in Headers */ = {isa = PBXBuildFile; fileRef = E98DBDD11537A33100514387 /* AKU-adcolony.h */; };
+		EB9EDE931BE9421B00E8938F /* AKU-chartboost.h in Headers */ = {isa = PBXBuildFile; fileRef = E98DBDD31537A33100514387 /* AKU-chartboost.h */; };
+		EB9EDE941BE9421B00E8938F /* MOAIScissorRect.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C3B18A15587833005C1858 /* MOAIScissorRect.h */; };
+		EB9EDE951BE9421B00E8938F /* MOAIFoo.h in Headers */ = {isa = PBXBuildFile; fileRef = CD06AF93155B443E00EB03C5 /* MOAIFoo.h */; };
+		EB9EDE961BE9421B00E8938F /* MOAIFooMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = CD06AF94155B443E00EB03C5 /* MOAIFooMgr.h */; };
+		EB9EDE971BE9421B00E8938F /* MOAITextBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF0E6B6155C90920028E770 /* MOAITextBundle.h */; };
+		EB9EDE981BE9421B00E8938F /* MOAIBoundsDeck.h in Headers */ = {isa = PBXBuildFile; fileRef = E969155D1561B7C1007E977B /* MOAIBoundsDeck.h */; };
+		EB9EDE991BE9421B00E8938F /* fullluasocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 669C0568155DB5D500A5CE7F /* fullluasocket.h */; };
+		EB9EDE9A1BE9421B00E8938F /* MOAIEaseSimpleInOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4973591872634A00D46882 /* MOAIEaseSimpleInOut.h */; };
+		EB9EDE9B1BE9421B00E8938F /* luasocketscripts.h in Headers */ = {isa = PBXBuildFile; fileRef = 669C056A155DB5D500A5CE7F /* luasocketscripts.h */; };
+		EB9EDE9C1BE9421B00E8938F /* USQuaternion.h in Headers */ = {isa = PBXBuildFile; fileRef = 669C6973156DBDCD00D21820 /* USQuaternion.h */; };
+		EB9EDE9D1BE9421B00E8938F /* MOAIAnimCurveBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5723E1575579900A486AB /* MOAIAnimCurveBase.h */; };
+		EB9EDE9E1BE9421B00E8938F /* MOAIAnimCurveQuat.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C57244157557B500A486AB /* MOAIAnimCurveQuat.h */; };
+		EB9EDE9F1BE9421B00E8938F /* MOAIAnimCurveVec.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C57248157557BD00A486AB /* MOAIAnimCurveVec.h */; };
+		EB9EDEA01BE9421B00E8938F /* MOAIDataBufferStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5724D157557F500A486AB /* MOAIDataBufferStream.h */; };
+		EB9EDEA11BE9421B00E8938F /* MOAIStreamWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572541575582900A486AB /* MOAIStreamWriter.h */; };
+		EB9EDEA21BE9421B00E8938F /* MOAIStreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5725A1575587400A486AB /* MOAIStreamReader.h */; };
+		EB9EDEA31BE9421B00E8938F /* MOAIFileStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726015756E4300A486AB /* MOAIFileStream.h */; };
+		EB9EDEA41BE9421B00E8938F /* MOAIStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572661575700A00A486AB /* MOAIStream.h */; };
+		EB9EDEA51BE9421B00E8938F /* MOAIMemStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726C1575703300A486AB /* MOAIMemStream.h */; };
+		EB9EDEA61BE9421B00E8938F /* USDeflateReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572781575709400A486AB /* USDeflateReader.h */; };
+		EB9EDEA71BE9421B00E8938F /* USDeflateWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5727E157570A800A486AB /* USDeflateWriter.h */; };
+		EB9EDEA81BE9421B00E8938F /* USStreamWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C57284157570FF00A486AB /* USStreamWriter.h */; };
+		EB9EDEA91BE9421B00E8938F /* MOAIEaseBackIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851D901873DC56009DF1C4 /* MOAIEaseBackIn.h */; };
+		EB9EDEAA1BE9421B00E8938F /* USBase64Reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5728A1575710F00A486AB /* USBase64Reader.h */; };
+		EB9EDEAB1BE9421B00E8938F /* USBase64Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5728C1575711000A486AB /* USBase64Writer.h */; };
+		EB9EDEAC1BE9421B00E8938F /* USStreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5729A1575713C00A486AB /* USStreamReader.h */; };
+		EB9EDEAD1BE9421B00E8938F /* USBase64Encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572A81575714B00A486AB /* USBase64Encoder.h */; };
+		EB9EDEAE1BE9421B00E8938F /* MOAIGridDeck2D.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572AE1575717000A486AB /* MOAIGridDeck2D.h */; };
+		EB9EDEAF1BE9421B00E8938F /* MOAIMoviePlayerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */; };
+		EB9EDEB01BE9421B00E8938F /* MOAIHashWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0755162515A6CA2B00161409 /* MOAIHashWriter.h */; };
+		EB9EDEB11BE9421B00E8938F /* USHexWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703C816127FFD002D0D27 /* USHexWriter.h */; };
+		EB9EDEB21BE9421B00E8938F /* USHashWriterAdler32.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703CC16128038002D0D27 /* USHashWriterAdler32.h */; };
+		EB9EDEB31BE9421B00E8938F /* USHashWriterCRC32.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703CE16128038002D0D27 /* USHashWriterCRC32.h */; };
+		EB9EDEB41BE9421B00E8938F /* USHashWriterMD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703D016128038002D0D27 /* USHashWriterMD5.h */; };
+		EB9EDEB51BE9421B00E8938F /* USHashWriterSHA1.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703D216128038002D0D27 /* USHashWriterSHA1.h */; };
+		EB9EDEB61BE9421B00E8938F /* USHashWriterSHA224.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703D416128038002D0D27 /* USHashWriterSHA224.h */; };
+		EB9EDEB71BE9421B00E8938F /* USHashWriterSHA256.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703D616128038002D0D27 /* USHashWriterSHA256.h */; };
+		EB9EDEB81BE9421B00E8938F /* USHashWriterSHA384.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703D816128038002D0D27 /* USHashWriterSHA384.h */; };
+		EB9EDEB91BE9421B00E8938F /* USHashWriterSHA512.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703DA16128038002D0D27 /* USHashWriterSHA512.h */; };
+		EB9EDEBA1BE9421B00E8938F /* USHashWriterWhirlpool.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703DC16128038002D0D27 /* USHashWriterWhirlpool.h */; };
+		EB9EDEBB1BE9421B00E8938F /* USHexReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 663703DE16128038002D0D27 /* USHexReader.h */; };
+		EB9EDEBC1BE9421B00E8938F /* USHashWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6637040B161280E1002D0D27 /* USHashWriter.h */; };
+		EB9EDEBD1BE9421B00E8938F /* MOAIDataIOTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C0216AE2E12009B9C29 /* MOAIDataIOTask.h */; };
+		EB9EDEBE1BE9421B00E8938F /* MOAIThread_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C0916AE30C0009B9C29 /* MOAIThread_posix.h */; };
+		EB9EDEBF1BE9421B00E8938F /* MOAIThread_win32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C0B16AE30C0009B9C29 /* MOAIThread_win32.h */; };
+		EB9EDEC01BE9421B00E8938F /* MOAIThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C0D16AE30C0009B9C29 /* MOAIThread.h */; };
+		EB9EDEC11BE9421B00E8938F /* MOAITask.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C1B16AE3100009B9C29 /* MOAITask.h */; };
+		EB9EDEC21BE9421B00E8938F /* MOAITaskQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C1D16AE3100009B9C29 /* MOAITaskQueue.h */; };
+		EB9EDEC31BE9421B00E8938F /* MOAITaskSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C1F16AE3100009B9C29 /* MOAITaskSubscriber.h */; };
+		EB9EDEC41BE9421B00E8938F /* MOAITaskThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C2116AE3100009B9C29 /* MOAITaskThread.h */; };
+		EB9EDEC51BE9421B00E8938F /* MOAIMutex_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3316AE312A009B9C29 /* MOAIMutex_posix.h */; };
+		EB9EDEC61BE9421B00E8938F /* MOAIMutex_win32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3516AE312A009B9C29 /* MOAIMutex_win32.h */; };
+		EB9EDEC71BE9421B00E8938F /* MOAIMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E62C3716AE312A009B9C29 /* MOAIMutex.h */; };
+		EB9EDEC81BE9421B00E8938F /* MOAITakeCameraListener.h in Headers */ = {isa = PBXBuildFile; fileRef = EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */; };
+		EB9EDEC91BE9421B00E8938F /* MOAIMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D64916D8021D00C172D2 /* MOAIMath.h */; };
+		EB9EDECA1BE9421B00E8938F /* MOAIFrameBufferTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D67116D8025000C172D2 /* MOAIFrameBufferTexture.h */; };
+		EB9EDECB1BE9421B00E8938F /* MOAIAnimCurveCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = EB665DEA1756B13B009A8F29 /* MOAIAnimCurveCustom.h */; };
+		EB9EDECC1BE9421B00E8938F /* MOAIFreeTypeFont.h in Headers */ = {isa = PBXBuildFile; fileRef = B489B0781756A43400C114DA /* MOAIFreeTypeFont.h */; };
+		EB9EDECD1BE9421B00E8938F /* MOAITextRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = B45A8BEB1829A95C00D2B255 /* MOAITextRenderer.h */; };
+		EB9EDECE1BE9421B00E8938F /* MOAITest_sample.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA0A18CE609F00F9A780 /* MOAITest_sample.h */; };
+		EB9EDECF1BE9421B00E8938F /* MOAITest_USQuaternion.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA0B18CE609F00F9A780 /* MOAITest_USQuaternion.h */; };
+		EB9EDED01BE9421B00E8938F /* MOAITest.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA0D18CE609F00F9A780 /* MOAITest.h */; };
+		EB9EDED11BE9421B00E8938F /* MOAITestKeywords.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA0E18CE609F00F9A780 /* MOAITestKeywords.h */; };
+		EB9EDED21BE9421B00E8938F /* MOAITestMgr.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA1018CE609F00F9A780 /* MOAITestMgr.h */; };
+		EB9EDED31BE9421B00E8938F /* AKU-test.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA1918CE612E00F9A780 /* AKU-test.h */; };
+		EB9EDED41BE9421B00E8938F /* MOAIXmlWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = B408CA1D18CE638300F9A780 /* MOAIXmlWriter.h */; };
+		EB9EDED61BE9421B00E8938F /* m_md5.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9951846B2880031F295 /* m_md5.c */; };
+		EB9EDED71BE9421B00E8938F /* md5_dgst.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A98B1846B1A30031F295 /* md5_dgst.c */; };
+		EB9EDED81BE9421B00E8938F /* md5_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A98C1846B1A30031F295 /* md5_one.c */; };
+		EB9EDED91BE9421B00E8938F /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A98D1846B1A30031F295 /* md5.c */; };
+		EB9EDEDA1BE9421B00E8938F /* mem_clr.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9811846AD8D0031F295 /* mem_clr.c */; };
+		EB9EDEDB1BE9421B00E8938F /* ldo.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49004A141AB6EC00913D80 /* ldo.c */; };
+		EB9EDEDC1BE9421B00E8938F /* MOAIGfxQuadDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E53F13564BC7000ADC60 /* MOAIGfxQuadDeck2D.cpp */; };
+		EB9EDEDD1BE9421B00E8938F /* sha_dgst.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9661846ACCF0031F295 /* sha_dgst.c */; };
+		EB9EDEDE1BE9421B00E8938F /* sha_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9671846ACCF0031F295 /* sha_one.c */; };
+		EB9EDEDF1BE9421B00E8938F /* sha.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9681846ACCF0031F295 /* sha.c */; };
+		EB9EDEE01BE9421B00E8938F /* sha1_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9691846ACCF0031F295 /* sha1_one.c */; };
+		EB9EDEE11BE9421B00E8938F /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A96A1846ACCF0031F295 /* sha1.c */; };
+		EB9EDEE21BE9421B00E8938F /* sha1dgst.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A96B1846ACCF0031F295 /* sha1dgst.c */; };
+		EB9EDEE31BE9421B00E8938F /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A96D1846ACCF0031F295 /* sha256.c */; };
+		EB9EDEE41BE9421B00E8938F /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A96F1846ACCF0031F295 /* sha512.c */; };
+		EB9EDEE51BE9421B00E8938F /* MOAIFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E53913564BC7000ADC60 /* MOAIFont.cpp */; };
+		EB9EDEE61BE9421B00E8938F /* MOAILayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C2E15181FDF0008F1A5 /* MOAILayer.cpp */; };
+		EB9EDEE71BE9421B00E8938F /* MOAIMultiTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C61151820CE0008F1A5 /* MOAIMultiTexture.cpp */; };
+		EB9EDEE81BE9421B00E8938F /* MOAILayerBridge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C3015181FDF0008F1A5 /* MOAILayerBridge.cpp */; };
+		EB9EDEE91BE9421B00E8938F /* MOAIHttpTaskBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C45151820890008F1A5 /* MOAIHttpTaskBase.cpp */; };
+		EB9EDEEA1BE9421B00E8938F /* MOAIStaticGlyphCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C64151820CF0008F1A5 /* MOAIStaticGlyphCache.cpp */; };
+		EB9EDEEB1BE9421B00E8938F /* MOAIEaseBackIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851D8F1873DC56009DF1C4 /* MOAIEaseBackIn.cpp */; };
+		EB9EDEEC1BE9421B00E8938F /* MOAIImageTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C5F151820CE0008F1A5 /* MOAIImageTexture.cpp */; };
+		EB9EDEED1BE9421B00E8938F /* USPrism.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C98151829070008F1A5 /* USPrism.cpp */; };
+		EB9EDEEE1BE9421B00E8938F /* MOAICamera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C4D151820CE0008F1A5 /* MOAICamera.cpp */; };
+		EB9EDEEF1BE9421B00E8938F /* USFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C96151829070008F1A5 /* USFrustum.cpp */; };
+		EB9EDEF01BE9421B00E8938F /* MOAIBitmapFontReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C4B151820CE0008F1A5 /* MOAIBitmapFontReader.cpp */; };
+		EB9EDEF11BE9421B00E8938F /* MOAIFontReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C51151820CE0008F1A5 /* MOAIFontReader.cpp */; };
+		EB9EDEF21BE9421B00E8938F /* MOAIFreeTypeFontReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C53151820CE0008F1A5 /* MOAIFreeTypeFontReader.cpp */; };
+		EB9EDEF31BE9421B00E8938F /* MOAITextStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C39151820470008F1A5 /* MOAITextStyle.cpp */; };
+		EB9EDEF41BE9421B00E8938F /* MOAITextStyler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C3B151820470008F1A5 /* MOAITextStyler.cpp */; };
+		EB9EDEF51BE9421B00E8938F /* MOAIEaseSineOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70432A18761D9A0057E450 /* MOAIEaseSineOut.cpp */; };
+		EB9EDEF61BE9421B00E8938F /* MOAIGlyphCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C55151820CE0008F1A5 /* MOAIGlyphCache.cpp */; };
+		EB9EDEF71BE9421B00E8938F /* MOAIGlyphCacheBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C57151820CE0008F1A5 /* MOAIGlyphCacheBase.cpp */; };
+		EB9EDEF81BE9421B00E8938F /* MOAIGlyphCachePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C59151820CE0008F1A5 /* MOAIGlyphCachePage.cpp */; };
+		EB9EDEF91BE9421B00E8938F /* MOAITextDesigner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C37151820470008F1A5 /* MOAITextDesigner.cpp */; };
+		EB9EDEFA1BE9421B00E8938F /* MOAIGlyphSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C5B151820CE0008F1A5 /* MOAIGlyphSet.cpp */; };
+		EB9EDEFB1BE9421B00E8938F /* MOAITextureBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C66151820CF0008F1A5 /* MOAITextureBase.cpp */; };
+		EB9EDEFC1BE9421B00E8938F /* AKU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E4F313564BC7000ADC60 /* AKU.cpp */; };
+		EB9EDEFD1BE9421B00E8938F /* pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E4F713564BC7000ADC60 /* pch.cpp */; };
+		EB9EDEFE1BE9421B00E8938F /* MOAIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E4FA13564BC7000ADC60 /* MOAIAction.cpp */; };
+		EB9EDEFF1BE9421B00E8938F /* MOAIAnim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E4FC13564BC7000ADC60 /* MOAIAnim.cpp */; };
+		EB9EDF001BE9421B00E8938F /* MOAIAnimCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E4FE13564BC7000ADC60 /* MOAIAnimCurve.cpp */; };
+		EB9EDF011BE9421B00E8938F /* MOAIBlocker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50013564BC7000ADC60 /* MOAIBlocker.cpp */; };
+		EB9EDF021BE9421B00E8938F /* MOAIBox2DArbiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50213564BC7000ADC60 /* MOAIBox2DArbiter.cpp */; };
+		EB9EDF031BE9421B00E8938F /* MOAIBox2DBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50413564BC7000ADC60 /* MOAIBox2DBody.cpp */; };
+		EB9EDF041BE9421B00E8938F /* MOAIBox2DDebugDraw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50613564BC7000ADC60 /* MOAIBox2DDebugDraw.cpp */; };
+		EB9EDF051BE9421B00E8938F /* USRhombus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E91A4C9A151829070008F1A5 /* USRhombus.cpp */; };
+		EB9EDF061BE9421B00E8938F /* MOAIBox2DFixture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50813564BC7000ADC60 /* MOAIBox2DFixture.cpp */; };
+		EB9EDF071BE9421B00E8938F /* MOAIBox2DJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50A13564BC7000ADC60 /* MOAIBox2DJoint.cpp */; };
+		EB9EDF081BE9421B00E8938F /* MOAIBox2DWorld.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50C13564BC7000ADC60 /* MOAIBox2DWorld.cpp */; };
+		EB9EDF091BE9421B00E8938F /* MOAIButtonSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E50E13564BC7000ADC60 /* MOAIButtonSensor.cpp */; };
+		EB9EDF0A1BE9421B00E8938F /* MOAIColor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51013564BC7000ADC60 /* MOAIColor.cpp */; };
+		EB9EDF0B1BE9421B00E8938F /* MOAIEaseBackBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851D891873DAB7009DF1C4 /* MOAIEaseBackBase.cpp */; };
+		EB9EDF0C1BE9421B00E8938F /* MOAICompassSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51213564BC7000ADC60 /* MOAICompassSensor.cpp */; };
+		EB9EDF0D1BE9421B00E8938F /* moaicore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51513564BC7000ADC60 /* moaicore.cpp */; };
+		EB9EDF0E1BE9421B00E8938F /* MOAICp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51713564BC7000ADC60 /* MOAICp.cpp */; };
+		EB9EDF0F1BE9421B00E8938F /* MOAICpArbiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51913564BC7000ADC60 /* MOAICpArbiter.cpp */; };
+		EB9EDF101BE9421B00E8938F /* MOAICpBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51B13564BC7000ADC60 /* MOAICpBody.cpp */; };
+		EB9EDF111BE9421B00E8938F /* MOAICpConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51D13564BC7000ADC60 /* MOAICpConstraint.cpp */; };
+		EB9EDF121BE9421B00E8938F /* MOAICpDebugDraw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E51F13564BC7000ADC60 /* MOAICpDebugDraw.cpp */; };
+		EB9EDF131BE9421B00E8938F /* MOAICpShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52113564BC7000ADC60 /* MOAICpShape.cpp */; };
+		EB9EDF141BE9421B00E8938F /* MOAICpSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52313564BC7000ADC60 /* MOAICpSpace.cpp */; };
+		EB9EDF151BE9421B00E8938F /* MOAIDataBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52513564BC7000ADC60 /* MOAIDataBuffer.cpp */; };
+		EB9EDF161BE9421B00E8938F /* MOAIDebugLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52913564BC7000ADC60 /* MOAIDebugLines.cpp */; };
+		EB9EDF171BE9421B00E8938F /* MOAIDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52B13564BC7000ADC60 /* MOAIDeck.cpp */; };
+		EB9EDF181BE9421B00E8938F /* MOAIEaseDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52F13564BC7000ADC60 /* MOAIEaseDriver.cpp */; };
+		EB9EDF191BE9421B00E8938F /* MOAIEaseType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E53113564BC7000ADC60 /* MOAIEaseType.cpp */; };
+		EB9EDF1A1BE9421B00E8938F /* MOAIEaseExponentialOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70433C18761FCB0057E450 /* MOAIEaseExponentialOut.cpp */; };
+		EB9EDF1B1BE9421B00E8938F /* MOAIGfxQuad2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E53D13564BC7000ADC60 /* MOAIGfxQuad2D.cpp */; };
+		EB9EDF1C1BE9421B00E8938F /* MOAIGfxQuadListDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54113564BC7000ADC60 /* MOAIGfxQuadListDeck2D.cpp */; };
+		EB9EDF1D1BE9421B00E8938F /* MOAIGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54313564BC7000ADC60 /* MOAIGrid.cpp */; };
+		EB9EDF1E1BE9421B00E8938F /* MOAIIndexBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54713564BC7000ADC60 /* MOAIIndexBuffer.cpp */; };
+		EB9EDF1F1BE9421B00E8938F /* MOAIInputDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54913564BC7000ADC60 /* MOAIInputDevice.cpp */; };
+		EB9EDF201BE9421B00E8938F /* MOAIInputMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54B13564BC7000ADC60 /* MOAIInputMgr.cpp */; };
+		EB9EDF211BE9421B00E8938F /* MOAIJoystickSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54D13564BC7000ADC60 /* MOAIJoystickSensor.cpp */; };
+		EB9EDF221BE9421B00E8938F /* MOAIEaseSimpleOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D49735018725EC400D46882 /* MOAIEaseSimpleOut.cpp */; };
+		EB9EDF231BE9421B00E8938F /* MOAIKeyboardSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E54F13564BC7000ADC60 /* MOAIKeyboardSensor.cpp */; };
+		EB9EDF241BE9421B00E8938F /* MOAILayoutFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E55513564BC7000ADC60 /* MOAILayoutFrame.cpp */; };
+		EB9EDF251BE9421B00E8938F /* MOAILocationSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E55913564BC7000ADC60 /* MOAILocationSensor.cpp */; };
+		EB9EDF261BE9421B00E8938F /* MOAILogMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E55C13564BC7000ADC60 /* MOAILogMgr.cpp */; };
+		EB9EDF271BE9421B00E8938F /* MOAIMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E55E13564BC7000ADC60 /* MOAIMesh.cpp */; };
+		EB9EDF281BE9421B00E8938F /* MOAINode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E56013564BC7000ADC60 /* MOAINode.cpp */; };
+		EB9EDF291BE9421B00E8938F /* MOAINodeMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E56213564BC7000ADC60 /* MOAINodeMgr.cpp */; };
+		EB9EDF2A1BE9421B00E8938F /* MOAIParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E56413564BC7000ADC60 /* MOAIParser.cpp */; };
+		EB9EDF2B1BE9421B00E8938F /* MOAIEaseExponentialIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70433618761FBD0057E450 /* MOAIEaseExponentialIn.cpp */; };
+		EB9EDF2C1BE9421B00E8938F /* MOAIPartition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57213564BC7000ADC60 /* MOAIPartition.cpp */; };
+		EB9EDF2D1BE9421B00E8938F /* MOAIPartitionCell.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57413564BC7000ADC60 /* MOAIPartitionCell.cpp */; };
+		EB9EDF2E1BE9421B00E8938F /* MOAIPartitionLevel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57613564BC7000ADC60 /* MOAIPartitionLevel.cpp */; };
+		EB9EDF2F1BE9421B00E8938F /* MOAIPointerSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57813564BC7000ADC60 /* MOAIPointerSensor.cpp */; };
+		EB9EDF301BE9421B00E8938F /* MOAIProp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57A13564BC7000ADC60 /* MOAIProp.cpp */; };
+		EB9EDF311BE9421B00E8938F /* MOAIScriptNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E57E13564BC7000ADC60 /* MOAIScriptNode.cpp */; };
+		EB9EDF321BE9421B00E8938F /* MOAISensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58013564BC7000ADC60 /* MOAISensor.cpp */; };
+		EB9EDF331BE9421B00E8938F /* MOAISerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58213564BC7000ADC60 /* MOAISerializer.cpp */; };
+		EB9EDF341BE9421B00E8938F /* MOAIShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58413564BC7000ADC60 /* MOAIShader.cpp */; };
+		EB9EDF351BE9421B00E8938F /* MOAISim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58613564BC7000ADC60 /* MOAISim.cpp */; };
+		EB9EDF361BE9421B00E8938F /* MOAIStretchPatch2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58A13564BC7000ADC60 /* MOAIStretchPatch2D.cpp */; };
+		EB9EDF371BE9421B00E8938F /* MOAISurfaceDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58C13564BC8000ADC60 /* MOAISurfaceDeck2D.cpp */; };
+		EB9EDF381BE9421B00E8938F /* MOAISurfaceSampler2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E58E13564BC8000ADC60 /* MOAISurfaceSampler2D.cpp */; };
+		EB9EDF391BE9421B00E8938F /* MOAITextBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59013564BC8000ADC60 /* MOAITextBox.cpp */; };
+		EB9EDF3A1BE9421B00E8938F /* MOAIEaseElasticBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851DA11873E5ED009DF1C4 /* MOAIEaseElasticBase.cpp */; };
+		EB9EDF3B1BE9421B00E8938F /* MOAITexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59213564BC8000ADC60 /* MOAITexture.cpp */; };
+		EB9EDF3C1BE9421B00E8938F /* MOAITileDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59613564BC8000ADC60 /* MOAITileDeck2D.cpp */; };
+		EB9EDF3D1BE9421B00E8938F /* MOAIEaseSimpleBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4973541872608C00D46882 /* MOAIEaseSimpleBase.cpp */; };
+		EB9EDF3E1BE9421B00E8938F /* MOAITimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59813564BC8000ADC60 /* MOAITimer.cpp */; };
+		EB9EDF3F1BE9421B00E8938F /* MOAITouchSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59A13564BC8000ADC60 /* MOAITouchSensor.cpp */; };
+		EB9EDF401BE9421B00E8938F /* MOAIEase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4973441872370F00D46882 /* MOAIEase.cpp */; };
+		EB9EDF411BE9421B00E8938F /* MOAITransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59C13564BC8000ADC60 /* MOAITransform.cpp */; };
+		EB9EDF421BE9421B00E8938F /* MOAITransformBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E59E13564BC8000ADC60 /* MOAITransformBase.cpp */; };
+		EB9EDF431BE9421B00E8938F /* MOAIVertexBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5A013564BC8000ADC60 /* MOAIVertexBuffer.cpp */; };
+		EB9EDF441BE9421B00E8938F /* MOAIVertexFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5A213564BC8000ADC60 /* MOAIVertexFormat.cpp */; };
+		EB9EDF451BE9421B00E8938F /* MOAIViewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5A413564BC8000ADC60 /* MOAIViewport.cpp */; };
+		EB9EDF461BE9421B00E8938F /* MOAIXmlParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5A613564BC8000ADC60 /* MOAIXmlParser.cpp */; };
+		EB9EDF471BE9421B00E8938F /* STLString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5B213564BC8000ADC60 /* STLString.cpp */; };
+		EB9EDF481BE9421B00E8938F /* USByteStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5B713564BC8000ADC60 /* USByteStream.cpp */; };
+		EB9EDF491BE9421B00E8938F /* USDeviceTime_apple.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5C213564BC8000ADC60 /* USDeviceTime_apple.cpp */; };
+		EB9EDF4A1BE9421B00E8938F /* USDeviceTime_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5C313564BC8000ADC60 /* USDeviceTime_posix.cpp */; };
+		EB9EDF4B1BE9421B00E8938F /* USDeviceTime_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5C413564BC8000ADC60 /* USDeviceTime_win32.cpp */; };
+		EB9EDF4C1BE9421B00E8938F /* USFileStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5CB13564BC8000ADC60 /* USFileStream.cpp */; };
+		EB9EDF4D1BE9421B00E8938F /* USFileSys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5CD13564BC8000ADC60 /* USFileSys.cpp */; };
+		EB9EDF4E1BE9421B00E8938F /* USMemStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5EA13564BC8000ADC60 /* USMemStream.cpp */; };
+		EB9EDF4F1BE9421B00E8938F /* USStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5F213564BC8000ADC60 /* USStream.cpp */; };
+		EB9EDF501BE9421B00E8938F /* USZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5FB13564BC8000ADC60 /* USZip.cpp */; };
+		EB9EDF511BE9421B00E8938F /* USZipFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E5FD13564BC8000ADC60 /* USZipFile.cpp */; };
+		EB9EDF521BE9421B00E8938F /* AKU-iphone.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD1D0BA313599FD200802A3C /* AKU-iphone.mm */; };
+		EB9EDF531BE9421B00E8938F /* MOAIEventSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEB91421360A78800AAC558 /* MOAIEventSource.cpp */; };
+		EB9EDF541BE9421B00E8938F /* MOAIImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEB91441360A78800AAC558 /* MOAIImage.cpp */; };
+		EB9EDF551BE9421B00E8938F /* MOAICameraAnchor2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FA4CB138589C4007FD20C /* MOAICameraAnchor2D.cpp */; };
+		EB9EDF561BE9421B00E8938F /* MOAIEaseExponentialInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70434218761FDE0057E450 /* MOAIEaseExponentialInOut.cpp */; };
+		EB9EDF571BE9421B00E8938F /* MOAICameraFitter2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FA4CD138589C4007FD20C /* MOAICameraFitter2D.cpp */; };
+		EB9EDF581BE9421B00E8938F /* MOAIDeckRemapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 039C283B138EDAB300A3A780 /* MOAIDeckRemapper.cpp */; };
+		EB9EDF591BE9421B00E8938F /* NSArray+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ECE1398BA6200AB0420 /* NSArray+MOAILib.mm */; };
+		EB9EDF5A1BE9421B00E8938F /* NSData+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ED01398BA6200AB0420 /* NSData+MOAILib.mm */; };
+		EB9EDF5B1BE9421B00E8938F /* NSDate+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ED21398BA6200AB0420 /* NSDate+MOAILib.mm */; };
+		EB9EDF5C1BE9421B00E8938F /* NSDictionary+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ED41398BA6200AB0420 /* NSDictionary+MOAILib.mm */; };
+		EB9EDF5D1BE9421B00E8938F /* NSError+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ED61398BA6200AB0420 /* NSError+MOAILib.mm */; };
+		EB9EDF5E1BE9421B00E8938F /* NSNumber+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06ED81398BA6200AB0420 /* NSNumber+MOAILib.mm */; };
+		EB9EDF5F1BE9421B00E8938F /* NSObject+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06EDA1398BA6200AB0420 /* NSObject+MOAILib.mm */; };
+		EB9EDF601BE9421B00E8938F /* MOAIEaseSineIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70432418761BDE0057E450 /* MOAIEaseSineIn.cpp */; };
+		EB9EDF611BE9421B00E8938F /* NSString+MOAILib.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDD06EDC1398BA6200AB0420 /* NSString+MOAILib.mm */; };
+		EB9EDF621BE9421B00E8938F /* MOAIFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBC71161398C6E50016F98A /* MOAIFileSystem.cpp */; };
+		EB9EDF631BE9421B00E8938F /* USLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD218F7013A7FC79008337E7 /* USLog.cpp */; };
+		EB9EDF641BE9421B00E8938F /* MOAIJsonParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD62D6CA13A991BA002286EB /* MOAIJsonParser.cpp */; };
+		EB9EDF651BE9421B00E8938F /* MOAIEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031BBA5A13B17BD80005ECE0 /* MOAIEnvironment.cpp */; };
+		EB9EDF661BE9421B00E8938F /* moaicore-pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07FAC91513B8F1CA00AFD0B3 /* moaicore-pch.cpp */; };
+		EB9EDF671BE9421B00E8938F /* uslscore-pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07FAC91713B8F1E000AFD0B3 /* uslscore-pch.cpp */; };
+		EB9EDF681BE9421B00E8938F /* MOAIActionMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 033B1E5E13C4EC8A00CE21D2 /* MOAIActionMgr.cpp */; };
+		EB9EDF691BE9421B00E8938F /* MOAIMotionSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03B2EC1213C503B400F8B3CF /* MOAIMotionSensor.cpp */; };
+		EB9EDF6A1BE9421B00E8938F /* MOAIEaseElasticOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70430C187601CC0057E450 /* MOAIEaseElasticOut.cpp */; };
+		EB9EDF6B1BE9421B00E8938F /* MOAIDraw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3DE13E37F3C000A9523 /* MOAIDraw.cpp */; };
+		EB9EDF6C1BE9421B00E8938F /* MOAIGfxDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3E213E37F3C000A9523 /* MOAIGfxDevice.cpp */; };
+		EB9EDF6D1BE9421B00E8938F /* MOAIGlyph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3E413E37F3C000A9523 /* MOAIGlyph.cpp */; };
+		EB9EDF6E1BE9421B00E8938F /* MOAIGridSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3E613E37F3C000A9523 /* MOAIGridSpace.cpp */; };
+		EB9EDF6F1BE9421B00E8938F /* MOAIQuadBrush.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3EB13E37F3C000A9523 /* MOAIQuadBrush.cpp */; };
+		EB9EDF701BE9421B00E8938F /* MOAIShaderMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3ED13E37F3C000A9523 /* MOAIShaderMgr.cpp */; };
+		EB9EDF711BE9421B00E8938F /* MOAITileFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3F313E37F3C000A9523 /* MOAITileFlags.cpp */; };
+		EB9EDF721BE9421B00E8938F /* MOAIVertexFormatMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB3F513E37F3C000A9523 /* MOAIVertexFormatMgr.cpp */; };
+		EB9EDF731BE9421B00E8938F /* MOAIBlendMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07D1A89E13EDFD8300604979 /* MOAIBlendMode.cpp */; };
+		EB9EDF741BE9421B00E8938F /* MOAIFrameBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07D1A8A013EDFD8300604979 /* MOAIFrameBuffer.cpp */; };
+		EB9EDF751BE9421B00E8938F /* MOAIPartitionResultBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07AF16BC13F45A0100E38D1D /* MOAIPartitionResultBuffer.cpp */; };
+		EB9EDF761BE9421B00E8938F /* MOAIPartitionResultMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07AF16BE13F45A0100E38D1D /* MOAIPartitionResultMgr.cpp */; };
+		EB9EDF771BE9421B00E8938F /* USDirectoryItr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD490185141ABD1B00913D80 /* USDirectoryItr.cpp */; };
+		EB9EDF781BE9421B00E8938F /* MOAIGfxResource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDF7130D141EBC5C00D650CA /* MOAIGfxResource.cpp */; };
+		EB9EDF791BE9421B00E8938F /* MOAILogMessages.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66D967F4140479DF00017919 /* MOAILogMessages.cpp */; };
+		EB9EDF7A1BE9421B00E8938F /* MOAIScriptDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66D967F814047A2500017919 /* MOAIScriptDeck.cpp */; };
+		EB9EDF7B1BE9421B00E8938F /* MOAIBox2DDistanceJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D0A1425DC2600BC33D4 /* MOAIBox2DDistanceJoint.cpp */; };
+		EB9EDF7C1BE9421B00E8938F /* MOAIBox2DFrictionJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D0C1425DC2600BC33D4 /* MOAIBox2DFrictionJoint.cpp */; };
+		EB9EDF7D1BE9421B00E8938F /* MOAIBox2DGearJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D0E1425DC2600BC33D4 /* MOAIBox2DGearJoint.cpp */; };
+		EB9EDF7E1BE9421B00E8938F /* MOAIBox2DMouseJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D121425DC2600BC33D4 /* MOAIBox2DMouseJoint.cpp */; };
+		EB9EDF7F1BE9421B00E8938F /* MOAIBox2DPrismaticJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D141425DC2600BC33D4 /* MOAIBox2DPrismaticJoint.cpp */; };
+		EB9EDF801BE9421B00E8938F /* MOAIBox2DPulleyJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D161425DC2600BC33D4 /* MOAIBox2DPulleyJoint.cpp */; };
+		EB9EDF811BE9421B00E8938F /* MOAIBox2DRevoluteJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D181425DC2600BC33D4 /* MOAIBox2DRevoluteJoint.cpp */; };
+		EB9EDF821BE9421B00E8938F /* MOAIBox2DWeldJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDBD3D1A1425DC2600BC33D4 /* MOAIBox2DWeldJoint.cpp */; };
+		EB9EDF831BE9421B00E8938F /* MOAIImage-jpg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0795290F1447902700143A72 /* MOAIImage-jpg.cpp */; };
+		EB9EDF841BE9421B00E8938F /* MOAIImage-png.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 079529101447902700143A72 /* MOAIImage-png.cpp */; };
+		EB9EDF851BE9421B00E8938F /* MOAIBox2DRopeJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE4D146909ED00C86DF9 /* MOAIBox2DRopeJoint.cpp */; };
+		EB9EDF861BE9421B00E8938F /* MOAIBox2DWheelJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE4F146909ED00C86DF9 /* MOAIBox2DWheelJoint.cpp */; };
+		EB9EDF871BE9421B00E8938F /* MOAICanary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE8414693BC100990FE1 /* MOAICanary.cpp */; };
+		EB9EDF881BE9421B00E8938F /* MOAIDeserializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE8614693BC100990FE1 /* MOAIDeserializer.cpp */; };
+		EB9EDF891BE9421B00E8938F /* MOAIGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE8814693BC100990FE1 /* MOAIGlobals.cpp */; };
+		EB9EDF8A1BE9421B00E8938F /* MOAILuaObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE8E14693BC100990FE1 /* MOAILuaObject.cpp */; };
+		EB9EDF8B1BE9421B00E8938F /* MOAILuaRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9014693BC100990FE1 /* MOAILuaRef.cpp */; };
+		EB9EDF8C1BE9421B00E8938F /* MOAILuaRuntime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9214693BC100990FE1 /* MOAILuaRuntime.cpp */; };
+		EB9EDF8D1BE9421B00E8938F /* MOAILuaState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9614693BC100990FE1 /* MOAILuaState.cpp */; };
+		EB9EDF8E1BE9421B00E8938F /* MOAILuaStateHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9814693BC100990FE1 /* MOAILuaStateHandle.cpp */; };
+		EB9EDF8F1BE9421B00E8938F /* MOAIEaseBackInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851D9B1873DED9009DF1C4 /* MOAIEaseBackInOut.cpp */; };
+		EB9EDF901BE9421B00E8938F /* MOAIObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9A14693BC100990FE1 /* MOAIObject.cpp */; };
+		EB9EDF911BE9421B00E8938F /* MOAIRtti.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9C14693BC100990FE1 /* MOAIRtti.cpp */; };
+		EB9EDF921BE9421B00E8938F /* MOAISerializerBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD18CE9E14693BC100990FE1 /* MOAISerializerBase.cpp */; };
+		EB9EDF931BE9421B00E8938F /* MOAIWheelSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 668E165714887A0A00897ED6 /* MOAIWheelSensor.cpp */; };
+		EB9EDF941BE9421B00E8938F /* MOAIEaseSimpleIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D49734C18725B5600D46882 /* MOAIEaseSimpleIn.cpp */; };
+		EB9EDF951BE9421B00E8938F /* MOAIGridPathGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075110E1149AD7C3006C0B61 /* MOAIGridPathGraph.cpp */; };
+		EB9EDF961BE9421B00E8938F /* MOAIPathFinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075110E3149AD7C3006C0B61 /* MOAIPathFinder.cpp */; };
+		EB9EDF971BE9421B00E8938F /* MOAIPathGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075110E5149AD7C3006C0B61 /* MOAIPathGraph.cpp */; };
+		EB9EDF981BE9421B00E8938F /* MOAIPathTerrainDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075110E7149AD7C3006C0B61 /* MOAIPathTerrainDeck.cpp */; };
+		EB9EDF991BE9421B00E8938F /* USAdapterInfo_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7214B7A4A0006465CC /* USAdapterInfo_posix.cpp */; };
+		EB9EDF9A1BE9421B00E8938F /* USBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7614B7A4A0006465CC /* USBox.cpp */; };
+		EB9EDF9B1BE9421B00E8938F /* USCgt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7814B7A4A0006465CC /* USCgt.cpp */; };
+		EB9EDF9C1BE9421B00E8938F /* USColor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7A14B7A4A0006465CC /* USColor.cpp */; };
+		EB9EDF9D1BE9421B00E8938F /* MOAIEaseElasticInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB7043121876030B0057E450 /* MOAIEaseElasticInOut.cpp */; };
+		EB9EDF9E1BE9421B00E8938F /* USCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7C14B7A4A0006465CC /* USCurve.cpp */; };
+		EB9EDF9F1BE9421B00E8938F /* USDistance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8414B7A4A0006465CC /* USDistance.cpp */; };
+		EB9EDFA01BE9421B00E8938F /* USHexDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8614B7A4A0006465CC /* USHexDump.cpp */; };
+		EB9EDFA11BE9421B00E8938F /* MOAIEaseCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4973681872793400D46882 /* MOAIEaseCustom.cpp */; };
+		EB9EDFA21BE9421B00E8938F /* USInterpolate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8814B7A4A0006465CC /* USInterpolate.cpp */; };
+		EB9EDFA31BE9421B00E8938F /* USIntersect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8A14B7A4A0006465CC /* USIntersect.cpp */; };
+		EB9EDFA41BE9421B00E8938F /* MOAICCParticleSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B4F51F9919898558005F5779 /* MOAICCParticleSystem.cpp */; };
+		EB9EDFA51BE9421B00E8938F /* USLexStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8C14B7A4A0006465CC /* USLexStream.cpp */; };
+		EB9EDFA61BE9421B00E8938F /* USMercator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9214B7A4A0006465CC /* USMercator.cpp */; };
+		EB9EDFA71BE9421B00E8938F /* USParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9814B7A4A0006465CC /* USParser.cpp */; };
+		EB9EDFA81BE9421B00E8938F /* USPlane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9A14B7A4A0006465CC /* USPlane.cpp */; };
+		EB9EDFA91BE9421B00E8938F /* USPolar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9C14B7A4A0006465CC /* USPolar.cpp */; };
+		EB9EDFAA1BE9421B00E8938F /* USQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DA014B7A4A0006465CC /* USQuad.cpp */; };
+		EB9EDFAB1BE9421B00E8938F /* USQuadCoord.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DA214B7A4A0006465CC /* USQuadCoord.cpp */; };
+		EB9EDFAC1BE9421B00E8938F /* MOAICCParticle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B4352EA91AA6CA0600E4AF3A /* MOAICCParticle.cpp */; };
+		EB9EDFAD1BE9421B00E8938F /* USSurface2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DA614B7A4A0006465CC /* USSurface2D.cpp */; };
+		EB9EDFAE1BE9421B00E8938F /* MOAIEaseSineInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB70433018761E630057E450 /* MOAIEaseSineInOut.cpp */; };
+		EB9EDFAF1BE9421B00E8938F /* USSyntaxNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DA814B7A4A0006465CC /* USSyntaxNode.cpp */; };
+		EB9EDFB01BE9421B00E8938F /* USSyntaxScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAA14B7A4A0006465CC /* USSyntaxScanner.cpp */; };
+		EB9EDFB11BE9421B00E8938F /* MOAIEaseSimpleInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4973581872634A00D46882 /* MOAIEaseSimpleInOut.cpp */; };
+		EB9EDFB21BE9421B00E8938F /* USTrig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB414B7A4A0006465CC /* USTrig.cpp */; };
+		EB9EDFB31BE9421B00E8938F /* USTypedPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB614B7A4A0006465CC /* USTypedPtr.cpp */; };
+		EB9EDFB41BE9421B00E8938F /* USXmlReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB814B7A4A0006465CC /* USXmlReader.cpp */; };
+		EB9EDFB51BE9421B00E8938F /* AKU-audiosampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66459FB31511638B0075BF13 /* AKU-audiosampler.cpp */; };
+		EB9EDFB61BE9421B00E8938F /* MOAIAudioSampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66459FB81511641F0075BF13 /* MOAIAudioSampler.cpp */; };
+		EB9EDFB71BE9421B00E8938F /* MOAIHttpTaskNaCl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075BA089151949C50002E925 /* MOAIHttpTaskNaCl.cpp */; };
+		EB9EDFB81BE9421B00E8938F /* MOAIUrlMgrNaCl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 075BA08D151949C50002E925 /* MOAIUrlMgrNaCl.cpp */; };
+		EB9EDFB91BE9421B00E8938F /* MOAIRenderable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 077D500B1519A4A1003DFC89 /* MOAIRenderable.cpp */; };
+		EB9EDFBA1BE9421B00E8938F /* MOAIRenderMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 077D500D1519A4A1003DFC89 /* MOAIRenderMgr.cpp */; };
+		EB9EDFBB1BE9421B00E8938F /* USUnique_linux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD19AA06151AF7E2006A1F9D /* USUnique_linux.cpp */; };
+		EB9EDFBC1BE9421B00E8938F /* MOAICrittercismIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9A41AB6151AAA5400650276 /* MOAICrittercismIOS.mm */; };
+		EB9EDFBD1BE9421B00E8938F /* MOAINotificationsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1DFD151AD5B4005F39B7 /* MOAINotificationsIOS.mm */; };
+		EB9EDFBE1BE9421B00E8938F /* MOAIAppIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C612151B146F0009D47D /* MOAIAppIOS.mm */; };
+		EB9EDFBF1BE9421B00E8938F /* MOAIDialogIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C616151B146F0009D47D /* MOAIDialogIOS.mm */; };
+		EB9EDFC01BE9421B00E8938F /* MOAIWebViewDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDF2C629151B17540009D47D /* MOAIWebViewDelegate.mm */; };
+		EB9EDFC11BE9421B00E8938F /* MOAIGameCenterIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E55151C7D71005F39B7 /* MOAIGameCenterIOS.mm */; };
+		EB9EDFC21BE9421B00E8938F /* MOAIWebViewIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */; };
+		EB9EDFC31BE9421B00E8938F /* MOAIKeyboardIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD91E3FF15252E2F00AE1883 /* MOAIKeyboardIOS.mm */; };
+		EB9EDFC41BE9421B00E8938F /* AKU-adcolony.mm in Sources */ = {isa = PBXBuildFile; fileRef = E98DBDD21537A33100514387 /* AKU-adcolony.mm */; };
+		EB9EDFC51BE9421B00E8938F /* AKU-chartboost.mm in Sources */ = {isa = PBXBuildFile; fileRef = E98DBDD41537A33100514387 /* AKU-chartboost.mm */; };
+		EB9EDFC61BE9421B00E8938F /* MOAIFoo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 667AE739154A09CA00CCE42D /* MOAIFoo.cpp */; };
+		EB9EDFC71BE9421B00E8938F /* MOAIFooMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 667AE73C154A0CAD00CCE42D /* MOAIFooMgr.cpp */; };
+		EB9EDFC81BE9421B00E8938F /* MOAIScissorRect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C3B18715587827005C1858 /* MOAIScissorRect.cpp */; };
+		EB9EDFC91BE9421B00E8938F /* MOAITextBundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDF0E6B5155C90920028E770 /* MOAITextBundle.cpp */; };
+		EB9EDFCA1BE9421B00E8938F /* MOAIFont_bmfont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDF0E6C3155C90AA0028E770 /* MOAIFont_bmfont.cpp */; };
+		EB9EDFCB1BE9421B00E8938F /* MOAIBoundsDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E969155C1561B7C1007E977B /* MOAIBoundsDeck.cpp */; };
+		EB9EDFCC1BE9421B00E8938F /* fullluasocket.c in Sources */ = {isa = PBXBuildFile; fileRef = 669C0567155DB5D500A5CE7F /* fullluasocket.c */; };
+		EB9EDFCD1BE9421B00E8938F /* luasocketscripts.c in Sources */ = {isa = PBXBuildFile; fileRef = 669C0569155DB5D500A5CE7F /* luasocketscripts.c */; };
+		EB9EDFCE1BE9421B00E8938F /* USQuaternion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 669C696F156DBDC400D21820 /* USQuaternion.cpp */; };
+		EB9EDFCF1BE9421B00E8938F /* MOAIAnimCurveBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5723B1575579200A486AB /* MOAIAnimCurveBase.cpp */; };
+		EB9EDFD01BE9421B00E8938F /* MOAIAnimCurveQuat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C57241157557AE00A486AB /* MOAIAnimCurveQuat.cpp */; };
+		EB9EDFD11BE9421B00E8938F /* MOAIAnimCurveVec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C57247157557BD00A486AB /* MOAIAnimCurveVec.cpp */; };
+		EB9EDFD21BE9421B00E8938F /* MOAIDataBufferStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C57250157557FB00A486AB /* MOAIDataBufferStream.cpp */; };
+		EB9EDFD31BE9421B00E8938F /* MOAIStreamWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572531575582900A486AB /* MOAIStreamWriter.cpp */; };
+		EB9EDFD41BE9421B00E8938F /* MOAIStreamReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572591575587400A486AB /* MOAIStreamReader.cpp */; };
+		EB9EDFD51BE9421B00E8938F /* MOAIFileStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5725F15756E4300A486AB /* MOAIFileStream.cpp */; };
+		EB9EDFD61BE9421B00E8938F /* MOAIStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572651575700A00A486AB /* MOAIStream.cpp */; };
+		EB9EDFD71BE9421B00E8938F /* MOAIMemStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5726B1575703300A486AB /* MOAIMemStream.cpp */; };
+		EB9EDFD81BE9421B00E8938F /* USDeflateReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572771575709400A486AB /* USDeflateReader.cpp */; };
+		EB9EDFD91BE9421B00E8938F /* USDeflateWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5727D157570A800A486AB /* USDeflateWriter.cpp */; };
+		EB9EDFDA1BE9421B00E8938F /* USStreamWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C57283157570FF00A486AB /* USStreamWriter.cpp */; };
+		EB9EDFDB1BE9421B00E8938F /* USBase64Reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572891575710F00A486AB /* USBase64Reader.cpp */; };
+		EB9EDFDC1BE9421B00E8938F /* USBase64Writer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5728B1575710F00A486AB /* USBase64Writer.cpp */; };
+		EB9EDFDD1BE9421B00E8938F /* USStreamReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572991575713C00A486AB /* USStreamReader.cpp */; };
+		EB9EDFDE1BE9421B00E8938F /* USBase64Encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572A71575714A00A486AB /* USBase64Encoder.cpp */; };
+		EB9EDFDF1BE9421B00E8938F /* MOAIGridDeck2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572AD1575717000A486AB /* MOAIGridDeck2D.cpp */; };
+		EB9EDFE01BE9421B00E8938F /* MOAIMoviePlayerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */; };
+		EB9EDFE11BE9421B00E8938F /* MOAIHashWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0755162415A6CA2B00161409 /* MOAIHashWriter.cpp */; };
+		EB9EDFE21BE9421B00E8938F /* USHashWriterAdler32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703CB16128038002D0D27 /* USHashWriterAdler32.cpp */; };
+		EB9EDFE31BE9421B00E8938F /* USHashWriterCRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703CD16128038002D0D27 /* USHashWriterCRC32.cpp */; };
+		EB9EDFE41BE9421B00E8938F /* MOAIEaseBackOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851D951873DDE6009DF1C4 /* MOAIEaseBackOut.cpp */; };
+		EB9EDFE51BE9421B00E8938F /* USHashWriterMD5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703CF16128038002D0D27 /* USHashWriterMD5.cpp */; };
+		EB9EDFE61BE9421B00E8938F /* USHashWriterSHA1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703D116128038002D0D27 /* USHashWriterSHA1.cpp */; };
+		EB9EDFE71BE9421B00E8938F /* USHashWriterSHA224.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703D316128038002D0D27 /* USHashWriterSHA224.cpp */; };
+		EB9EDFE81BE9421B00E8938F /* MOAIEaseElasticIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851DA71873E760009DF1C4 /* MOAIEaseElasticIn.cpp */; };
+		EB9EDFE91BE9421B00E8938F /* USHashWriterSHA256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703D516128038002D0D27 /* USHashWriterSHA256.cpp */; };
+		EB9EDFEA1BE9421B00E8938F /* USHashWriterSHA384.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703D716128038002D0D27 /* USHashWriterSHA384.cpp */; };
+		EB9EDFEB1BE9421B00E8938F /* USHashWriterSHA512.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703D916128038002D0D27 /* USHashWriterSHA512.cpp */; };
+		EB9EDFEC1BE9421B00E8938F /* USHashWriterWhirlpool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703DB16128038002D0D27 /* USHashWriterWhirlpool.cpp */; };
+		EB9EDFED1BE9421B00E8938F /* USHexReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703DD16128038002D0D27 /* USHexReader.cpp */; };
+		EB9EDFEE1BE9421B00E8938F /* USHexWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663703DF16128038002D0D27 /* USHexWriter.cpp */; };
+		EB9EDFEF1BE9421B00E8938F /* USHashWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6637040A161280E1002D0D27 /* USHashWriter.cpp */; };
+		EB9EDFF01BE9421B00E8938F /* MOAIDataIOTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C0116AE2E12009B9C29 /* MOAIDataIOTask.cpp */; };
+		EB9EDFF11BE9421B00E8938F /* MOAIThread_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C0816AE30C0009B9C29 /* MOAIThread_posix.cpp */; };
+		EB9EDFF21BE9421B00E8938F /* MOAIThread_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C0A16AE30C0009B9C29 /* MOAIThread_win32.cpp */; };
+		EB9EDFF31BE9421B00E8938F /* MOAIThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C0C16AE30C0009B9C29 /* MOAIThread.cpp */; };
+		EB9EDFF41BE9421B00E8938F /* MOAITask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C1A16AE3100009B9C29 /* MOAITask.cpp */; };
+		EB9EDFF51BE9421B00E8938F /* MOAITaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C1C16AE3100009B9C29 /* MOAITaskQueue.cpp */; };
+		EB9EDFF61BE9421B00E8938F /* MOAITaskSubscriber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C1E16AE3100009B9C29 /* MOAITaskSubscriber.cpp */; };
+		EB9EDFF71BE9421B00E8938F /* MOAITaskThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C2016AE3100009B9C29 /* MOAITaskThread.cpp */; };
+		EB9EDFF81BE9421B00E8938F /* MOAIMutex_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3216AE312A009B9C29 /* MOAIMutex_posix.cpp */; };
+		EB9EDFF91BE9421B00E8938F /* MOAIMutex_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3416AE312A009B9C29 /* MOAIMutex_win32.cpp */; };
+		EB9EDFFA1BE9421B00E8938F /* MOAIMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66E62C3616AE312A009B9C29 /* MOAIMutex.cpp */; };
+		EB9EDFFB1BE9421B00E8938F /* MOAITakeCameraListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */; };
+		EB9EDFFC1BE9421B00E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
+		EB9EDFFD1BE9421B00E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
+		EB9EDFFE1BE9421B00E8938F /* MOAIEaseLinear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D497348187258FA00D46882 /* MOAIEaseLinear.cpp */; };
+		EB9EDFFF1BE9421B00E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
+		EB9EE0001BE9421B00E8938F /* MOAIAnimCurveCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB665DE91756B13B009A8F29 /* MOAIAnimCurveCustom.cpp */; };
+		EB9EE0011BE9421B00E8938F /* MOAIFreeTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B489B0771756A43400C114DA /* MOAIFreeTypeFont.cpp */; };
+		EB9EE0021BE9421B00E8938F /* MOAITextRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B45A8BEA1829A95C00D2B255 /* MOAITextRenderer.cpp */; };
+		EB9EE0031BE9421B00E8938F /* MOAITest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B408CA0C18CE609F00F9A780 /* MOAITest.cpp */; };
+		EB9EE0041BE9421B00E8938F /* MOAITestMgr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B408CA0F18CE609F00F9A780 /* MOAITestMgr.cpp */; };
+		EB9EE0051BE9421B00E8938F /* AKU-test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B408CA1818CE612E00F9A780 /* AKU-test.cpp */; };
+		EB9EE0061BE9421B00E8938F /* MOAIXmlWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B408CA1C18CE638300F9A780 /* MOAIXmlWriter.cpp */; };
+		EB9EE00E1BE9422800E8938F /* cpConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4013564CAF000ADC60 /* cpConstraint.h */; };
+		EB9EE00F1BE9422800E8938F /* cpDampedRotarySpring.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4213564CAF000ADC60 /* cpDampedRotarySpring.h */; };
+		EB9EE0101BE9422800E8938F /* cpDampedSpring.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4413564CAF000ADC60 /* cpDampedSpring.h */; };
+		EB9EE0111BE9422800E8938F /* cpGearJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4613564CAF000ADC60 /* cpGearJoint.h */; };
+		EB9EE0121BE9422800E8938F /* cpGrooveJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4813564CAF000ADC60 /* cpGrooveJoint.h */; };
+		EB9EE0131BE9422800E8938F /* cpPinJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4A13564CAF000ADC60 /* cpPinJoint.h */; };
+		EB9EE0141BE9422800E8938F /* cpPivotJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4C13564CAF000ADC60 /* cpPivotJoint.h */; };
+		EB9EE0151BE9422800E8938F /* cpRatchetJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A4E13564CAF000ADC60 /* cpRatchetJoint.h */; };
+		EB9EE0161BE9422800E8938F /* cpRotaryLimitJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5013564CAF000ADC60 /* cpRotaryLimitJoint.h */; };
+		EB9EE0171BE9422800E8938F /* cpSimpleMotor.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5213564CAF000ADC60 /* cpSimpleMotor.h */; };
+		EB9EE0181BE9422800E8938F /* cpSlideJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5413564CAF000ADC60 /* cpSlideJoint.h */; };
+		EB9EE0191BE9422800E8938F /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5513564CAF000ADC60 /* util.h */; };
+		EB9EE01A1BE9422800E8938F /* chipmunk_ffi.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5613564CAF000ADC60 /* chipmunk_ffi.h */; };
+		EB9EE01B1BE9422800E8938F /* chipmunk_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5713564CAF000ADC60 /* chipmunk_private.h */; };
+		EB9EE01C1BE9422800E8938F /* chipmunk_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5813564CAF000ADC60 /* chipmunk_types.h */; };
+		EB9EE01D1BE9422800E8938F /* chipmunk_unsafe.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5913564CAF000ADC60 /* chipmunk_unsafe.h */; };
+		EB9EE01E1BE9422800E8938F /* chipmunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5B13564CAF000ADC60 /* chipmunk.h */; };
+		EB9EE01F1BE9422800E8938F /* cpArbiter.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5D13564CAF000ADC60 /* cpArbiter.h */; };
+		EB9EE0201BE9422800E8938F /* cpArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A5F13564CAF000ADC60 /* cpArray.h */; };
+		EB9EE0211BE9422800E8938F /* cpBB.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6113564CAF000ADC60 /* cpBB.h */; };
+		EB9EE0221BE9422800E8938F /* cpBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6313564CAF000ADC60 /* cpBody.h */; };
+		EB9EE0231BE9422800E8938F /* cpCollision.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6513564CAF000ADC60 /* cpCollision.h */; };
+		EB9EE0241BE9422800E8938F /* cpHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6713564CAF000ADC60 /* cpHashSet.h */; };
+		EB9EE0251BE9422800E8938F /* cpPolyShape.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6913564CAF000ADC60 /* cpPolyShape.h */; };
+		EB9EE0261BE9422800E8938F /* cpShape.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6B13564CAF000ADC60 /* cpShape.h */; };
+		EB9EE0271BE9422800E8938F /* cpSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A6D13564CAF000ADC60 /* cpSpace.h */; };
+		EB9EE0281BE9422800E8938F /* cpSpaceHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A7013564CAF000ADC60 /* cpSpaceHash.h */; };
+		EB9EE0291BE9422800E8938F /* cpVect.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A7413564CAF000ADC60 /* cpVect.h */; };
+		EB9EE02A1BE9422800E8938F /* prime.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A7513564CAF000ADC60 /* prime.h */; };
+		EB9EE02B1BE9422800E8938F /* utf8.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240A7813564CAF000ADC60 /* utf8.h */; };
+		EB9EE02C1BE9422800E8938F /* ascii.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1413564CB0000ADC60 /* ascii.h */; };
+		EB9EE02D1BE9422800E8938F /* asciitab.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1513564CB0000ADC60 /* asciitab.h */; };
+		EB9EE02E1BE9422800E8938F /* expat.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1613564CB0000ADC60 /* expat.h */; };
+		EB9EE02F1BE9422800E8938F /* expat_external.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1713564CB0000ADC60 /* expat_external.h */; };
+		EB9EE0301BE9422800E8938F /* iasciitab.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1813564CB0000ADC60 /* iasciitab.h */; };
+		EB9EE0311BE9422800E8938F /* internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1913564CB0000ADC60 /* internal.h */; };
+		EB9EE0321BE9422800E8938F /* latin1tab.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1A13564CB0000ADC60 /* latin1tab.h */; };
+		EB9EE0331BE9422800E8938F /* macconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1B13564CB0000ADC60 /* macconfig.h */; };
+		EB9EE0341BE9422800E8938F /* nametab.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1C13564CB0000ADC60 /* nametab.h */; };
+		EB9EE0351BE9422800E8938F /* utf8tab.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1D13564CB0000ADC60 /* utf8tab.h */; };
+		EB9EE0361BE9422800E8938F /* winconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B1E13564CB0000ADC60 /* winconfig.h */; };
+		EB9EE0371BE9422800E8938F /* xmlrole.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2113564CB0000ADC60 /* xmlrole.h */; };
+		EB9EE0381BE9422800E8938F /* xmltok.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2313564CB0000ADC60 /* xmltok.h */; };
+		EB9EE0391BE9422800E8938F /* xmltok_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2513564CB0000ADC60 /* xmltok_impl.h */; };
+		EB9EE03A1BE9422800E8938F /* sqlite3ext.h in Headers */ = {isa = PBXBuildFile; fileRef = 579E367218CF8EEF00A3CE47 /* sqlite3ext.h */; };
+		EB9EE03B1BE9422800E8938F /* ft2build.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2913564CB0000ADC60 /* ft2build.h */; };
+		EB9EE03C1BE9422800E8938F /* ftconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2A13564CB0000ADC60 /* ftconfig.h */; };
+		EB9EE03D1BE9422800E8938F /* ftheader.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2B13564CB0000ADC60 /* ftheader.h */; };
+		EB9EE03E1BE9422800E8938F /* ftmodule.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2C13564CB0000ADC60 /* ftmodule.h */; };
+		EB9EE03F1BE9422800E8938F /* ftoption.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2D13564CB0000ADC60 /* ftoption.h */; };
+		EB9EE0401BE9422800E8938F /* ftstdlib.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B2E13564CB0000ADC60 /* ftstdlib.h */; };
+		EB9EE0411BE9422800E8938F /* png.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B5A13564CB0000ADC60 /* png.h */; };
+		EB9EE0421BE9422800E8938F /* pngconf.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B5B13564CB0000ADC60 /* pngconf.h */; };
+		EB9EE0431BE9422800E8938F /* pngpriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240B6013564CB0000ADC60 /* pngpriv.h */; };
+		EB9EE0441BE9422800E8938F /* tinyxml.h in Headers */ = {isa = PBXBuildFile; fileRef = 03240BA813564CB0000ADC60 /* tinyxml.h */; };
+		EB9EE0451BE9422800E8938F /* MOAIISO8601DateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD80F63D135BBCFF006B0683 /* MOAIISO8601DateFormatter.h */; };
+		EB9EE0461BE9422800E8938F /* luasql.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F8613A7FD6E008337E7 /* luasql.h */; };
+		EB9EE0471BE9422800E8938F /* hashtable.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9413A7FDBA008337E7 /* hashtable.h */; };
+		EB9EE0481BE9422800E8938F /* jansson_config.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9513A7FDBA008337E7 /* jansson_config.h */; };
+		EB9EE0491BE9422800E8938F /* jansson_private.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9613A7FDBA008337E7 /* jansson_private.h */; };
+		EB9EE04A1BE9422800E8938F /* jansson.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9713A7FDBA008337E7 /* jansson.h */; };
+		EB9EE04B1BE9422800E8938F /* strbuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9C13A7FDBA008337E7 /* strbuffer.h */; };
+		EB9EE04C1BE9422800E8938F /* utf.h in Headers */ = {isa = PBXBuildFile; fileRef = CD218F9E13A7FDBA008337E7 /* utf.h */; };
+		EB9EE04D1BE9422800E8938F /* lapi.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490041141AB6EC00913D80 /* lapi.h */; };
+		EB9EE04E1BE9422800E8938F /* lauxlib.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490043141AB6EC00913D80 /* lauxlib.h */; };
+		EB9EE04F1BE9422800E8938F /* lcode.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490046141AB6EC00913D80 /* lcode.h */; };
+		EB9EE0501BE9422800E8938F /* ldebug.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490049141AB6EC00913D80 /* ldebug.h */; };
+		EB9EE0511BE9422800E8938F /* ldo.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49004B141AB6EC00913D80 /* ldo.h */; };
+		EB9EE0521BE9422800E8938F /* lfunc.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49004E141AB6EC00913D80 /* lfunc.h */; };
+		EB9EE0531BE9422800E8938F /* lgc.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490050141AB6EC00913D80 /* lgc.h */; };
+		EB9EE0541BE9422800E8938F /* llex.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490054141AB6EC00913D80 /* llex.h */; };
+		EB9EE0551BE9422800E8938F /* llimits.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490055141AB6EC00913D80 /* llimits.h */; };
+		EB9EE0561BE9422800E8938F /* lmem.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490058141AB6EC00913D80 /* lmem.h */; };
+		EB9EE0571BE9422800E8938F /* lobject.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49005B141AB6EC00913D80 /* lobject.h */; };
+		EB9EE0581BE9422800E8938F /* lopcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49005D141AB6EC00913D80 /* lopcodes.h */; };
+		EB9EE0591BE9422800E8938F /* lparser.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490060141AB6EC00913D80 /* lparser.h */; };
+		EB9EE05A1BE9422800E8938F /* lstate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490062141AB6EC00913D80 /* lstate.h */; };
+		EB9EE05B1BE9422800E8938F /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 579E367118CF8EEF00A3CE47 /* sqlite3.h */; };
+		EB9EE05C1BE9422800E8938F /* lstring.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490064141AB6EC00913D80 /* lstring.h */; };
+		EB9EE05D1BE9422800E8938F /* ltable.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490067141AB6EC00913D80 /* ltable.h */; };
+		EB9EE05E1BE9422800E8938F /* ltm.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49006A141AB6EC00913D80 /* ltm.h */; };
+		EB9EE05F1BE9422800E8938F /* lua.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49006B141AB6EC00913D80 /* lua.h */; };
+		EB9EE0601BE9422800E8938F /* luaconf.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49006C141AB6EC00913D80 /* luaconf.h */; };
+		EB9EE0611BE9422800E8938F /* lualib.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49006D141AB6EC00913D80 /* lualib.h */; };
+		EB9EE0621BE9422800E8938F /* lundump.h in Headers */ = {isa = PBXBuildFile; fileRef = CD49006F141AB6EC00913D80 /* lundump.h */; };
+		EB9EE0631BE9422800E8938F /* lvm.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490071141AB6EC00913D80 /* lvm.h */; };
+		EB9EE0641BE9422800E8938F /* lzio.h in Headers */ = {isa = PBXBuildFile; fileRef = CD490073141AB6EC00913D80 /* lzio.h */; };
+		EB9EE0651BE9422800E8938F /* jconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529411447907100143A72 /* jconfig.h */; };
+		EB9EE0661BE9422800E8938F /* jdct.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529561447907100143A72 /* jdct.h */; };
+		EB9EE0671BE9422800E8938F /* jerror.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529661447907100143A72 /* jerror.h */; };
+		EB9EE0681BE9422800E8938F /* jinclude.h in Headers */ = {isa = PBXBuildFile; fileRef = 0795296D1447907100143A72 /* jinclude.h */; };
+		EB9EE0691BE9422800E8938F /* jmemsys.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529751447907100143A72 /* jmemsys.h */; };
+		EB9EE06A1BE9422800E8938F /* jmorecfg.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529761447907100143A72 /* jmorecfg.h */; };
+		EB9EE06B1BE9422800E8938F /* jpegint.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529771447907100143A72 /* jpegint.h */; };
+		EB9EE06C1BE9422800E8938F /* jpeglib.h in Headers */ = {isa = PBXBuildFile; fileRef = 079529781447907100143A72 /* jpeglib.h */; };
+		EB9EE06D1BE9422800E8938F /* jversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 0795297E1447907100143A72 /* jversion.h */; };
+		EB9EE06E1BE9422800E8938F /* tlsf.h in Headers */ = {isa = PBXBuildFile; fileRef = 0765874C145CD06900723A7D /* tlsf.h */; };
+		EB9EE06F1BE9422800E8938F /* tlsfbits.h in Headers */ = {isa = PBXBuildFile; fileRef = 0765874D145CD06900723A7D /* tlsfbits.h */; };
+		EB9EE0701BE9422800E8938F /* Box2D.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD3C1468C16B00C86DF9 /* Box2D.h */; };
+		EB9EE0711BE9422800E8938F /* b2BroadPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD401468C18000C86DF9 /* b2BroadPhase.h */; };
+		EB9EE0721BE9422800E8938F /* b2Collision.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD451468C18000C86DF9 /* b2Collision.h */; };
+		EB9EE0731BE9422800E8938F /* b2Distance.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD471468C18000C86DF9 /* b2Distance.h */; };
+		EB9EE0741BE9422800E8938F /* b2DynamicTree.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD491468C18000C86DF9 /* b2DynamicTree.h */; };
+		EB9EE0751BE9422800E8938F /* b2TimeOfImpact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD4B1468C18000C86DF9 /* b2TimeOfImpact.h */; };
+		EB9EE0761BE9422800E8938F /* b2ChainShape.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD671468C19D00C86DF9 /* b2ChainShape.h */; };
+		EB9EE0771BE9422800E8938F /* b2CircleShape.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD691468C19D00C86DF9 /* b2CircleShape.h */; };
+		EB9EE0781BE9422800E8938F /* b2EdgeShape.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD6B1468C19D00C86DF9 /* b2EdgeShape.h */; };
+		EB9EE0791BE9422800E8938F /* b2PolygonShape.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD6D1468C19D00C86DF9 /* b2PolygonShape.h */; };
+		EB9EE07A1BE9422800E8938F /* b2Shape.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD6E1468C19D00C86DF9 /* b2Shape.h */; };
+		EB9EE07B1BE9422800E8938F /* b2BlockAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD821468C1AF00C86DF9 /* b2BlockAllocator.h */; };
+		EB9EE07C1BE9422800E8938F /* b2Draw.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD841468C1AF00C86DF9 /* b2Draw.h */; };
+		EB9EE07D1BE9422800E8938F /* b2GrowableStack.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD851468C1AF00C86DF9 /* b2GrowableStack.h */; };
+		EB9EE07E1BE9422800E8938F /* b2Math.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD871468C1AF00C86DF9 /* b2Math.h */; };
+		EB9EE07F1BE9422800E8938F /* b2Settings.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD891468C1AF00C86DF9 /* b2Settings.h */; };
+		EB9EE0801BE9422800E8938F /* b2StackAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD8B1468C1AF00C86DF9 /* b2StackAllocator.h */; };
+		EB9EE0811BE9422800E8938F /* b2Timer.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDD8D1468C1AF00C86DF9 /* b2Timer.h */; };
+		EB9EE0821BE9422800E8938F /* b2Body.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDA91468C1BF00C86DF9 /* b2Body.h */; };
+		EB9EE0831BE9422800E8938F /* b2ContactManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDAB1468C1BF00C86DF9 /* b2ContactManager.h */; };
+		EB9EE0841BE9422800E8938F /* b2Fixture.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDAD1468C1BF00C86DF9 /* b2Fixture.h */; };
+		EB9EE0851BE9422800E8938F /* b2Island.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDAF1468C1BF00C86DF9 /* b2Island.h */; };
+		EB9EE0861BE9422800E8938F /* b2TimeStep.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDB01468C1BF00C86DF9 /* b2TimeStep.h */; };
+		EB9EE0871BE9422800E8938F /* b2World.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDB21468C1BF00C86DF9 /* b2World.h */; };
+		EB9EE0881BE9422800E8938F /* b2WorldCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDB41468C1BF00C86DF9 /* b2WorldCallbacks.h */; };
+		EB9EE0891BE9422800E8938F /* b2ChainAndCircleContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDD01468C1D900C86DF9 /* b2ChainAndCircleContact.h */; };
+		EB9EE08A1BE9422800E8938F /* b2ChainAndPolygonContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDD21468C1D900C86DF9 /* b2ChainAndPolygonContact.h */; };
+		EB9EE08B1BE9422800E8938F /* b2CircleContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDD41468C1D900C86DF9 /* b2CircleContact.h */; };
+		EB9EE08C1BE9422800E8938F /* b2Contact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDD61468C1D900C86DF9 /* b2Contact.h */; };
+		EB9EE08D1BE9422800E8938F /* b2ContactSolver.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDD81468C1D900C86DF9 /* b2ContactSolver.h */; };
+		EB9EE08E1BE9422800E8938F /* b2EdgeAndCircleContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDDA1468C1D900C86DF9 /* b2EdgeAndCircleContact.h */; };
+		EB9EE08F1BE9422800E8938F /* b2EdgeAndPolygonContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDDC1468C1D900C86DF9 /* b2EdgeAndPolygonContact.h */; };
+		EB9EE0901BE9422800E8938F /* b2PolygonAndCircleContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDDE1468C1D900C86DF9 /* b2PolygonAndCircleContact.h */; };
+		EB9EE0911BE9422800E8938F /* b2PolygonContact.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDDE01468C1D900C86DF9 /* b2PolygonContact.h */; };
+		EB9EE0921BE9422800E8938F /* b2DistanceJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE061468C1EC00C86DF9 /* b2DistanceJoint.h */; };
+		EB9EE0931BE9422800E8938F /* b2FrictionJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE081468C1EC00C86DF9 /* b2FrictionJoint.h */; };
+		EB9EE0941BE9422800E8938F /* b2GearJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE0A1468C1EC00C86DF9 /* b2GearJoint.h */; };
+		EB9EE0951BE9422800E8938F /* b2Joint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE0C1468C1EC00C86DF9 /* b2Joint.h */; };
+		EB9EE0961BE9422800E8938F /* b2MouseJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE0E1468C1EC00C86DF9 /* b2MouseJoint.h */; };
+		EB9EE0971BE9422800E8938F /* b2PrismaticJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE101468C1EC00C86DF9 /* b2PrismaticJoint.h */; };
+		EB9EE0981BE9422800E8938F /* b2PulleyJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE121468C1EC00C86DF9 /* b2PulleyJoint.h */; };
+		EB9EE0991BE9422800E8938F /* b2RevoluteJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE141468C1EC00C86DF9 /* b2RevoluteJoint.h */; };
+		EB9EE09A1BE9422800E8938F /* b2RopeJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE161468C1EC00C86DF9 /* b2RopeJoint.h */; };
+		EB9EE09B1BE9422800E8938F /* b2WeldJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE181468C1EC00C86DF9 /* b2WeldJoint.h */; };
+		EB9EE09C1BE9422800E8938F /* b2WheelJoint.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE1A1468C1EC00C86DF9 /* b2WheelJoint.h */; };
+		EB9EE09D1BE9422800E8938F /* b2Rope.h in Headers */ = {isa = PBXBuildFile; fileRef = CDEBDE481468C1FD00C86DF9 /* b2Rope.h */; };
+		EB9EE09E1BE9422800E8938F /* crc32.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEBA14725714009C20E5 /* crc32.h */; };
+		EB9EE09F1BE9422800E8938F /* deflate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEBC14725714009C20E5 /* deflate.h */; };
+		EB9EE0A01BE9422800E8938F /* inffast.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC014725714009C20E5 /* inffast.h */; };
+		EB9EE0A11BE9422800E8938F /* inffixed.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC114725714009C20E5 /* inffixed.h */; };
+		EB9EE0A21BE9422800E8938F /* inflate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC314725714009C20E5 /* inflate.h */; };
+		EB9EE0A31BE9422800E8938F /* inftrees.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC514725714009C20E5 /* inftrees.h */; };
+		EB9EE0A41BE9422800E8938F /* trees.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC714725714009C20E5 /* trees.h */; };
+		EB9EE0A51BE9422800E8938F /* zconf.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC914725714009C20E5 /* zconf.h */; };
+		EB9EE0A61BE9422800E8938F /* zlib.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AECA14725714009C20E5 /* zlib.h */; };
+		EB9EE0A71BE9422800E8938F /* zutil.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AECC14725714009C20E5 /* zutil.h */; };
+		EB9EE0A81BE9422800E8938F /* whirlpool.h in Headers */ = {isa = PBXBuildFile; fileRef = 663704111612812C002D0D27 /* whirlpool.h */; };
+		EB9EE0A91BE9422800E8938F /* MOAIMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D64916D8021D00C172D2 /* MOAIMath.h */; };
+		EB9EE0AA1BE9422800E8938F /* MOAIFrameBufferTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D67116D8025000C172D2 /* MOAIFrameBufferTexture.h */; };
+		EB9EE0AC1BE9422800E8938F /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240A7713564CAF000ADC60 /* utf8.c */; };
+		EB9EE0AD1BE9422800E8938F /* xmlparse.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B1F13564CB0000ADC60 /* xmlparse.c */; };
+		EB9EE0AE1BE9422800E8938F /* xmlrole.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B2013564CB0000ADC60 /* xmlrole.c */; };
+		EB9EE0AF1BE9422800E8938F /* xmltok.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B2213564CB0000ADC60 /* xmltok.c */; };
+		EB9EE0B01BE9422800E8938F /* xmltok_impl.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B2413564CB0000ADC60 /* xmltok_impl.c */; };
+		EB9EE0B11BE9422800E8938F /* xmltok_ns.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B2613564CB0000ADC60 /* xmltok_ns.c */; };
+		EB9EE0B21BE9422800E8938F /* ftbbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3113564CB0000ADC60 /* ftbbox.c */; };
+		EB9EE0B31BE9422800E8938F /* ftgxval.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3213564CB0000ADC60 /* ftgxval.c */; };
+		EB9EE0B41BE9422800E8938F /* ftlcdfil.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3313564CB0000ADC60 /* ftlcdfil.c */; };
+		EB9EE0B51BE9422800E8938F /* ftmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3413564CB0000ADC60 /* ftmm.c */; };
+		EB9EE0B61BE9422800E8938F /* ftotval.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3513564CB0000ADC60 /* ftotval.c */; };
+		EB9EE0B71BE9422800E8938F /* ftpatent.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3613564CB0000ADC60 /* ftpatent.c */; };
+		EB9EE0B81BE9422800E8938F /* ftpfr.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3713564CB0000ADC60 /* ftpfr.c */; };
+		EB9EE0B91BE9422800E8938F /* ftsynth.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3813564CB0000ADC60 /* ftsynth.c */; };
+		EB9EE0BA1BE9422800E8938F /* fttype1.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3913564CB0000ADC60 /* fttype1.c */; };
+		EB9EE0BB1BE9422800E8938F /* ftwinfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3A13564CB0000ADC60 /* ftwinfnt.c */; };
+		EB9EE0BC1BE9422800E8938F /* ftxf86.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3B13564CB0000ADC60 /* ftxf86.c */; };
+		EB9EE0BD1BE9422800E8938F /* pcf.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3C13564CB0000ADC60 /* pcf.c */; };
+		EB9EE0BE1BE9422800E8938F /* pfr.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3D13564CB0000ADC60 /* pfr.c */; };
+		EB9EE0BF1BE9422800E8938F /* psaux.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3E13564CB0000ADC60 /* psaux.c */; };
+		EB9EE0C01BE9422800E8938F /* pshinter.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B3F13564CB0000ADC60 /* pshinter.c */; };
+		EB9EE0C11BE9422800E8938F /* psmodule.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4013564CB0000ADC60 /* psmodule.c */; };
+		EB9EE0C21BE9422800E8938F /* raster.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4113564CB0000ADC60 /* raster.c */; };
+		EB9EE0C31BE9422800E8938F /* sfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4213564CB0000ADC60 /* sfnt.c */; };
+		EB9EE0C41BE9422800E8938F /* truetype.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4313564CB0000ADC60 /* truetype.c */; };
+		EB9EE0C51BE9422800E8938F /* type1.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4413564CB0000ADC60 /* type1.c */; };
+		EB9EE0C61BE9422800E8938F /* type1cid.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4513564CB0000ADC60 /* type1cid.c */; };
+		EB9EE0C71BE9422800E8938F /* type42.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4613564CB0000ADC60 /* type42.c */; };
+		EB9EE0C81BE9422800E8938F /* winfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4713564CB0000ADC60 /* winfnt.c */; };
+		EB9EE0C91BE9422800E8938F /* autofit.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4813564CB0000ADC60 /* autofit.c */; };
+		EB9EE0CA1BE9422800E8938F /* bdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4913564CB0000ADC60 /* bdf.c */; };
+		EB9EE0CB1BE9422800E8938F /* cff.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4A13564CB0000ADC60 /* cff.c */; };
+		EB9EE0CC1BE9422800E8938F /* ftbase.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4B13564CB0000ADC60 /* ftbase.c */; };
+		EB9EE0CD1BE9422800E8938F /* ftbitmap.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4C13564CB0000ADC60 /* ftbitmap.c */; };
+		EB9EE0CE1BE9422800E8938F /* ftcache.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4D13564CB0000ADC60 /* ftcache.c */; };
+		EB9EE0CF1BE9422800E8938F /* ftdebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4E13564CB0000ADC60 /* ftdebug.c */; };
+		EB9EE0D01BE9422800E8938F /* ftfstype.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B4F13564CB0000ADC60 /* ftfstype.c */; };
+		EB9EE0D11BE9422800E8938F /* ftgasp.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5013564CB0000ADC60 /* ftgasp.c */; };
+		EB9EE0D21BE9422800E8938F /* ftglyph.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5113564CB0000ADC60 /* ftglyph.c */; };
+		EB9EE0D31BE9422800E8938F /* ftgzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5213564CB0000ADC60 /* ftgzip.c */; };
+		EB9EE0D41BE9422800E8938F /* ftinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5313564CB0000ADC60 /* ftinit.c */; };
+		EB9EE0D51BE9422800E8938F /* ftlzw.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5413564CB0000ADC60 /* ftlzw.c */; };
+		EB9EE0D61BE9422800E8938F /* ftstroke.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5513564CB0000ADC60 /* ftstroke.c */; };
+		EB9EE0D71BE9422800E8938F /* ftsystem.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5613564CB0000ADC60 /* ftsystem.c */; };
+		EB9EE0D81BE9422800E8938F /* smooth.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5713564CB0000ADC60 /* smooth.c */; };
+		EB9EE0D91BE9422800E8938F /* png.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5913564CB0000ADC60 /* png.c */; };
+		EB9EE0DA1BE9422800E8938F /* pngerror.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5C13564CB0000ADC60 /* pngerror.c */; };
+		EB9EE0DB1BE9422800E8938F /* pngget.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5D13564CB0000ADC60 /* pngget.c */; };
+		EB9EE0DC1BE9422800E8938F /* pngmem.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5E13564CB0000ADC60 /* pngmem.c */; };
+		EB9EE0DD1BE9422800E8938F /* pngpread.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B5F13564CB0000ADC60 /* pngpread.c */; };
+		EB9EE0DE1BE9422800E8938F /* pngread.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6113564CB0000ADC60 /* pngread.c */; };
+		EB9EE0DF1BE9422800E8938F /* pngrio.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6213564CB0000ADC60 /* pngrio.c */; };
+		EB9EE0E01BE9422800E8938F /* pngrtran.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6313564CB0000ADC60 /* pngrtran.c */; };
+		EB9EE0E11BE9422800E8938F /* pngrutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6413564CB0000ADC60 /* pngrutil.c */; };
+		EB9EE0E21BE9422800E8938F /* pngset.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6513564CB0000ADC60 /* pngset.c */; };
+		EB9EE0E31BE9422800E8938F /* pngtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6713564CB0000ADC60 /* pngtrans.c */; };
+		EB9EE0E41BE9422800E8938F /* pngwio.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6813564CB0000ADC60 /* pngwio.c */; };
+		EB9EE0E51BE9422800E8938F /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6913564CB0000ADC60 /* pngwrite.c */; };
+		EB9EE0E61BE9422800E8938F /* pngwtran.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6A13564CB0000ADC60 /* pngwtran.c */; };
+		EB9EE0E71BE9422800E8938F /* pngwutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 03240B6B13564CB0000ADC60 /* pngwutil.c */; };
+		EB9EE0E81BE9422800E8938F /* tinyxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03240BA713564CB0000ADC60 /* tinyxml.cpp */; };
+		EB9EE0E91BE9422800E8938F /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03240BA913564CB0000ADC60 /* tinyxmlerror.cpp */; };
+		EB9EE0EA1BE9422800E8938F /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03240BAA13564CB0000ADC60 /* tinyxmlparser.cpp */; };
+		EB9EE0EB1BE9422800E8938F /* MOAIISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD80F63E135BBCFF006B0683 /* MOAIISO8601DateFormatter.m */; };
+		EB9EE0EC1BE9422800E8938F /* ls_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F8413A7FD6E008337E7 /* ls_sqlite3.c */; };
+		EB9EE0ED1BE9422800E8938F /* luasql.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F8513A7FD6E008337E7 /* luasql.c */; };
+		EB9EE0EE1BE9422800E8938F /* dump.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9113A7FDBA008337E7 /* dump.c */; };
+		EB9EE0EF1BE9422800E8938F /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9213A7FDBA008337E7 /* error.c */; };
+		EB9EE0F01BE9422800E8938F /* hashtable.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9313A7FDBA008337E7 /* hashtable.c */; };
+		EB9EE0F11BE9422800E8938F /* load.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9813A7FDBA008337E7 /* load.c */; };
+		EB9EE0F21BE9422800E8938F /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9913A7FDBA008337E7 /* memory.c */; };
+		EB9EE0F31BE9422800E8938F /* pack_unpack.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9A13A7FDBA008337E7 /* pack_unpack.c */; };
+		EB9EE0F41BE9422800E8938F /* strbuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9B13A7FDBA008337E7 /* strbuffer.c */; };
+		EB9EE0F51BE9422800E8938F /* utf.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9D13A7FDBA008337E7 /* utf.c */; };
+		EB9EE0F61BE9422800E8938F /* value.c in Sources */ = {isa = PBXBuildFile; fileRef = CD218F9F13A7FDBA008337E7 /* value.c */; };
+		EB9EE0F71BE9422800E8938F /* lapi.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490040141AB6EC00913D80 /* lapi.c */; };
+		EB9EE0F81BE9422800E8938F /* lauxlib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490042141AB6EC00913D80 /* lauxlib.c */; };
+		EB9EE0F91BE9422800E8938F /* lbaselib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490044141AB6EC00913D80 /* lbaselib.c */; };
+		EB9EE0FA1BE9422800E8938F /* lcode.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490045141AB6EC00913D80 /* lcode.c */; };
+		EB9EE0FB1BE9422800E8938F /* ldblib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490047141AB6EC00913D80 /* ldblib.c */; };
+		EB9EE0FC1BE9422800E8938F /* ldebug.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490048141AB6EC00913D80 /* ldebug.c */; };
+		EB9EE0FD1BE9422800E8938F /* ldump.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49004C141AB6EC00913D80 /* ldump.c */; };
+		EB9EE0FE1BE9422800E8938F /* lfunc.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49004D141AB6EC00913D80 /* lfunc.c */; };
+		EB9EE0FF1BE9422800E8938F /* lgc.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49004F141AB6EC00913D80 /* lgc.c */; };
+		EB9EE1001BE9422800E8938F /* linit.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490051141AB6EC00913D80 /* linit.c */; };
+		EB9EE1011BE9422800E8938F /* liolib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490052141AB6EC00913D80 /* liolib.c */; };
+		EB9EE1021BE9422800E8938F /* llex.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490053141AB6EC00913D80 /* llex.c */; };
+		EB9EE1031BE9422800E8938F /* lmathlib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490056141AB6EC00913D80 /* lmathlib.c */; };
+		EB9EE1041BE9422800E8938F /* lmem.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490057141AB6EC00913D80 /* lmem.c */; };
+		EB9EE1051BE9422800E8938F /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490059141AB6EC00913D80 /* loadlib.c */; };
+		EB9EE1061BE9422800E8938F /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005A141AB6EC00913D80 /* lobject.c */; };
+		EB9EE1071BE9422800E8938F /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005C141AB6EC00913D80 /* lopcodes.c */; };
+		EB9EE1081BE9422800E8938F /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005E141AB6EC00913D80 /* loslib.c */; };
+		EB9EE1091BE9422800E8938F /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005F141AB6EC00913D80 /* lparser.c */; };
+		EB9EE10A1BE9422800E8938F /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490061141AB6EC00913D80 /* lstate.c */; };
+		EB9EE10B1BE9422800E8938F /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490063141AB6EC00913D80 /* lstring.c */; };
+		EB9EE10C1BE9422800E8938F /* lstrlib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490065141AB6EC00913D80 /* lstrlib.c */; };
+		EB9EE10D1BE9422800E8938F /* ltable.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490066141AB6EC00913D80 /* ltable.c */; };
+		EB9EE10E1BE9422800E8938F /* ltablib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490068141AB6EC00913D80 /* ltablib.c */; };
+		EB9EE10F1BE9422800E8938F /* ltm.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490069141AB6EC00913D80 /* ltm.c */; };
+		EB9EE1101BE9422800E8938F /* lundump.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49006E141AB6EC00913D80 /* lundump.c */; };
+		EB9EE1111BE9422800E8938F /* lvm.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490070141AB6EC00913D80 /* lvm.c */; };
+		EB9EE1121BE9422800E8938F /* lzio.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490072141AB6EC00913D80 /* lzio.c */; };
+		EB9EE1131BE9422800E8938F /* print.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490074141AB6EC00913D80 /* print.c */; };
+		EB9EE1141BE9422800E8938F /* jaricom.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529311447907100143A72 /* jaricom.c */; };
+		EB9EE1151BE9422800E8938F /* jcapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529321447907100143A72 /* jcapimin.c */; };
+		EB9EE1161BE9422800E8938F /* jcapistd.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529331447907100143A72 /* jcapistd.c */; };
+		EB9EE1171BE9422800E8938F /* jcarith.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529341447907100143A72 /* jcarith.c */; };
+		EB9EE1181BE9422800E8938F /* jccoefct.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529351447907100143A72 /* jccoefct.c */; };
+		EB9EE1191BE9422800E8938F /* jccolor.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529361447907100143A72 /* jccolor.c */; };
+		EB9EE11A1BE9422800E8938F /* jcdctmgr.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529371447907100143A72 /* jcdctmgr.c */; };
+		EB9EE11B1BE9422800E8938F /* jchuff.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529381447907100143A72 /* jchuff.c */; };
+		EB9EE11C1BE9422800E8938F /* jcinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529391447907100143A72 /* jcinit.c */; };
+		EB9EE11D1BE9422800E8938F /* jcmainct.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795293A1447907100143A72 /* jcmainct.c */; };
+		EB9EE11E1BE9422800E8938F /* jcmarker.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795293B1447907100143A72 /* jcmarker.c */; };
+		EB9EE11F1BE9422800E8938F /* jcmaster.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795293C1447907100143A72 /* jcmaster.c */; };
+		EB9EE1201BE9422800E8938F /* jcomapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795293D1447907100143A72 /* jcomapi.c */; };
+		EB9EE1211BE9422800E8938F /* jcparam.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795294B1447907100143A72 /* jcparam.c */; };
+		EB9EE1221BE9422800E8938F /* jcprepct.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795294C1447907100143A72 /* jcprepct.c */; };
+		EB9EE1231BE9422800E8938F /* jcsample.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795294D1447907100143A72 /* jcsample.c */; };
+		EB9EE1241BE9422800E8938F /* jctrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795294E1447907100143A72 /* jctrans.c */; };
+		EB9EE1251BE9422800E8938F /* jdapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795294F1447907100143A72 /* jdapimin.c */; };
+		EB9EE1261BE9422800E8938F /* jdapistd.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529501447907100143A72 /* jdapistd.c */; };
+		EB9EE1271BE9422800E8938F /* jdarith.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529511447907100143A72 /* jdarith.c */; };
+		EB9EE1281BE9422800E8938F /* jdatadst.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529521447907100143A72 /* jdatadst.c */; };
+		EB9EE1291BE9422800E8938F /* jdatasrc.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529531447907100143A72 /* jdatasrc.c */; };
+		EB9EE12A1BE9422800E8938F /* jdcoefct.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529541447907100143A72 /* jdcoefct.c */; };
+		EB9EE12B1BE9422800E8938F /* jdcolor.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529551447907100143A72 /* jdcolor.c */; };
+		EB9EE12C1BE9422800E8938F /* jddctmgr.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529571447907100143A72 /* jddctmgr.c */; };
+		EB9EE12D1BE9422800E8938F /* jdhuff.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529581447907100143A72 /* jdhuff.c */; };
+		EB9EE12E1BE9422800E8938F /* jdinput.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529591447907100143A72 /* jdinput.c */; };
+		EB9EE12F1BE9422800E8938F /* jdmainct.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795295A1447907100143A72 /* jdmainct.c */; };
+		EB9EE1301BE9422800E8938F /* jdmarker.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795295B1447907100143A72 /* jdmarker.c */; };
+		EB9EE1311BE9422800E8938F /* jdmaster.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795295C1447907100143A72 /* jdmaster.c */; };
+		EB9EE1321BE9422800E8938F /* jdmerge.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795295D1447907100143A72 /* jdmerge.c */; };
+		EB9EE1331BE9422800E8938F /* jdpostct.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529611447907100143A72 /* jdpostct.c */; };
+		EB9EE1341BE9422800E8938F /* jdsample.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529621447907100143A72 /* jdsample.c */; };
+		EB9EE1351BE9422800E8938F /* jdtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529631447907100143A72 /* jdtrans.c */; };
+		EB9EE1361BE9422800E8938F /* jerror-moai.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529641447907100143A72 /* jerror-moai.c */; };
+		EB9EE1371BE9422800E8938F /* jfdctflt.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529671447907100143A72 /* jfdctflt.c */; };
+		EB9EE1381BE9422800E8938F /* jfdctfst.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529681447907100143A72 /* jfdctfst.c */; };
+		EB9EE1391BE9422800E8938F /* jfdctint.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529691447907100143A72 /* jfdctint.c */; };
+		EB9EE13A1BE9422800E8938F /* jidctflt.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795296A1447907100143A72 /* jidctflt.c */; };
+		EB9EE13B1BE9422800E8938F /* jidctfst.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795296B1447907100143A72 /* jidctfst.c */; };
+		EB9EE13C1BE9422800E8938F /* jidctint.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795296C1447907100143A72 /* jidctint.c */; };
+		EB9EE13D1BE9422800E8938F /* jmemmgr.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529721447907100143A72 /* jmemmgr.c */; };
+		EB9EE13E1BE9422800E8938F /* jmemnobs.c in Sources */ = {isa = PBXBuildFile; fileRef = 079529741447907100143A72 /* jmemnobs.c */; };
+		EB9EE13F1BE9422800E8938F /* jquant1.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795297B1447907100143A72 /* jquant1.c */; };
+		EB9EE1401BE9422800E8938F /* jquant2.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795297C1447907100143A72 /* jquant2.c */; };
+		EB9EE1411BE9422800E8938F /* jutils.c in Sources */ = {isa = PBXBuildFile; fileRef = 0795297D1447907100143A72 /* jutils.c */; };
+		EB9EE1421BE9422800E8938F /* tlsf.c in Sources */ = {isa = PBXBuildFile; fileRef = 0765874B145CD06900723A7D /* tlsf.c */; };
+		EB9EE1431BE9422800E8938F /* b2BroadPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD3F1468C18000C86DF9 /* b2BroadPhase.cpp */; };
+		EB9EE1441BE9422800E8938F /* b2CollideCircle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD411468C18000C86DF9 /* b2CollideCircle.cpp */; };
+		EB9EE1451BE9422800E8938F /* b2CollideEdge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD421468C18000C86DF9 /* b2CollideEdge.cpp */; };
+		EB9EE1461BE9422800E8938F /* b2CollidePolygon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD431468C18000C86DF9 /* b2CollidePolygon.cpp */; };
+		EB9EE1471BE9422800E8938F /* b2Collision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD441468C18000C86DF9 /* b2Collision.cpp */; };
+		EB9EE1481BE9422800E8938F /* b2Distance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD461468C18000C86DF9 /* b2Distance.cpp */; };
+		EB9EE1491BE9422800E8938F /* b2DynamicTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD481468C18000C86DF9 /* b2DynamicTree.cpp */; };
+		EB9EE14A1BE9422800E8938F /* b2TimeOfImpact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD4A1468C18000C86DF9 /* b2TimeOfImpact.cpp */; };
+		EB9EE14B1BE9422800E8938F /* b2ChainShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD661468C19D00C86DF9 /* b2ChainShape.cpp */; };
+		EB9EE14C1BE9422800E8938F /* b2CircleShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD681468C19D00C86DF9 /* b2CircleShape.cpp */; };
+		EB9EE14D1BE9422800E8938F /* b2EdgeShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD6A1468C19D00C86DF9 /* b2EdgeShape.cpp */; };
+		EB9EE14E1BE9422800E8938F /* b2PolygonShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD6C1468C19D00C86DF9 /* b2PolygonShape.cpp */; };
+		EB9EE14F1BE9422800E8938F /* b2BlockAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD811468C1AF00C86DF9 /* b2BlockAllocator.cpp */; };
+		EB9EE1501BE9422800E8938F /* b2Draw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD831468C1AF00C86DF9 /* b2Draw.cpp */; };
+		EB9EE1511BE9422800E8938F /* b2Math.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD861468C1AF00C86DF9 /* b2Math.cpp */; };
+		EB9EE1521BE9422800E8938F /* b2Settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD881468C1AF00C86DF9 /* b2Settings.cpp */; };
+		EB9EE1531BE9422800E8938F /* b2StackAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD8A1468C1AF00C86DF9 /* b2StackAllocator.cpp */; };
+		EB9EE1541BE9422800E8938F /* b2Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDD8C1468C1AF00C86DF9 /* b2Timer.cpp */; };
+		EB9EE1551BE9422800E8938F /* b2Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDA81468C1BF00C86DF9 /* b2Body.cpp */; };
+		EB9EE1561BE9422800E8938F /* b2ContactManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDAA1468C1BF00C86DF9 /* b2ContactManager.cpp */; };
+		EB9EE1571BE9422800E8938F /* b2Fixture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDAC1468C1BF00C86DF9 /* b2Fixture.cpp */; };
+		EB9EE1581BE9422800E8938F /* b2Island.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDAE1468C1BF00C86DF9 /* b2Island.cpp */; };
+		EB9EE1591BE9422800E8938F /* b2World.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDB11468C1BF00C86DF9 /* b2World.cpp */; };
+		EB9EE15A1BE9422800E8938F /* b2WorldCallbacks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDB31468C1BF00C86DF9 /* b2WorldCallbacks.cpp */; };
+		EB9EE15B1BE9422800E8938F /* b2ChainAndCircleContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDCF1468C1D900C86DF9 /* b2ChainAndCircleContact.cpp */; };
+		EB9EE15C1BE9422800E8938F /* b2ChainAndPolygonContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDD11468C1D900C86DF9 /* b2ChainAndPolygonContact.cpp */; };
+		EB9EE15D1BE9422800E8938F /* b2CircleContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDD31468C1D900C86DF9 /* b2CircleContact.cpp */; };
+		EB9EE15E1BE9422800E8938F /* b2Contact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDD51468C1D900C86DF9 /* b2Contact.cpp */; };
+		EB9EE15F1BE9422800E8938F /* b2ContactSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDD71468C1D900C86DF9 /* b2ContactSolver.cpp */; };
+		EB9EE1601BE9422800E8938F /* b2EdgeAndCircleContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDD91468C1D900C86DF9 /* b2EdgeAndCircleContact.cpp */; };
+		EB9EE1611BE9422800E8938F /* b2EdgeAndPolygonContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDDB1468C1D900C86DF9 /* b2EdgeAndPolygonContact.cpp */; };
+		EB9EE1621BE9422800E8938F /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 579E367018CF8EEF00A3CE47 /* sqlite3.c */; };
+		EB9EE1631BE9422800E8938F /* b2PolygonAndCircleContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDDD1468C1D900C86DF9 /* b2PolygonAndCircleContact.cpp */; };
+		EB9EE1641BE9422800E8938F /* b2PolygonContact.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDDDF1468C1D900C86DF9 /* b2PolygonContact.cpp */; };
+		EB9EE1651BE9422800E8938F /* b2DistanceJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE051468C1EC00C86DF9 /* b2DistanceJoint.cpp */; };
+		EB9EE1661BE9422800E8938F /* b2FrictionJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE071468C1EC00C86DF9 /* b2FrictionJoint.cpp */; };
+		EB9EE1671BE9422800E8938F /* b2GearJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE091468C1EC00C86DF9 /* b2GearJoint.cpp */; };
+		EB9EE1681BE9422800E8938F /* b2Joint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE0B1468C1EC00C86DF9 /* b2Joint.cpp */; };
+		EB9EE1691BE9422800E8938F /* b2MouseJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE0D1468C1EC00C86DF9 /* b2MouseJoint.cpp */; };
+		EB9EE16A1BE9422800E8938F /* b2PrismaticJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE0F1468C1EC00C86DF9 /* b2PrismaticJoint.cpp */; };
+		EB9EE16B1BE9422800E8938F /* b2PulleyJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE111468C1EC00C86DF9 /* b2PulleyJoint.cpp */; };
+		EB9EE16C1BE9422800E8938F /* b2RevoluteJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE131468C1EC00C86DF9 /* b2RevoluteJoint.cpp */; };
+		EB9EE16D1BE9422800E8938F /* b2RopeJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE151468C1EC00C86DF9 /* b2RopeJoint.cpp */; };
+		EB9EE16E1BE9422800E8938F /* b2WeldJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE171468C1EC00C86DF9 /* b2WeldJoint.cpp */; };
+		EB9EE16F1BE9422800E8938F /* b2WheelJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE191468C1EC00C86DF9 /* b2WheelJoint.cpp */; };
+		EB9EE1701BE9422800E8938F /* b2Rope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDEBDE471468C1FD00C86DF9 /* b2Rope.cpp */; };
+		EB9EE1711BE9422800E8938F /* adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB714725714009C20E5 /* adler32.c */; };
+		EB9EE1721BE9422800E8938F /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB814725714009C20E5 /* compress.c */; };
+		EB9EE1731BE9422800E8938F /* crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB914725714009C20E5 /* crc32.c */; };
+		EB9EE1741BE9422800E8938F /* deflate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBB14725714009C20E5 /* deflate.c */; };
+		EB9EE1751BE9422800E8938F /* gzio.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBD14725714009C20E5 /* gzio.c */; };
+		EB9EE1761BE9422800E8938F /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBE14725714009C20E5 /* infback.c */; };
+		EB9EE1771BE9422800E8938F /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBF14725714009C20E5 /* inffast.c */; };
+		EB9EE1781BE9422800E8938F /* inflate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC214725714009C20E5 /* inflate.c */; };
+		EB9EE1791BE9422800E8938F /* inftrees.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC414725714009C20E5 /* inftrees.c */; };
+		EB9EE17A1BE9422800E8938F /* trees.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC614725714009C20E5 /* trees.c */; };
+		EB9EE17B1BE9422800E8938F /* uncompr.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC814725714009C20E5 /* uncompr.c */; };
+		EB9EE17C1BE9422800E8938F /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AECB14725714009C20E5 /* zutil.c */; };
+		EB9EE17D1BE9422800E8938F /* whirlpool.c in Sources */ = {isa = PBXBuildFile; fileRef = 66E345451614CA710021FC4B /* whirlpool.c */; };
+		EB9EE17E1BE9422800E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
+		EB9EE17F1BE9422800E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
+		EB9EE1801BE9422800E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
+		EB9EE1881BE9423500E8938F /* lcrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D891398832300AB0420 /* lcrypto.h */; };
+		EB9EE1891BE9423500E8938F /* auxiliar.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D8F1398838D00AB0420 /* auxiliar.h */; };
+		EB9EE18A1BE9423500E8938F /* buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D911398838D00AB0420 /* buffer.h */; };
+		EB9EE18B1BE9423500E8938F /* except.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D931398838D00AB0420 /* except.h */; };
+		EB9EE18C1BE9423500E8938F /* inet.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D951398838D00AB0420 /* inet.h */; };
+		EB9EE18D1BE9423500E8938F /* io.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D971398838D00AB0420 /* io.h */; };
+		EB9EE18E1BE9423500E8938F /* luasocket.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D991398838D00AB0420 /* luasocket.h */; };
+		EB9EE18F1BE9423500E8938F /* mime.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D9C1398838D00AB0420 /* mime.h */; };
+		EB9EE1901BE9423500E8938F /* options.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06D9E1398838D00AB0420 /* options.h */; };
+		EB9EE1911BE9423500E8938F /* select.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DA01398838D00AB0420 /* select.h */; };
+		EB9EE1921BE9423500E8938F /* socket.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DA11398838D00AB0420 /* socket.h */; };
+		EB9EE1931BE9423500E8938F /* tcp.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DA31398838D00AB0420 /* tcp.h */; };
+		EB9EE1941BE9423500E8938F /* timeout.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DA51398838D00AB0420 /* timeout.h */; };
+		EB9EE1951BE9423500E8938F /* udp.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DA81398838D00AB0420 /* udp.h */; };
+		EB9EE1961BE9423500E8938F /* unix.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DAA1398838D00AB0420 /* unix.h */; };
+		EB9EE1971BE9423500E8938F /* usocket.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06DAD1398838D00AB0420 /* usocket.h */; };
+		EB9EE1981BE9423500E8938F /* AKU-luaext.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06E531398B5A500AB0420 /* AKU-luaext.h */; };
+		EB9EE1991BE9423500E8938F /* lfs.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D6714B7A217006465CC /* lfs.h */; };
+		EB9EE19A1BE9423500E8938F /* MOAICoroutine.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D6D14B7A414006465CC /* MOAICoroutine.h */; };
+		EB9EE19B1BE9423500E8938F /* MOAIMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D64916D8021D00C172D2 /* MOAIMath.h */; };
+		EB9EE19C1BE9423500E8938F /* MOAIFrameBufferTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D67116D8025000C172D2 /* MOAIFrameBufferTexture.h */; };
+		EB9EE19E1BE9423500E8938F /* lcrypto.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D881398832300AB0420 /* lcrypto.c */; };
+		EB9EE19F1BE9423500E8938F /* auxiliar.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D8E1398838D00AB0420 /* auxiliar.c */; };
+		EB9EE1A01BE9423500E8938F /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D901398838D00AB0420 /* buffer.c */; };
+		EB9EE1A11BE9423500E8938F /* except.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D921398838D00AB0420 /* except.c */; };
+		EB9EE1A21BE9423500E8938F /* inet.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D941398838D00AB0420 /* inet.c */; };
+		EB9EE1A31BE9423500E8938F /* c_hook.c in Sources */ = {isa = PBXBuildFile; fileRef = CB4B0B8E1858F1B80020381E /* c_hook.c */; };
+		EB9EE1A41BE9423500E8938F /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D961398838D00AB0420 /* io.c */; };
+		EB9EE1A51BE9423500E8938F /* luasocket.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D981398838D00AB0420 /* luasocket.c */; };
+		EB9EE1A61BE9423500E8938F /* mime.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D9B1398838D00AB0420 /* mime.c */; };
+		EB9EE1A71BE9423500E8938F /* options.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D9D1398838D00AB0420 /* options.c */; };
+		EB9EE1A81BE9423500E8938F /* select.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06D9F1398838D00AB0420 /* select.c */; };
+		EB9EE1A91BE9423500E8938F /* tcp.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06DA21398838D00AB0420 /* tcp.c */; };
+		EB9EE1AA1BE9423500E8938F /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06DA41398838D00AB0420 /* timeout.c */; };
+		EB9EE1AB1BE9423500E8938F /* udp.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06DA71398838D00AB0420 /* udp.c */; };
+		EB9EE1AC1BE9423500E8938F /* unix.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06DA91398838D00AB0420 /* unix.c */; };
+		EB9EE1AD1BE9423500E8938F /* usocket.c in Sources */ = {isa = PBXBuildFile; fileRef = CDD06DAC1398838D00AB0420 /* usocket.c */; };
+		EB9EE1AE1BE9423500E8938F /* AKU-luaext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD06E521398B5A500AB0420 /* AKU-luaext.cpp */; };
+		EB9EE1AF1BE9423500E8938F /* lfs.c in Sources */ = {isa = PBXBuildFile; fileRef = E9940D6514B7A217006465CC /* lfs.c */; };
+		EB9EE1B01BE9423500E8938F /* MOAICoroutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D6C14B7A414006465CC /* MOAICoroutine.cpp */; };
+		EB9EE1B11BE9423500E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
+		EB9EE1B21BE9423500E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
+		EB9EE1B31BE9423500E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
+		EB9EE1BB1BE9424500E8938F /* crc32.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEBA14725714009C20E5 /* crc32.h */; };
+		EB9EE1BC1BE9424500E8938F /* deflate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEBC14725714009C20E5 /* deflate.h */; };
+		EB9EE1BD1BE9424500E8938F /* inffast.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC014725714009C20E5 /* inffast.h */; };
+		EB9EE1BE1BE9424500E8938F /* inffixed.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC114725714009C20E5 /* inffixed.h */; };
+		EB9EE1BF1BE9424500E8938F /* inflate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC314725714009C20E5 /* inflate.h */; };
+		EB9EE1C01BE9424500E8938F /* inftrees.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC514725714009C20E5 /* inftrees.h */; };
+		EB9EE1C11BE9424500E8938F /* trees.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC714725714009C20E5 /* trees.h */; };
+		EB9EE1C21BE9424500E8938F /* zconf.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AEC914725714009C20E5 /* zconf.h */; };
+		EB9EE1C31BE9424500E8938F /* zlib.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AECA14725714009C20E5 /* zlib.h */; };
+		EB9EE1C41BE9424500E8938F /* zutil.h in Headers */ = {isa = PBXBuildFile; fileRef = CD04AECC14725714009C20E5 /* zutil.h */; };
+		EB9EE1C51BE9424500E8938F /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC3155B4EE300BD5BB1 /* pch.h */; };
+		EB9EE1C61BE9424500E8938F /* zl_mutex.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC5155B4EE300BD5BB1 /* zl_mutex.h */; };
+		EB9EE1C71BE9424500E8938F /* zl_replace_locale.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC6155B4EE300BD5BB1 /* zl_replace_locale.h */; };
+		EB9EE1C81BE9424500E8938F /* zl_replace_new_delete.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC7155B4EE300BD5BB1 /* zl_replace_new_delete.h */; };
+		EB9EE1C91BE9424500E8938F /* zl_replace_stdio.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC8155B4EE300BD5BB1 /* zl_replace_stdio.h */; };
+		EB9EE1CA1BE9424500E8938F /* zl_replace_stdlib.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAC9155B4EE300BD5BB1 /* zl_replace_stdlib.h */; };
+		EB9EE1CB1BE9424500E8938F /* zl_replace.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EACA155B4EE300BD5BB1 /* zl_replace.h */; };
+		EB9EE1CC1BE9424500E8938F /* zl_util.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EACC155B4EE300BD5BB1 /* zl_util.h */; };
+		EB9EE1CD1BE9424500E8938F /* ZLDirectoryItr.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAD2155B4EE300BD5BB1 /* ZLDirectoryItr.h */; };
+		EB9EE1CE1BE9424500E8938F /* ZLFile.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAD4155B4EE300BD5BB1 /* ZLFile.h */; };
+		EB9EE1CF1BE9424500E8938F /* ZLFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAD6155B4EE300BD5BB1 /* ZLFileSystem.h */; };
+		EB9EE1D01BE9424500E8938F /* ZLVirtualPath.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EAD8155B4EE300BD5BB1 /* ZLVirtualPath.h */; };
+		EB9EE1D11BE9424500E8938F /* ZLZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EADA155B4EE300BD5BB1 /* ZLZipArchive.h */; };
+		EB9EE1D21BE9424500E8938F /* ZLZipStream.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD2EADC155B4EE300BD5BB1 /* ZLZipStream.h */; };
+		EB9EE1D31BE9424500E8938F /* zlcore.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE8A7B7155E413100C2DFF5 /* zlcore.h */; };
+		EB9EE1D41BE9424500E8938F /* MOAIMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D64916D8021D00C172D2 /* MOAIMath.h */; };
+		EB9EE1D51BE9424500E8938F /* MOAIFrameBufferTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = DD80D67116D8025000C172D2 /* MOAIFrameBufferTexture.h */; };
+		EB9EE1D71BE9424500E8938F /* adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB714725714009C20E5 /* adler32.c */; };
+		EB9EE1D81BE9424500E8938F /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB814725714009C20E5 /* compress.c */; };
+		EB9EE1D91BE9424500E8938F /* crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEB914725714009C20E5 /* crc32.c */; };
+		EB9EE1DA1BE9424500E8938F /* deflate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBB14725714009C20E5 /* deflate.c */; };
+		EB9EE1DB1BE9424500E8938F /* gzio.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBD14725714009C20E5 /* gzio.c */; };
+		EB9EE1DC1BE9424500E8938F /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBE14725714009C20E5 /* infback.c */; };
+		EB9EE1DD1BE9424500E8938F /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEBF14725714009C20E5 /* inffast.c */; };
+		EB9EE1DE1BE9424500E8938F /* inflate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC214725714009C20E5 /* inflate.c */; };
+		EB9EE1DF1BE9424500E8938F /* inftrees.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC414725714009C20E5 /* inftrees.c */; };
+		EB9EE1E01BE9424500E8938F /* trees.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC614725714009C20E5 /* trees.c */; };
+		EB9EE1E11BE9424500E8938F /* uncompr.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AEC814725714009C20E5 /* uncompr.c */; };
+		EB9EE1E21BE9424500E8938F /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = CD04AECB14725714009C20E5 /* zutil.c */; };
+		EB9EE1E31BE9424500E8938F /* zl_mutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAC4155B4EE300BD5BB1 /* zl_mutex.cpp */; };
+		EB9EE1E41BE9424500E8938F /* zl_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EACB155B4EE300BD5BB1 /* zl_util.cpp */; };
+		EB9EE1E51BE9424500E8938F /* zl_vfscanf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EACD155B4EE300BD5BB1 /* zl_vfscanf.cpp */; };
+		EB9EE1E61BE9424500E8938F /* zlcore-pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EACE155B4EE300BD5BB1 /* zlcore-pch.cpp */; };
+		EB9EE1E71BE9424500E8938F /* ZLDirectoryItr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAD1155B4EE300BD5BB1 /* ZLDirectoryItr.cpp */; };
+		EB9EE1E81BE9424500E8938F /* ZLFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAD3155B4EE300BD5BB1 /* ZLFile.cpp */; };
+		EB9EE1E91BE9424500E8938F /* ZLFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAD5155B4EE300BD5BB1 /* ZLFileSystem.cpp */; };
+		EB9EE1EA1BE9424500E8938F /* ZLVirtualPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAD7155B4EE300BD5BB1 /* ZLVirtualPath.cpp */; };
+		EB9EE1EB1BE9424500E8938F /* ZLZipArchive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EAD9155B4EE300BD5BB1 /* ZLZipArchive.cpp */; };
+		EB9EE1EC1BE9424500E8938F /* ZLZipStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD2EADB155B4EE300BD5BB1 /* ZLZipStream.cpp */; };
+		EB9EE1ED1BE9424500E8938F /* zlcore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDE8A7B6155E413100C2DFF5 /* zlcore.cpp */; };
+		EB9EE1EE1BE9424500E8938F /* MOAIMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D64816D8021D00C172D2 /* MOAIMath.cpp */; };
+		EB9EE1EF1BE9424500E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
+		EB9EE1F01BE9424500E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
 		EBC495FA184D21840059FBDE /* MOAITextRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B45A8BEA1829A95C00D2B255 /* MOAITextRenderer.cpp */; };
 		EBC495FB184D21880059FBDE /* MOAITextRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = B45A8BEB1829A95C00D2B255 /* MOAITextRenderer.h */; };
 		F00D616E18C00F1E00625DA9 /* sha1_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9691846ACCF0031F295 /* sha1_one.c */; };
@@ -3322,6 +4409,10 @@
 		EB70434318761FDE0057E450 /* MOAIEaseExponentialInOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIEaseExponentialInOut.h; sourceTree = "<group>"; };
 		EB92A50616B6671000FC326E /* MOAITakeCameraListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MOAITakeCameraListener.h; path = "moaiext-iphone/MOAITakeCameraListener.h"; sourceTree = "<group>"; };
 		EB92A50716B6671000FC326E /* MOAITakeCameraListener.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAITakeCameraListener.mm; path = "moaiext-iphone/MOAITakeCameraListener.mm"; sourceTree = "<group>"; };
+		EB9EE00B1BE9421B00E8938F /* liblibmoai-tvos.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB9EE1851BE9422800E8938F /* liblibmoai-tvos-3rdparty.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-3rdparty.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB9EE1B81BE9423500E8938F /* liblibmoai-tvos-luaext.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-luaext.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB9EE1F51BE9424500E8938F /* liblibmoai-tvos-zlcore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-zlcore.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F055A9491846ABF40031F295 /* sha.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sha.h; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha.h"; sourceTree = "<group>"; };
 		F055A9641846ACA90031F295 /* sha_locl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sha_locl.h; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha_locl.h"; sourceTree = "<group>"; };
 		F055A9661846ACCF0031F295 /* sha_dgst.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sha_dgst.c; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha_dgst.c"; sourceTree = "<group>"; };
@@ -3392,6 +4483,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CDD06D82139882D900AB0420 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE0071BE9421B00E8938F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1811BE9422800E8938F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1B41BE9423500E8938F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1F11BE9424500E8938F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3910,6 +5029,10 @@
 				CDD06D87139882D900AB0420 /* libmoai-osx-luaext.a */,
 				CD04ACB414725568009C20E5 /* libmoai-ios-zlcore.a */,
 				CD04AE7F1472557F009C20E5 /* libmoai-osx-zlcore.a */,
+				EB9EE00B1BE9421B00E8938F /* liblibmoai-tvos.a */,
+				EB9EE1851BE9422800E8938F /* liblibmoai-tvos-3rdparty.a */,
+				EB9EE1B81BE9423500E8938F /* liblibmoai-tvos-luaext.a */,
+				EB9EE1F51BE9424500E8938F /* liblibmoai-tvos-zlcore.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -6436,6 +7559,555 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EB9EDD981BE9421B00E8938F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EDD991BE9421B00E8938F /* md5_locl.h in Headers */,
+				EB9EDD9A1BE9421B00E8938F /* md5.h in Headers */,
+				EB9EDD9B1BE9421B00E8938F /* ldo.h in Headers */,
+				EB9EDD9C1BE9421B00E8938F /* sha_locl.h in Headers */,
+				EB9EDD9D1BE9421B00E8938F /* sha.h in Headers */,
+				EB9EDD9E1BE9421B00E8938F /* AKU.h in Headers */,
+				EB9EDD9F1BE9421B00E8938F /* USRhombus.h in Headers */,
+				EB9EDDA01BE9421B00E8938F /* pch.h in Headers */,
+				EB9EDDA11BE9421B00E8938F /* MOAIAction.h in Headers */,
+				EB9EDDA21BE9421B00E8938F /* MOAIAnim.h in Headers */,
+				EB9EDDA31BE9421B00E8938F /* MOAIEaseExponentialInOut.h in Headers */,
+				EB9EDDA41BE9421B00E8938F /* MOAIAnimCurve.h in Headers */,
+				EB9EDDA51BE9421B00E8938F /* MOAIBlocker.h in Headers */,
+				EB9EDDA61BE9421B00E8938F /* MOAIBox2DArbiter.h in Headers */,
+				EB9EDDA71BE9421B00E8938F /* MOAIBox2DBody.h in Headers */,
+				EB9EDDA81BE9421B00E8938F /* MOAIBox2DDebugDraw.h in Headers */,
+				EB9EDDA91BE9421B00E8938F /* MOAIBox2DFixture.h in Headers */,
+				EB9EDDAA1BE9421B00E8938F /* MOAIBox2DJoint.h in Headers */,
+				EB9EDDAB1BE9421B00E8938F /* MOAIBox2DWorld.h in Headers */,
+				EB9EDDAC1BE9421B00E8938F /* MOAIButtonSensor.h in Headers */,
+				EB9EDDAD1BE9421B00E8938F /* MOAIColor.h in Headers */,
+				EB9EDDAE1BE9421B00E8938F /* MOAICompassSensor.h in Headers */,
+				EB9EDDAF1BE9421B00E8938F /* moaicore.h in Headers */,
+				EB9EDDB01BE9421B00E8938F /* MOAICp.h in Headers */,
+				EB9EDDB11BE9421B00E8938F /* MOAIEaseBackInOut.h in Headers */,
+				EB9EDDB21BE9421B00E8938F /* MOAIEaseSimpleIn.h in Headers */,
+				EB9EDDB31BE9421B00E8938F /* MOAICpArbiter.h in Headers */,
+				EB9EDDB41BE9421B00E8938F /* MOAICpBody.h in Headers */,
+				EB9EDDB51BE9421B00E8938F /* MOAIEaseBackBase.h in Headers */,
+				EB9EDDB61BE9421B00E8938F /* MOAIEaseSineIn.h in Headers */,
+				EB9EDDB71BE9421B00E8938F /* MOAICpConstraint.h in Headers */,
+				EB9EDDB81BE9421B00E8938F /* MOAICpDebugDraw.h in Headers */,
+				EB9EDDB91BE9421B00E8938F /* MOAICpShape.h in Headers */,
+				EB9EDDBA1BE9421B00E8938F /* MOAICpSpace.h in Headers */,
+				EB9EDDBB1BE9421B00E8938F /* MOAIDataBuffer.h in Headers */,
+				EB9EDDBC1BE9421B00E8938F /* MOAIDebugLines.h in Headers */,
+				EB9EDDBD1BE9421B00E8938F /* MOAIDeck.h in Headers */,
+				EB9EDDBE1BE9421B00E8938F /* MOAIEaseDriver.h in Headers */,
+				EB9EDDBF1BE9421B00E8938F /* MOAIEaseType.h in Headers */,
+				EB9EDDC01BE9421B00E8938F /* MOAIFont.h in Headers */,
+				EB9EDDC11BE9421B00E8938F /* MOAIGfxQuad2D.h in Headers */,
+				EB9EDDC21BE9421B00E8938F /* MOAIGfxQuadDeck2D.h in Headers */,
+				EB9EDDC31BE9421B00E8938F /* MOAIGfxQuadListDeck2D.h in Headers */,
+				EB9EDDC41BE9421B00E8938F /* MOAIGrid.h in Headers */,
+				EB9EDDC51BE9421B00E8938F /* MOAIIndexBuffer.h in Headers */,
+				EB9EDDC61BE9421B00E8938F /* MOAIInputDevice.h in Headers */,
+				EB9EDDC71BE9421B00E8938F /* MOAIInputMgr.h in Headers */,
+				EB9EDDC81BE9421B00E8938F /* MOAIJoystickSensor.h in Headers */,
+				EB9EDDC91BE9421B00E8938F /* MOAIKeyboardSensor.h in Headers */,
+				EB9EDDCA1BE9421B00E8938F /* MOAILayoutFrame.h in Headers */,
+				EB9EDDCB1BE9421B00E8938F /* MOAILocationSensor.h in Headers */,
+				EB9EDDCC1BE9421B00E8938F /* MOAILogMessages.h in Headers */,
+				EB9EDDCD1BE9421B00E8938F /* MOAIEaseElasticInOut.h in Headers */,
+				EB9EDDCE1BE9421B00E8938F /* MOAILogMgr.h in Headers */,
+				EB9EDDCF1BE9421B00E8938F /* MOAIMesh.h in Headers */,
+				EB9EDDD01BE9421B00E8938F /* MOAINode.h in Headers */,
+				EB9EDDD11BE9421B00E8938F /* MOAINodeMgr.h in Headers */,
+				EB9EDDD21BE9421B00E8938F /* MOAIParser.h in Headers */,
+				EB9EDDD31BE9421B00E8938F /* MOAIPartition.h in Headers */,
+				EB9EDDD41BE9421B00E8938F /* MOAIPartitionCell.h in Headers */,
+				EB9EDDD51BE9421B00E8938F /* MOAIPartitionLevel.h in Headers */,
+				EB9EDDD61BE9421B00E8938F /* MOAIPointerSensor.h in Headers */,
+				EB9EDDD71BE9421B00E8938F /* MOAIProp.h in Headers */,
+				EB9EDDD81BE9421B00E8938F /* MOAIScriptNode.h in Headers */,
+				EB9EDDD91BE9421B00E8938F /* MOAISensor.h in Headers */,
+				EB9EDDDA1BE9421B00E8938F /* MOAISerializer.h in Headers */,
+				EB9EDDDB1BE9421B00E8938F /* MOAIShader.h in Headers */,
+				EB9EDDDC1BE9421B00E8938F /* MOAISim.h in Headers */,
+				EB9EDDDD1BE9421B00E8938F /* MOAIEaseBackOut.h in Headers */,
+				EB9EDDDE1BE9421B00E8938F /* MOAIStretchPatch2D.h in Headers */,
+				EB9EDDDF1BE9421B00E8938F /* MOAICCParticle.h in Headers */,
+				EB9EDDE01BE9421B00E8938F /* MOAISurfaceDeck2D.h in Headers */,
+				EB9EDDE11BE9421B00E8938F /* MOAISurfaceSampler2D.h in Headers */,
+				EB9EDDE21BE9421B00E8938F /* MOAITextBox.h in Headers */,
+				EB9EDDE31BE9421B00E8938F /* MOAITexture.h in Headers */,
+				EB9EDDE41BE9421B00E8938F /* MOAIEase.h in Headers */,
+				EB9EDDE51BE9421B00E8938F /* MOAITileDeck2D.h in Headers */,
+				EB9EDDE61BE9421B00E8938F /* MOAITimer.h in Headers */,
+				EB9EDDE71BE9421B00E8938F /* MOAITouchSensor.h in Headers */,
+				EB9EDDE81BE9421B00E8938F /* MOAITransform.h in Headers */,
+				EB9EDDE91BE9421B00E8938F /* MOAITransformBase.h in Headers */,
+				EB9EDDEA1BE9421B00E8938F /* MOAIVertexBuffer.h in Headers */,
+				EB9EDDEB1BE9421B00E8938F /* MOAIVertexFormat.h in Headers */,
+				EB9EDDEC1BE9421B00E8938F /* MOAIViewport.h in Headers */,
+				EB9EDDED1BE9421B00E8938F /* MOAIXmlParser.h in Headers */,
+				EB9EDDEE1BE9421B00E8938F /* pch.h in Headers */,
+				EB9EDDEF1BE9421B00E8938F /* pch.h in Headers */,
+				EB9EDDF01BE9421B00E8938F /* STLArray.h in Headers */,
+				EB9EDDF11BE9421B00E8938F /* STLIteration.h in Headers */,
+				EB9EDDF21BE9421B00E8938F /* STLList.h in Headers */,
+				EB9EDDF31BE9421B00E8938F /* STLMap.h in Headers */,
+				EB9EDDF41BE9421B00E8938F /* STLSet.h in Headers */,
+				EB9EDDF51BE9421B00E8938F /* STLString.h in Headers */,
+				EB9EDDF61BE9421B00E8938F /* USAccessors.h in Headers */,
+				EB9EDDF71BE9421B00E8938F /* USByteStream.h in Headers */,
+				EB9EDDF81BE9421B00E8938F /* USDeviceTime.h in Headers */,
+				EB9EDDF91BE9421B00E8938F /* USDirectoryItr.h in Headers */,
+				EB9EDDFA1BE9421B00E8938F /* USFactory.h in Headers */,
+				EB9EDDFB1BE9421B00E8938F /* USFileStream.h in Headers */,
+				EB9EDDFC1BE9421B00E8938F /* USFileSys.h in Headers */,
+				EB9EDDFD1BE9421B00E8938F /* USFloat.h in Headers */,
+				EB9EDDFE1BE9421B00E8938F /* USLeanArray.h in Headers */,
+				EB9EDDFF1BE9421B00E8938F /* MOAIEaseExponentialOut.h in Headers */,
+				EB9EDE001BE9421B00E8938F /* USLeanList.h in Headers */,
+				EB9EDE011BE9421B00E8938F /* USLeanPool.h in Headers */,
+				EB9EDE021BE9421B00E8938F /* USLeanStack.h in Headers */,
+				EB9EDE031BE9421B00E8938F /* USList.h in Headers */,
+				EB9EDE041BE9421B00E8938F /* uslscore.h in Headers */,
+				EB9EDE051BE9421B00E8938F /* MOAIEaseCustom.h in Headers */,
+				EB9EDE061BE9421B00E8938F /* USMemStream.h in Headers */,
+				EB9EDE071BE9421B00E8938F /* USRect.h in Headers */,
+				EB9EDE081BE9421B00E8938F /* USStream.h in Headers */,
+				EB9EDE091BE9421B00E8938F /* USTypeID.h in Headers */,
+				EB9EDE0A1BE9421B00E8938F /* USUnion.h in Headers */,
+				EB9EDE0B1BE9421B00E8938F /* USVec2D.h in Headers */,
+				EB9EDE0C1BE9421B00E8938F /* USVec3D.h in Headers */,
+				EB9EDE0D1BE9421B00E8938F /* USZip.h in Headers */,
+				EB9EDE0E1BE9421B00E8938F /* USZipFile.h in Headers */,
+				EB9EDE0F1BE9421B00E8938F /* AKU-iphone.h in Headers */,
+				EB9EDE101BE9421B00E8938F /* MOAIEventSource.h in Headers */,
+				EB9EDE111BE9421B00E8938F /* MOAIImage.h in Headers */,
+				EB9EDE121BE9421B00E8938F /* MOAIEaseSineInOut.h in Headers */,
+				EB9EDE131BE9421B00E8938F /* MOAICameraAnchor2D.h in Headers */,
+				EB9EDE141BE9421B00E8938F /* MOAICameraFitter2D.h in Headers */,
+				EB9EDE151BE9421B00E8938F /* MOAIDeckRemapper.h in Headers */,
+				EB9EDE161BE9421B00E8938F /* moaiext-iphone.h in Headers */,
+				EB9EDE171BE9421B00E8938F /* MOAIEaseExponentialIn.h in Headers */,
+				EB9EDE181BE9421B00E8938F /* NSArray+MOAILib.h in Headers */,
+				EB9EDE191BE9421B00E8938F /* NSData+MOAILib.h in Headers */,
+				EB9EDE1A1BE9421B00E8938F /* MOAIEaseLinear.h in Headers */,
+				EB9EDE1B1BE9421B00E8938F /* NSDate+MOAILib.h in Headers */,
+				EB9EDE1C1BE9421B00E8938F /* NSDictionary+MOAILib.h in Headers */,
+				EB9EDE1D1BE9421B00E8938F /* NSError+MOAILib.h in Headers */,
+				EB9EDE1E1BE9421B00E8938F /* NSNumber+MOAILib.h in Headers */,
+				EB9EDE1F1BE9421B00E8938F /* NSObject+MOAILib.h in Headers */,
+				EB9EDE201BE9421B00E8938F /* NSString+MOAILib.h in Headers */,
+				EB9EDE211BE9421B00E8938F /* MOAIFileSystem.h in Headers */,
+				EB9EDE221BE9421B00E8938F /* USLog.h in Headers */,
+				EB9EDE231BE9421B00E8938F /* MOAIJsonParser.h in Headers */,
+				EB9EDE241BE9421B00E8938F /* MOAIEnvironment.h in Headers */,
+				EB9EDE251BE9421B00E8938F /* MOAIActionMgr.h in Headers */,
+				EB9EDE261BE9421B00E8938F /* MOAIMotionSensor.h in Headers */,
+				EB9EDE271BE9421B00E8938F /* MOAIDraw.h in Headers */,
+				EB9EDE281BE9421B00E8938F /* MOAIGfxDevice.h in Headers */,
+				EB9EDE291BE9421B00E8938F /* MOAIGlyph.h in Headers */,
+				EB9EDE2A1BE9421B00E8938F /* MOAIGridSpace.h in Headers */,
+				EB9EDE2B1BE9421B00E8938F /* MOAIPvrHeader.h in Headers */,
+				EB9EDE2C1BE9421B00E8938F /* MOAIQuadBrush.h in Headers */,
+				EB9EDE2D1BE9421B00E8938F /* MOAIShaderMgr.h in Headers */,
+				EB9EDE2E1BE9421B00E8938F /* MOAITileFlags.h in Headers */,
+				EB9EDE2F1BE9421B00E8938F /* MOAIVertexFormatMgr.h in Headers */,
+				EB9EDE301BE9421B00E8938F /* MOAIBlendMode.h in Headers */,
+				EB9EDE311BE9421B00E8938F /* MOAIFrameBuffer.h in Headers */,
+				EB9EDE321BE9421B00E8938F /* MOAIDeck2DShader-fsh.h in Headers */,
+				EB9EDE331BE9421B00E8938F /* MOAIDeck2DShader-vsh.h in Headers */,
+				EB9EDE341BE9421B00E8938F /* MOAIFontShader-fsh.h in Headers */,
+				EB9EDE351BE9421B00E8938F /* MOAIFontShader-vsh.h in Headers */,
+				EB9EDE361BE9421B00E8938F /* MOAILineShader-fsh.h in Headers */,
+				EB9EDE371BE9421B00E8938F /* MOAILineShader-vsh.h in Headers */,
+				EB9EDE381BE9421B00E8938F /* MOAIPartitionResultBuffer.h in Headers */,
+				EB9EDE391BE9421B00E8938F /* MOAIPartitionResultMgr.h in Headers */,
+				EB9EDE3A1BE9421B00E8938F /* MOAIEaseSineOut.h in Headers */,
+				EB9EDE3B1BE9421B00E8938F /* MOAIScriptDeck.h in Headers */,
+				EB9EDE3C1BE9421B00E8938F /* MOAIGfxResource.h in Headers */,
+				EB9EDE3D1BE9421B00E8938F /* MOAIBox2DDistanceJoint.h in Headers */,
+				EB9EDE3E1BE9421B00E8938F /* MOAIBox2DFrictionJoint.h in Headers */,
+				EB9EDE3F1BE9421B00E8938F /* MOAIBox2DGearJoint.h in Headers */,
+				EB9EDE401BE9421B00E8938F /* MOAIBox2DMouseJoint.h in Headers */,
+				EB9EDE411BE9421B00E8938F /* MOAIBox2DPrismaticJoint.h in Headers */,
+				EB9EDE421BE9421B00E8938F /* MOAICCParticleSystem.h in Headers */,
+				EB9EDE431BE9421B00E8938F /* MOAIBox2DPulleyJoint.h in Headers */,
+				EB9EDE441BE9421B00E8938F /* MOAIBox2DRevoluteJoint.h in Headers */,
+				EB9EDE451BE9421B00E8938F /* MOAIBox2DWeldJoint.h in Headers */,
+				EB9EDE461BE9421B00E8938F /* MOAIAttrOp.h in Headers */,
+				EB9EDE471BE9421B00E8938F /* MOAIBox2DRopeJoint.h in Headers */,
+				EB9EDE481BE9421B00E8938F /* MOAIBox2DWheelJoint.h in Headers */,
+				EB9EDE491BE9421B00E8938F /* MOAIEaseElasticBase.h in Headers */,
+				EB9EDE4A1BE9421B00E8938F /* MOAICanary.h in Headers */,
+				EB9EDE4B1BE9421B00E8938F /* MOAIDeserializer.h in Headers */,
+				EB9EDE4C1BE9421B00E8938F /* MOAIGlobals.h in Headers */,
+				EB9EDE4D1BE9421B00E8938F /* MOAILua.h in Headers */,
+				EB9EDE4E1BE9421B00E8938F /* MOAILuaObject-impl.h in Headers */,
+				EB9EDE4F1BE9421B00E8938F /* MOAILuaObject.h in Headers */,
+				EB9EDE501BE9421B00E8938F /* MOAIEaseElasticOut.h in Headers */,
+				EB9EDE511BE9421B00E8938F /* MOAILuaRef.h in Headers */,
+				EB9EDE521BE9421B00E8938F /* MOAIEaseSimpleBase.h in Headers */,
+				EB9EDE531BE9421B00E8938F /* MOAILuaRuntime.h in Headers */,
+				EB9EDE541BE9421B00E8938F /* MOAILuaSharedPtr.h in Headers */,
+				EB9EDE551BE9421B00E8938F /* MOAILuaState-impl.h in Headers */,
+				EB9EDE561BE9421B00E8938F /* MOAILuaState.h in Headers */,
+				EB9EDE571BE9421B00E8938F /* MOAILuaStateHandle.h in Headers */,
+				EB9EDE581BE9421B00E8938F /* MOAIObject.h in Headers */,
+				EB9EDE591BE9421B00E8938F /* MOAIRtti.h in Headers */,
+				EB9EDE5A1BE9421B00E8938F /* MOAISerializerBase.h in Headers */,
+				EB9EDE5B1BE9421B00E8938F /* MOAISharedPtr.h in Headers */,
+				EB9EDE5C1BE9421B00E8938F /* MOAIWeakPtr.h in Headers */,
+				EB9EDE5D1BE9421B00E8938F /* MOAIWheelSensor.h in Headers */,
+				EB9EDE5E1BE9421B00E8938F /* MOAIGridPathGraph.h in Headers */,
+				EB9EDE5F1BE9421B00E8938F /* MOAIPathFinder.h in Headers */,
+				EB9EDE601BE9421B00E8938F /* MOAIPathGraph.h in Headers */,
+				EB9EDE611BE9421B00E8938F /* MOAIPathTerrainDeck.h in Headers */,
+				EB9EDE621BE9421B00E8938F /* MOAIEaseElasticIn.h in Headers */,
+				EB9EDE631BE9421B00E8938F /* USAdapterInfo.h in Headers */,
+				EB9EDE641BE9421B00E8938F /* USAffine2D.h in Headers */,
+				EB9EDE651BE9421B00E8938F /* USBinarySearch.h in Headers */,
+				EB9EDE661BE9421B00E8938F /* USBox.h in Headers */,
+				EB9EDE671BE9421B00E8938F /* USCgt.h in Headers */,
+				EB9EDE681BE9421B00E8938F /* USColor.h in Headers */,
+				EB9EDE691BE9421B00E8938F /* USCurve.h in Headers */,
+				EB9EDE6A1BE9421B00E8938F /* USDelegate.h in Headers */,
+				EB9EDE6B1BE9421B00E8938F /* USDistance.h in Headers */,
+				EB9EDE6C1BE9421B00E8938F /* USHexDump.h in Headers */,
+				EB9EDE6D1BE9421B00E8938F /* USInterpolate.h in Headers */,
+				EB9EDE6E1BE9421B00E8938F /* USIntersect.h in Headers */,
+				EB9EDE6F1BE9421B00E8938F /* USMathConsts.h in Headers */,
+				EB9EDE701BE9421B00E8938F /* USMatrix.h in Headers */,
+				EB9EDE711BE9421B00E8938F /* USMatrix3x3.h in Headers */,
+				EB9EDE721BE9421B00E8938F /* USMatrix4x4.h in Headers */,
+				EB9EDE731BE9421B00E8938F /* USMercator.h in Headers */,
+				EB9EDE741BE9421B00E8938F /* USParser.h in Headers */,
+				EB9EDE751BE9421B00E8938F /* USPlane.h in Headers */,
+				EB9EDE761BE9421B00E8938F /* USPolar.h in Headers */,
+				EB9EDE771BE9421B00E8938F /* USPolygon2D.h in Headers */,
+				EB9EDE781BE9421B00E8938F /* USPolyScanner.h in Headers */,
+				EB9EDE791BE9421B00E8938F /* USQuad.h in Headers */,
+				EB9EDE7A1BE9421B00E8938F /* USQuadCoord.h in Headers */,
+				EB9EDE7B1BE9421B00E8938F /* USRadixSort16.h in Headers */,
+				EB9EDE7C1BE9421B00E8938F /* USRadixSort32.h in Headers */,
+				EB9EDE7D1BE9421B00E8938F /* USSurface2D.h in Headers */,
+				EB9EDE7E1BE9421B00E8938F /* USSyntaxNode.h in Headers */,
+				EB9EDE7F1BE9421B00E8938F /* USSyntaxScanner.h in Headers */,
+				EB9EDE801BE9421B00E8938F /* USTrig.h in Headers */,
+				EB9EDE811BE9421B00E8938F /* USTypedPtr.h in Headers */,
+				EB9EDE821BE9421B00E8938F /* USXmlReader.h in Headers */,
+				EB9EDE831BE9421B00E8938F /* MOAIAudioSampler.h in Headers */,
+				EB9EDE841BE9421B00E8938F /* MOAIHttpTaskNaCl.h in Headers */,
+				EB9EDE851BE9421B00E8938F /* MOAIUrlMgrNaCl.h in Headers */,
+				EB9EDE861BE9421B00E8938F /* MOAIRenderable.h in Headers */,
+				EB9EDE871BE9421B00E8938F /* MOAIRenderMgr.h in Headers */,
+				EB9EDE881BE9421B00E8938F /* USUnique.h in Headers */,
+				EB9EDE891BE9421B00E8938F /* MOAICrittercismIOS.h in Headers */,
+				EB9EDE8A1BE9421B00E8938F /* MOAINotificationsIOS.h in Headers */,
+				EB9EDE8B1BE9421B00E8938F /* MOAIAppIOS.h in Headers */,
+				EB9EDE8C1BE9421B00E8938F /* MOAIDialogIOS.h in Headers */,
+				EB9EDE8D1BE9421B00E8938F /* MOAIWebViewDelegate.h in Headers */,
+				EB9EDE8E1BE9421B00E8938F /* MOAIGameCenterIOS.h in Headers */,
+				EB9EDE8F1BE9421B00E8938F /* MOAIEaseSimpleOut.h in Headers */,
+				EB9EDE901BE9421B00E8938F /* MOAIWebViewIOS.h in Headers */,
+				EB9EDE911BE9421B00E8938F /* MOAIKeyboardIOS.h in Headers */,
+				EB9EDE921BE9421B00E8938F /* AKU-adcolony.h in Headers */,
+				EB9EDE931BE9421B00E8938F /* AKU-chartboost.h in Headers */,
+				EB9EDE941BE9421B00E8938F /* MOAIScissorRect.h in Headers */,
+				EB9EDE951BE9421B00E8938F /* MOAIFoo.h in Headers */,
+				EB9EDE961BE9421B00E8938F /* MOAIFooMgr.h in Headers */,
+				EB9EDE971BE9421B00E8938F /* MOAITextBundle.h in Headers */,
+				EB9EDE981BE9421B00E8938F /* MOAIBoundsDeck.h in Headers */,
+				EB9EDE991BE9421B00E8938F /* fullluasocket.h in Headers */,
+				EB9EDE9A1BE9421B00E8938F /* MOAIEaseSimpleInOut.h in Headers */,
+				EB9EDE9B1BE9421B00E8938F /* luasocketscripts.h in Headers */,
+				EB9EDE9C1BE9421B00E8938F /* USQuaternion.h in Headers */,
+				EB9EDE9D1BE9421B00E8938F /* MOAIAnimCurveBase.h in Headers */,
+				EB9EDE9E1BE9421B00E8938F /* MOAIAnimCurveQuat.h in Headers */,
+				EB9EDE9F1BE9421B00E8938F /* MOAIAnimCurveVec.h in Headers */,
+				EB9EDEA01BE9421B00E8938F /* MOAIDataBufferStream.h in Headers */,
+				EB9EDEA11BE9421B00E8938F /* MOAIStreamWriter.h in Headers */,
+				EB9EDEA21BE9421B00E8938F /* MOAIStreamReader.h in Headers */,
+				EB9EDEA31BE9421B00E8938F /* MOAIFileStream.h in Headers */,
+				EB9EDEA41BE9421B00E8938F /* MOAIStream.h in Headers */,
+				EB9EDEA51BE9421B00E8938F /* MOAIMemStream.h in Headers */,
+				EB9EDEA61BE9421B00E8938F /* USDeflateReader.h in Headers */,
+				EB9EDEA71BE9421B00E8938F /* USDeflateWriter.h in Headers */,
+				EB9EDEA81BE9421B00E8938F /* USStreamWriter.h in Headers */,
+				EB9EDEA91BE9421B00E8938F /* MOAIEaseBackIn.h in Headers */,
+				EB9EDEAA1BE9421B00E8938F /* USBase64Reader.h in Headers */,
+				EB9EDEAB1BE9421B00E8938F /* USBase64Writer.h in Headers */,
+				EB9EDEAC1BE9421B00E8938F /* USStreamReader.h in Headers */,
+				EB9EDEAD1BE9421B00E8938F /* USBase64Encoder.h in Headers */,
+				EB9EDEAE1BE9421B00E8938F /* MOAIGridDeck2D.h in Headers */,
+				EB9EDEAF1BE9421B00E8938F /* MOAIMoviePlayerIOS.h in Headers */,
+				EB9EDEB01BE9421B00E8938F /* MOAIHashWriter.h in Headers */,
+				EB9EDEB11BE9421B00E8938F /* USHexWriter.h in Headers */,
+				EB9EDEB21BE9421B00E8938F /* USHashWriterAdler32.h in Headers */,
+				EB9EDEB31BE9421B00E8938F /* USHashWriterCRC32.h in Headers */,
+				EB9EDEB41BE9421B00E8938F /* USHashWriterMD5.h in Headers */,
+				EB9EDEB51BE9421B00E8938F /* USHashWriterSHA1.h in Headers */,
+				EB9EDEB61BE9421B00E8938F /* USHashWriterSHA224.h in Headers */,
+				EB9EDEB71BE9421B00E8938F /* USHashWriterSHA256.h in Headers */,
+				EB9EDEB81BE9421B00E8938F /* USHashWriterSHA384.h in Headers */,
+				EB9EDEB91BE9421B00E8938F /* USHashWriterSHA512.h in Headers */,
+				EB9EDEBA1BE9421B00E8938F /* USHashWriterWhirlpool.h in Headers */,
+				EB9EDEBB1BE9421B00E8938F /* USHexReader.h in Headers */,
+				EB9EDEBC1BE9421B00E8938F /* USHashWriter.h in Headers */,
+				EB9EDEBD1BE9421B00E8938F /* MOAIDataIOTask.h in Headers */,
+				EB9EDEBE1BE9421B00E8938F /* MOAIThread_posix.h in Headers */,
+				EB9EDEBF1BE9421B00E8938F /* MOAIThread_win32.h in Headers */,
+				EB9EDEC01BE9421B00E8938F /* MOAIThread.h in Headers */,
+				EB9EDEC11BE9421B00E8938F /* MOAITask.h in Headers */,
+				EB9EDEC21BE9421B00E8938F /* MOAITaskQueue.h in Headers */,
+				EB9EDEC31BE9421B00E8938F /* MOAITaskSubscriber.h in Headers */,
+				EB9EDEC41BE9421B00E8938F /* MOAITaskThread.h in Headers */,
+				EB9EDEC51BE9421B00E8938F /* MOAIMutex_posix.h in Headers */,
+				EB9EDEC61BE9421B00E8938F /* MOAIMutex_win32.h in Headers */,
+				EB9EDEC71BE9421B00E8938F /* MOAIMutex.h in Headers */,
+				EB9EDEC81BE9421B00E8938F /* MOAITakeCameraListener.h in Headers */,
+				EB9EDEC91BE9421B00E8938F /* MOAIMath.h in Headers */,
+				EB9EDECA1BE9421B00E8938F /* MOAIFrameBufferTexture.h in Headers */,
+				EB9EDECB1BE9421B00E8938F /* MOAIAnimCurveCustom.h in Headers */,
+				EB9EDECC1BE9421B00E8938F /* MOAIFreeTypeFont.h in Headers */,
+				EB9EDECD1BE9421B00E8938F /* MOAITextRenderer.h in Headers */,
+				EB9EDECE1BE9421B00E8938F /* MOAITest_sample.h in Headers */,
+				EB9EDECF1BE9421B00E8938F /* MOAITest_USQuaternion.h in Headers */,
+				EB9EDED01BE9421B00E8938F /* MOAITest.h in Headers */,
+				EB9EDED11BE9421B00E8938F /* MOAITestKeywords.h in Headers */,
+				EB9EDED21BE9421B00E8938F /* MOAITestMgr.h in Headers */,
+				EB9EDED31BE9421B00E8938F /* AKU-test.h in Headers */,
+				EB9EDED41BE9421B00E8938F /* MOAIXmlWriter.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE00D1BE9422800E8938F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE00E1BE9422800E8938F /* cpConstraint.h in Headers */,
+				EB9EE00F1BE9422800E8938F /* cpDampedRotarySpring.h in Headers */,
+				EB9EE0101BE9422800E8938F /* cpDampedSpring.h in Headers */,
+				EB9EE0111BE9422800E8938F /* cpGearJoint.h in Headers */,
+				EB9EE0121BE9422800E8938F /* cpGrooveJoint.h in Headers */,
+				EB9EE0131BE9422800E8938F /* cpPinJoint.h in Headers */,
+				EB9EE0141BE9422800E8938F /* cpPivotJoint.h in Headers */,
+				EB9EE0151BE9422800E8938F /* cpRatchetJoint.h in Headers */,
+				EB9EE0161BE9422800E8938F /* cpRotaryLimitJoint.h in Headers */,
+				EB9EE0171BE9422800E8938F /* cpSimpleMotor.h in Headers */,
+				EB9EE0181BE9422800E8938F /* cpSlideJoint.h in Headers */,
+				EB9EE0191BE9422800E8938F /* util.h in Headers */,
+				EB9EE01A1BE9422800E8938F /* chipmunk_ffi.h in Headers */,
+				EB9EE01B1BE9422800E8938F /* chipmunk_private.h in Headers */,
+				EB9EE01C1BE9422800E8938F /* chipmunk_types.h in Headers */,
+				EB9EE01D1BE9422800E8938F /* chipmunk_unsafe.h in Headers */,
+				EB9EE01E1BE9422800E8938F /* chipmunk.h in Headers */,
+				EB9EE01F1BE9422800E8938F /* cpArbiter.h in Headers */,
+				EB9EE0201BE9422800E8938F /* cpArray.h in Headers */,
+				EB9EE0211BE9422800E8938F /* cpBB.h in Headers */,
+				EB9EE0221BE9422800E8938F /* cpBody.h in Headers */,
+				EB9EE0231BE9422800E8938F /* cpCollision.h in Headers */,
+				EB9EE0241BE9422800E8938F /* cpHashSet.h in Headers */,
+				EB9EE0251BE9422800E8938F /* cpPolyShape.h in Headers */,
+				EB9EE0261BE9422800E8938F /* cpShape.h in Headers */,
+				EB9EE0271BE9422800E8938F /* cpSpace.h in Headers */,
+				EB9EE0281BE9422800E8938F /* cpSpaceHash.h in Headers */,
+				EB9EE0291BE9422800E8938F /* cpVect.h in Headers */,
+				EB9EE02A1BE9422800E8938F /* prime.h in Headers */,
+				EB9EE02B1BE9422800E8938F /* utf8.h in Headers */,
+				EB9EE02C1BE9422800E8938F /* ascii.h in Headers */,
+				EB9EE02D1BE9422800E8938F /* asciitab.h in Headers */,
+				EB9EE02E1BE9422800E8938F /* expat.h in Headers */,
+				EB9EE02F1BE9422800E8938F /* expat_external.h in Headers */,
+				EB9EE0301BE9422800E8938F /* iasciitab.h in Headers */,
+				EB9EE0311BE9422800E8938F /* internal.h in Headers */,
+				EB9EE0321BE9422800E8938F /* latin1tab.h in Headers */,
+				EB9EE0331BE9422800E8938F /* macconfig.h in Headers */,
+				EB9EE0341BE9422800E8938F /* nametab.h in Headers */,
+				EB9EE0351BE9422800E8938F /* utf8tab.h in Headers */,
+				EB9EE0361BE9422800E8938F /* winconfig.h in Headers */,
+				EB9EE0371BE9422800E8938F /* xmlrole.h in Headers */,
+				EB9EE0381BE9422800E8938F /* xmltok.h in Headers */,
+				EB9EE0391BE9422800E8938F /* xmltok_impl.h in Headers */,
+				EB9EE03A1BE9422800E8938F /* sqlite3ext.h in Headers */,
+				EB9EE03B1BE9422800E8938F /* ft2build.h in Headers */,
+				EB9EE03C1BE9422800E8938F /* ftconfig.h in Headers */,
+				EB9EE03D1BE9422800E8938F /* ftheader.h in Headers */,
+				EB9EE03E1BE9422800E8938F /* ftmodule.h in Headers */,
+				EB9EE03F1BE9422800E8938F /* ftoption.h in Headers */,
+				EB9EE0401BE9422800E8938F /* ftstdlib.h in Headers */,
+				EB9EE0411BE9422800E8938F /* png.h in Headers */,
+				EB9EE0421BE9422800E8938F /* pngconf.h in Headers */,
+				EB9EE0431BE9422800E8938F /* pngpriv.h in Headers */,
+				EB9EE0441BE9422800E8938F /* tinyxml.h in Headers */,
+				EB9EE0451BE9422800E8938F /* MOAIISO8601DateFormatter.h in Headers */,
+				EB9EE0461BE9422800E8938F /* luasql.h in Headers */,
+				EB9EE0471BE9422800E8938F /* hashtable.h in Headers */,
+				EB9EE0481BE9422800E8938F /* jansson_config.h in Headers */,
+				EB9EE0491BE9422800E8938F /* jansson_private.h in Headers */,
+				EB9EE04A1BE9422800E8938F /* jansson.h in Headers */,
+				EB9EE04B1BE9422800E8938F /* strbuffer.h in Headers */,
+				EB9EE04C1BE9422800E8938F /* utf.h in Headers */,
+				EB9EE04D1BE9422800E8938F /* lapi.h in Headers */,
+				EB9EE04E1BE9422800E8938F /* lauxlib.h in Headers */,
+				EB9EE04F1BE9422800E8938F /* lcode.h in Headers */,
+				EB9EE0501BE9422800E8938F /* ldebug.h in Headers */,
+				EB9EE0511BE9422800E8938F /* ldo.h in Headers */,
+				EB9EE0521BE9422800E8938F /* lfunc.h in Headers */,
+				EB9EE0531BE9422800E8938F /* lgc.h in Headers */,
+				EB9EE0541BE9422800E8938F /* llex.h in Headers */,
+				EB9EE0551BE9422800E8938F /* llimits.h in Headers */,
+				EB9EE0561BE9422800E8938F /* lmem.h in Headers */,
+				EB9EE0571BE9422800E8938F /* lobject.h in Headers */,
+				EB9EE0581BE9422800E8938F /* lopcodes.h in Headers */,
+				EB9EE0591BE9422800E8938F /* lparser.h in Headers */,
+				EB9EE05A1BE9422800E8938F /* lstate.h in Headers */,
+				EB9EE05B1BE9422800E8938F /* sqlite3.h in Headers */,
+				EB9EE05C1BE9422800E8938F /* lstring.h in Headers */,
+				EB9EE05D1BE9422800E8938F /* ltable.h in Headers */,
+				EB9EE05E1BE9422800E8938F /* ltm.h in Headers */,
+				EB9EE05F1BE9422800E8938F /* lua.h in Headers */,
+				EB9EE0601BE9422800E8938F /* luaconf.h in Headers */,
+				EB9EE0611BE9422800E8938F /* lualib.h in Headers */,
+				EB9EE0621BE9422800E8938F /* lundump.h in Headers */,
+				EB9EE0631BE9422800E8938F /* lvm.h in Headers */,
+				EB9EE0641BE9422800E8938F /* lzio.h in Headers */,
+				EB9EE0651BE9422800E8938F /* jconfig.h in Headers */,
+				EB9EE0661BE9422800E8938F /* jdct.h in Headers */,
+				EB9EE0671BE9422800E8938F /* jerror.h in Headers */,
+				EB9EE0681BE9422800E8938F /* jinclude.h in Headers */,
+				EB9EE0691BE9422800E8938F /* jmemsys.h in Headers */,
+				EB9EE06A1BE9422800E8938F /* jmorecfg.h in Headers */,
+				EB9EE06B1BE9422800E8938F /* jpegint.h in Headers */,
+				EB9EE06C1BE9422800E8938F /* jpeglib.h in Headers */,
+				EB9EE06D1BE9422800E8938F /* jversion.h in Headers */,
+				EB9EE06E1BE9422800E8938F /* tlsf.h in Headers */,
+				EB9EE06F1BE9422800E8938F /* tlsfbits.h in Headers */,
+				EB9EE0701BE9422800E8938F /* Box2D.h in Headers */,
+				EB9EE0711BE9422800E8938F /* b2BroadPhase.h in Headers */,
+				EB9EE0721BE9422800E8938F /* b2Collision.h in Headers */,
+				EB9EE0731BE9422800E8938F /* b2Distance.h in Headers */,
+				EB9EE0741BE9422800E8938F /* b2DynamicTree.h in Headers */,
+				EB9EE0751BE9422800E8938F /* b2TimeOfImpact.h in Headers */,
+				EB9EE0761BE9422800E8938F /* b2ChainShape.h in Headers */,
+				EB9EE0771BE9422800E8938F /* b2CircleShape.h in Headers */,
+				EB9EE0781BE9422800E8938F /* b2EdgeShape.h in Headers */,
+				EB9EE0791BE9422800E8938F /* b2PolygonShape.h in Headers */,
+				EB9EE07A1BE9422800E8938F /* b2Shape.h in Headers */,
+				EB9EE07B1BE9422800E8938F /* b2BlockAllocator.h in Headers */,
+				EB9EE07C1BE9422800E8938F /* b2Draw.h in Headers */,
+				EB9EE07D1BE9422800E8938F /* b2GrowableStack.h in Headers */,
+				EB9EE07E1BE9422800E8938F /* b2Math.h in Headers */,
+				EB9EE07F1BE9422800E8938F /* b2Settings.h in Headers */,
+				EB9EE0801BE9422800E8938F /* b2StackAllocator.h in Headers */,
+				EB9EE0811BE9422800E8938F /* b2Timer.h in Headers */,
+				EB9EE0821BE9422800E8938F /* b2Body.h in Headers */,
+				EB9EE0831BE9422800E8938F /* b2ContactManager.h in Headers */,
+				EB9EE0841BE9422800E8938F /* b2Fixture.h in Headers */,
+				EB9EE0851BE9422800E8938F /* b2Island.h in Headers */,
+				EB9EE0861BE9422800E8938F /* b2TimeStep.h in Headers */,
+				EB9EE0871BE9422800E8938F /* b2World.h in Headers */,
+				EB9EE0881BE9422800E8938F /* b2WorldCallbacks.h in Headers */,
+				EB9EE0891BE9422800E8938F /* b2ChainAndCircleContact.h in Headers */,
+				EB9EE08A1BE9422800E8938F /* b2ChainAndPolygonContact.h in Headers */,
+				EB9EE08B1BE9422800E8938F /* b2CircleContact.h in Headers */,
+				EB9EE08C1BE9422800E8938F /* b2Contact.h in Headers */,
+				EB9EE08D1BE9422800E8938F /* b2ContactSolver.h in Headers */,
+				EB9EE08E1BE9422800E8938F /* b2EdgeAndCircleContact.h in Headers */,
+				EB9EE08F1BE9422800E8938F /* b2EdgeAndPolygonContact.h in Headers */,
+				EB9EE0901BE9422800E8938F /* b2PolygonAndCircleContact.h in Headers */,
+				EB9EE0911BE9422800E8938F /* b2PolygonContact.h in Headers */,
+				EB9EE0921BE9422800E8938F /* b2DistanceJoint.h in Headers */,
+				EB9EE0931BE9422800E8938F /* b2FrictionJoint.h in Headers */,
+				EB9EE0941BE9422800E8938F /* b2GearJoint.h in Headers */,
+				EB9EE0951BE9422800E8938F /* b2Joint.h in Headers */,
+				EB9EE0961BE9422800E8938F /* b2MouseJoint.h in Headers */,
+				EB9EE0971BE9422800E8938F /* b2PrismaticJoint.h in Headers */,
+				EB9EE0981BE9422800E8938F /* b2PulleyJoint.h in Headers */,
+				EB9EE0991BE9422800E8938F /* b2RevoluteJoint.h in Headers */,
+				EB9EE09A1BE9422800E8938F /* b2RopeJoint.h in Headers */,
+				EB9EE09B1BE9422800E8938F /* b2WeldJoint.h in Headers */,
+				EB9EE09C1BE9422800E8938F /* b2WheelJoint.h in Headers */,
+				EB9EE09D1BE9422800E8938F /* b2Rope.h in Headers */,
+				EB9EE09E1BE9422800E8938F /* crc32.h in Headers */,
+				EB9EE09F1BE9422800E8938F /* deflate.h in Headers */,
+				EB9EE0A01BE9422800E8938F /* inffast.h in Headers */,
+				EB9EE0A11BE9422800E8938F /* inffixed.h in Headers */,
+				EB9EE0A21BE9422800E8938F /* inflate.h in Headers */,
+				EB9EE0A31BE9422800E8938F /* inftrees.h in Headers */,
+				EB9EE0A41BE9422800E8938F /* trees.h in Headers */,
+				EB9EE0A51BE9422800E8938F /* zconf.h in Headers */,
+				EB9EE0A61BE9422800E8938F /* zlib.h in Headers */,
+				EB9EE0A71BE9422800E8938F /* zutil.h in Headers */,
+				EB9EE0A81BE9422800E8938F /* whirlpool.h in Headers */,
+				EB9EE0A91BE9422800E8938F /* MOAIMath.h in Headers */,
+				EB9EE0AA1BE9422800E8938F /* MOAIFrameBufferTexture.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1871BE9423500E8938F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE1881BE9423500E8938F /* lcrypto.h in Headers */,
+				EB9EE1891BE9423500E8938F /* auxiliar.h in Headers */,
+				EB9EE18A1BE9423500E8938F /* buffer.h in Headers */,
+				EB9EE18B1BE9423500E8938F /* except.h in Headers */,
+				EB9EE18C1BE9423500E8938F /* inet.h in Headers */,
+				EB9EE18D1BE9423500E8938F /* io.h in Headers */,
+				EB9EE18E1BE9423500E8938F /* luasocket.h in Headers */,
+				EB9EE18F1BE9423500E8938F /* mime.h in Headers */,
+				EB9EE1901BE9423500E8938F /* options.h in Headers */,
+				EB9EE1911BE9423500E8938F /* select.h in Headers */,
+				EB9EE1921BE9423500E8938F /* socket.h in Headers */,
+				EB9EE1931BE9423500E8938F /* tcp.h in Headers */,
+				EB9EE1941BE9423500E8938F /* timeout.h in Headers */,
+				EB9EE1951BE9423500E8938F /* udp.h in Headers */,
+				EB9EE1961BE9423500E8938F /* unix.h in Headers */,
+				EB9EE1971BE9423500E8938F /* usocket.h in Headers */,
+				EB9EE1981BE9423500E8938F /* AKU-luaext.h in Headers */,
+				EB9EE1991BE9423500E8938F /* lfs.h in Headers */,
+				EB9EE19A1BE9423500E8938F /* MOAICoroutine.h in Headers */,
+				EB9EE19B1BE9423500E8938F /* MOAIMath.h in Headers */,
+				EB9EE19C1BE9423500E8938F /* MOAIFrameBufferTexture.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1BA1BE9424500E8938F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE1BB1BE9424500E8938F /* crc32.h in Headers */,
+				EB9EE1BC1BE9424500E8938F /* deflate.h in Headers */,
+				EB9EE1BD1BE9424500E8938F /* inffast.h in Headers */,
+				EB9EE1BE1BE9424500E8938F /* inffixed.h in Headers */,
+				EB9EE1BF1BE9424500E8938F /* inflate.h in Headers */,
+				EB9EE1C01BE9424500E8938F /* inftrees.h in Headers */,
+				EB9EE1C11BE9424500E8938F /* trees.h in Headers */,
+				EB9EE1C21BE9424500E8938F /* zconf.h in Headers */,
+				EB9EE1C31BE9424500E8938F /* zlib.h in Headers */,
+				EB9EE1C41BE9424500E8938F /* zutil.h in Headers */,
+				EB9EE1C51BE9424500E8938F /* pch.h in Headers */,
+				EB9EE1C61BE9424500E8938F /* zl_mutex.h in Headers */,
+				EB9EE1C71BE9424500E8938F /* zl_replace_locale.h in Headers */,
+				EB9EE1C81BE9424500E8938F /* zl_replace_new_delete.h in Headers */,
+				EB9EE1C91BE9424500E8938F /* zl_replace_stdio.h in Headers */,
+				EB9EE1CA1BE9424500E8938F /* zl_replace_stdlib.h in Headers */,
+				EB9EE1CB1BE9424500E8938F /* zl_replace.h in Headers */,
+				EB9EE1CC1BE9424500E8938F /* zl_util.h in Headers */,
+				EB9EE1CD1BE9424500E8938F /* ZLDirectoryItr.h in Headers */,
+				EB9EE1CE1BE9424500E8938F /* ZLFile.h in Headers */,
+				EB9EE1CF1BE9424500E8938F /* ZLFileSystem.h in Headers */,
+				EB9EE1D01BE9424500E8938F /* ZLVirtualPath.h in Headers */,
+				EB9EE1D11BE9424500E8938F /* ZLZipArchive.h in Headers */,
+				EB9EE1D21BE9424500E8938F /* ZLZipStream.h in Headers */,
+				EB9EE1D31BE9424500E8938F /* zlcore.h in Headers */,
+				EB9EE1D41BE9424500E8938F /* MOAIMath.h in Headers */,
+				EB9EE1D51BE9424500E8938F /* MOAIFrameBufferTexture.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -6575,6 +8247,74 @@
 			productReference = CDD06D87139882D900AB0420 /* libmoai-osx-luaext.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		EB9EDD971BE9421B00E8938F /* libmoai-tvos */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB9EE0081BE9421B00E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos" */;
+			buildPhases = (
+				EB9EDD981BE9421B00E8938F /* Headers */,
+				EB9EDED51BE9421B00E8938F /* Sources */,
+				EB9EE0071BE9421B00E8938F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-tvos";
+			productName = OpenUSLS;
+			productReference = EB9EE00B1BE9421B00E8938F /* liblibmoai-tvos.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		EB9EE00C1BE9422800E8938F /* libmoai-tvos-3rdparty */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB9EE1821BE9422800E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-3rdparty" */;
+			buildPhases = (
+				EB9EE00D1BE9422800E8938F /* Headers */,
+				EB9EE0AB1BE9422800E8938F /* Sources */,
+				EB9EE1811BE9422800E8938F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-tvos-3rdparty";
+			productName = OpenUSLS;
+			productReference = EB9EE1851BE9422800E8938F /* liblibmoai-tvos-3rdparty.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		EB9EE1861BE9423500E8938F /* libmoai-tvos-luaext */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB9EE1B51BE9423500E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-luaext" */;
+			buildPhases = (
+				EB9EE1871BE9423500E8938F /* Headers */,
+				EB9EE19D1BE9423500E8938F /* Sources */,
+				EB9EE1B41BE9423500E8938F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-tvos-luaext";
+			productName = OpenUSLS;
+			productReference = EB9EE1B81BE9423500E8938F /* liblibmoai-tvos-luaext.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		EB9EE1B91BE9424500E8938F /* libmoai-tvos-zlcore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB9EE1F21BE9424500E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-zlcore" */;
+			buildPhases = (
+				EB9EE1BA1BE9424500E8938F /* Headers */,
+				EB9EE1D61BE9424500E8938F /* Sources */,
+				EB9EE1F11BE9424500E8938F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-tvos-zlcore";
+			productName = OpenUSLS;
+			productReference = EB9EE1F51BE9424500E8938F /* liblibmoai-tvos-zlcore.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -6616,6 +8356,10 @@
 				0324E2A81356485F000ADC60 /* libmoai-osx-3rdparty */,
 				CDD06BD5139882D900AB0420 /* libmoai-osx-luaext */,
 				CD04ACB51472557F009C20E5 /* libmoai-osx-zlcore */,
+				EB9EDD971BE9421B00E8938F /* libmoai-tvos */,
+				EB9EE00C1BE9422800E8938F /* libmoai-tvos-3rdparty */,
+				EB9EE1861BE9423500E8938F /* libmoai-tvos-luaext */,
+				EB9EE1B91BE9424500E8938F /* libmoai-tvos-zlcore */,
 			);
 		};
 /* End PBXProject section */
@@ -7796,6 +9540,600 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EB9EDED51BE9421B00E8938F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EDED61BE9421B00E8938F /* m_md5.c in Sources */,
+				EB9EDED71BE9421B00E8938F /* md5_dgst.c in Sources */,
+				EB9EDED81BE9421B00E8938F /* md5_one.c in Sources */,
+				EB9EDED91BE9421B00E8938F /* md5.c in Sources */,
+				EB9EDEDA1BE9421B00E8938F /* mem_clr.c in Sources */,
+				EB9EDEDB1BE9421B00E8938F /* ldo.c in Sources */,
+				EB9EDEDC1BE9421B00E8938F /* MOAIGfxQuadDeck2D.cpp in Sources */,
+				EB9EDEDD1BE9421B00E8938F /* sha_dgst.c in Sources */,
+				EB9EDEDE1BE9421B00E8938F /* sha_one.c in Sources */,
+				EB9EDEDF1BE9421B00E8938F /* sha.c in Sources */,
+				EB9EDEE01BE9421B00E8938F /* sha1_one.c in Sources */,
+				EB9EDEE11BE9421B00E8938F /* sha1.c in Sources */,
+				EB9EDEE21BE9421B00E8938F /* sha1dgst.c in Sources */,
+				EB9EDEE31BE9421B00E8938F /* sha256.c in Sources */,
+				EB9EDEE41BE9421B00E8938F /* sha512.c in Sources */,
+				EB9EDEE51BE9421B00E8938F /* MOAIFont.cpp in Sources */,
+				EB9EDEE61BE9421B00E8938F /* MOAILayer.cpp in Sources */,
+				EB9EDEE71BE9421B00E8938F /* MOAIMultiTexture.cpp in Sources */,
+				EB9EDEE81BE9421B00E8938F /* MOAILayerBridge.cpp in Sources */,
+				EB9EDEE91BE9421B00E8938F /* MOAIHttpTaskBase.cpp in Sources */,
+				EB9EDEEA1BE9421B00E8938F /* MOAIStaticGlyphCache.cpp in Sources */,
+				EB9EDEEB1BE9421B00E8938F /* MOAIEaseBackIn.cpp in Sources */,
+				EB9EDEEC1BE9421B00E8938F /* MOAIImageTexture.cpp in Sources */,
+				EB9EDEED1BE9421B00E8938F /* USPrism.cpp in Sources */,
+				EB9EDEEE1BE9421B00E8938F /* MOAICamera.cpp in Sources */,
+				EB9EDEEF1BE9421B00E8938F /* USFrustum.cpp in Sources */,
+				EB9EDEF01BE9421B00E8938F /* MOAIBitmapFontReader.cpp in Sources */,
+				EB9EDEF11BE9421B00E8938F /* MOAIFontReader.cpp in Sources */,
+				EB9EDEF21BE9421B00E8938F /* MOAIFreeTypeFontReader.cpp in Sources */,
+				EB9EDEF31BE9421B00E8938F /* MOAITextStyle.cpp in Sources */,
+				EB9EDEF41BE9421B00E8938F /* MOAITextStyler.cpp in Sources */,
+				EB9EDEF51BE9421B00E8938F /* MOAIEaseSineOut.cpp in Sources */,
+				EB9EDEF61BE9421B00E8938F /* MOAIGlyphCache.cpp in Sources */,
+				EB9EDEF71BE9421B00E8938F /* MOAIGlyphCacheBase.cpp in Sources */,
+				EB9EDEF81BE9421B00E8938F /* MOAIGlyphCachePage.cpp in Sources */,
+				EB9EDEF91BE9421B00E8938F /* MOAITextDesigner.cpp in Sources */,
+				EB9EDEFA1BE9421B00E8938F /* MOAIGlyphSet.cpp in Sources */,
+				EB9EDEFB1BE9421B00E8938F /* MOAITextureBase.cpp in Sources */,
+				EB9EDEFC1BE9421B00E8938F /* AKU.cpp in Sources */,
+				EB9EDEFD1BE9421B00E8938F /* pch.cpp in Sources */,
+				EB9EDEFE1BE9421B00E8938F /* MOAIAction.cpp in Sources */,
+				EB9EDEFF1BE9421B00E8938F /* MOAIAnim.cpp in Sources */,
+				EB9EDF001BE9421B00E8938F /* MOAIAnimCurve.cpp in Sources */,
+				EB9EDF011BE9421B00E8938F /* MOAIBlocker.cpp in Sources */,
+				EB9EDF021BE9421B00E8938F /* MOAIBox2DArbiter.cpp in Sources */,
+				EB9EDF031BE9421B00E8938F /* MOAIBox2DBody.cpp in Sources */,
+				EB9EDF041BE9421B00E8938F /* MOAIBox2DDebugDraw.cpp in Sources */,
+				EB9EDF051BE9421B00E8938F /* USRhombus.cpp in Sources */,
+				EB9EDF061BE9421B00E8938F /* MOAIBox2DFixture.cpp in Sources */,
+				EB9EDF071BE9421B00E8938F /* MOAIBox2DJoint.cpp in Sources */,
+				EB9EDF081BE9421B00E8938F /* MOAIBox2DWorld.cpp in Sources */,
+				EB9EDF091BE9421B00E8938F /* MOAIButtonSensor.cpp in Sources */,
+				EB9EDF0A1BE9421B00E8938F /* MOAIColor.cpp in Sources */,
+				EB9EDF0B1BE9421B00E8938F /* MOAIEaseBackBase.cpp in Sources */,
+				EB9EDF0C1BE9421B00E8938F /* MOAICompassSensor.cpp in Sources */,
+				EB9EDF0D1BE9421B00E8938F /* moaicore.cpp in Sources */,
+				EB9EDF0E1BE9421B00E8938F /* MOAICp.cpp in Sources */,
+				EB9EDF0F1BE9421B00E8938F /* MOAICpArbiter.cpp in Sources */,
+				EB9EDF101BE9421B00E8938F /* MOAICpBody.cpp in Sources */,
+				EB9EDF111BE9421B00E8938F /* MOAICpConstraint.cpp in Sources */,
+				EB9EDF121BE9421B00E8938F /* MOAICpDebugDraw.cpp in Sources */,
+				EB9EDF131BE9421B00E8938F /* MOAICpShape.cpp in Sources */,
+				EB9EDF141BE9421B00E8938F /* MOAICpSpace.cpp in Sources */,
+				EB9EDF151BE9421B00E8938F /* MOAIDataBuffer.cpp in Sources */,
+				EB9EDF161BE9421B00E8938F /* MOAIDebugLines.cpp in Sources */,
+				EB9EDF171BE9421B00E8938F /* MOAIDeck.cpp in Sources */,
+				EB9EDF181BE9421B00E8938F /* MOAIEaseDriver.cpp in Sources */,
+				EB9EDF191BE9421B00E8938F /* MOAIEaseType.cpp in Sources */,
+				EB9EDF1A1BE9421B00E8938F /* MOAIEaseExponentialOut.cpp in Sources */,
+				EB9EDF1B1BE9421B00E8938F /* MOAIGfxQuad2D.cpp in Sources */,
+				EB9EDF1C1BE9421B00E8938F /* MOAIGfxQuadListDeck2D.cpp in Sources */,
+				EB9EDF1D1BE9421B00E8938F /* MOAIGrid.cpp in Sources */,
+				EB9EDF1E1BE9421B00E8938F /* MOAIIndexBuffer.cpp in Sources */,
+				EB9EDF1F1BE9421B00E8938F /* MOAIInputDevice.cpp in Sources */,
+				EB9EDF201BE9421B00E8938F /* MOAIInputMgr.cpp in Sources */,
+				EB9EDF211BE9421B00E8938F /* MOAIJoystickSensor.cpp in Sources */,
+				EB9EDF221BE9421B00E8938F /* MOAIEaseSimpleOut.cpp in Sources */,
+				EB9EDF231BE9421B00E8938F /* MOAIKeyboardSensor.cpp in Sources */,
+				EB9EDF241BE9421B00E8938F /* MOAILayoutFrame.cpp in Sources */,
+				EB9EDF251BE9421B00E8938F /* MOAILocationSensor.cpp in Sources */,
+				EB9EDF261BE9421B00E8938F /* MOAILogMgr.cpp in Sources */,
+				EB9EDF271BE9421B00E8938F /* MOAIMesh.cpp in Sources */,
+				EB9EDF281BE9421B00E8938F /* MOAINode.cpp in Sources */,
+				EB9EDF291BE9421B00E8938F /* MOAINodeMgr.cpp in Sources */,
+				EB9EDF2A1BE9421B00E8938F /* MOAIParser.cpp in Sources */,
+				EB9EDF2B1BE9421B00E8938F /* MOAIEaseExponentialIn.cpp in Sources */,
+				EB9EDF2C1BE9421B00E8938F /* MOAIPartition.cpp in Sources */,
+				EB9EDF2D1BE9421B00E8938F /* MOAIPartitionCell.cpp in Sources */,
+				EB9EDF2E1BE9421B00E8938F /* MOAIPartitionLevel.cpp in Sources */,
+				EB9EDF2F1BE9421B00E8938F /* MOAIPointerSensor.cpp in Sources */,
+				EB9EDF301BE9421B00E8938F /* MOAIProp.cpp in Sources */,
+				EB9EDF311BE9421B00E8938F /* MOAIScriptNode.cpp in Sources */,
+				EB9EDF321BE9421B00E8938F /* MOAISensor.cpp in Sources */,
+				EB9EDF331BE9421B00E8938F /* MOAISerializer.cpp in Sources */,
+				EB9EDF341BE9421B00E8938F /* MOAIShader.cpp in Sources */,
+				EB9EDF351BE9421B00E8938F /* MOAISim.cpp in Sources */,
+				EB9EDF361BE9421B00E8938F /* MOAIStretchPatch2D.cpp in Sources */,
+				EB9EDF371BE9421B00E8938F /* MOAISurfaceDeck2D.cpp in Sources */,
+				EB9EDF381BE9421B00E8938F /* MOAISurfaceSampler2D.cpp in Sources */,
+				EB9EDF391BE9421B00E8938F /* MOAITextBox.cpp in Sources */,
+				EB9EDF3A1BE9421B00E8938F /* MOAIEaseElasticBase.cpp in Sources */,
+				EB9EDF3B1BE9421B00E8938F /* MOAITexture.cpp in Sources */,
+				EB9EDF3C1BE9421B00E8938F /* MOAITileDeck2D.cpp in Sources */,
+				EB9EDF3D1BE9421B00E8938F /* MOAIEaseSimpleBase.cpp in Sources */,
+				EB9EDF3E1BE9421B00E8938F /* MOAITimer.cpp in Sources */,
+				EB9EDF3F1BE9421B00E8938F /* MOAITouchSensor.cpp in Sources */,
+				EB9EDF401BE9421B00E8938F /* MOAIEase.cpp in Sources */,
+				EB9EDF411BE9421B00E8938F /* MOAITransform.cpp in Sources */,
+				EB9EDF421BE9421B00E8938F /* MOAITransformBase.cpp in Sources */,
+				EB9EDF431BE9421B00E8938F /* MOAIVertexBuffer.cpp in Sources */,
+				EB9EDF441BE9421B00E8938F /* MOAIVertexFormat.cpp in Sources */,
+				EB9EDF451BE9421B00E8938F /* MOAIViewport.cpp in Sources */,
+				EB9EDF461BE9421B00E8938F /* MOAIXmlParser.cpp in Sources */,
+				EB9EDF471BE9421B00E8938F /* STLString.cpp in Sources */,
+				EB9EDF481BE9421B00E8938F /* USByteStream.cpp in Sources */,
+				EB9EDF491BE9421B00E8938F /* USDeviceTime_apple.cpp in Sources */,
+				EB9EDF4A1BE9421B00E8938F /* USDeviceTime_posix.cpp in Sources */,
+				EB9EDF4B1BE9421B00E8938F /* USDeviceTime_win32.cpp in Sources */,
+				EB9EDF4C1BE9421B00E8938F /* USFileStream.cpp in Sources */,
+				EB9EDF4D1BE9421B00E8938F /* USFileSys.cpp in Sources */,
+				EB9EDF4E1BE9421B00E8938F /* USMemStream.cpp in Sources */,
+				EB9EDF4F1BE9421B00E8938F /* USStream.cpp in Sources */,
+				EB9EDF501BE9421B00E8938F /* USZip.cpp in Sources */,
+				EB9EDF511BE9421B00E8938F /* USZipFile.cpp in Sources */,
+				EB9EDF521BE9421B00E8938F /* AKU-iphone.mm in Sources */,
+				EB9EDF531BE9421B00E8938F /* MOAIEventSource.cpp in Sources */,
+				EB9EDF541BE9421B00E8938F /* MOAIImage.cpp in Sources */,
+				EB9EDF551BE9421B00E8938F /* MOAICameraAnchor2D.cpp in Sources */,
+				EB9EDF561BE9421B00E8938F /* MOAIEaseExponentialInOut.cpp in Sources */,
+				EB9EDF571BE9421B00E8938F /* MOAICameraFitter2D.cpp in Sources */,
+				EB9EDF581BE9421B00E8938F /* MOAIDeckRemapper.cpp in Sources */,
+				EB9EDF591BE9421B00E8938F /* NSArray+MOAILib.mm in Sources */,
+				EB9EDF5A1BE9421B00E8938F /* NSData+MOAILib.mm in Sources */,
+				EB9EDF5B1BE9421B00E8938F /* NSDate+MOAILib.mm in Sources */,
+				EB9EDF5C1BE9421B00E8938F /* NSDictionary+MOAILib.mm in Sources */,
+				EB9EDF5D1BE9421B00E8938F /* NSError+MOAILib.mm in Sources */,
+				EB9EDF5E1BE9421B00E8938F /* NSNumber+MOAILib.mm in Sources */,
+				EB9EDF5F1BE9421B00E8938F /* NSObject+MOAILib.mm in Sources */,
+				EB9EDF601BE9421B00E8938F /* MOAIEaseSineIn.cpp in Sources */,
+				EB9EDF611BE9421B00E8938F /* NSString+MOAILib.mm in Sources */,
+				EB9EDF621BE9421B00E8938F /* MOAIFileSystem.cpp in Sources */,
+				EB9EDF631BE9421B00E8938F /* USLog.cpp in Sources */,
+				EB9EDF641BE9421B00E8938F /* MOAIJsonParser.cpp in Sources */,
+				EB9EDF651BE9421B00E8938F /* MOAIEnvironment.cpp in Sources */,
+				EB9EDF661BE9421B00E8938F /* moaicore-pch.cpp in Sources */,
+				EB9EDF671BE9421B00E8938F /* uslscore-pch.cpp in Sources */,
+				EB9EDF681BE9421B00E8938F /* MOAIActionMgr.cpp in Sources */,
+				EB9EDF691BE9421B00E8938F /* MOAIMotionSensor.cpp in Sources */,
+				EB9EDF6A1BE9421B00E8938F /* MOAIEaseElasticOut.cpp in Sources */,
+				EB9EDF6B1BE9421B00E8938F /* MOAIDraw.cpp in Sources */,
+				EB9EDF6C1BE9421B00E8938F /* MOAIGfxDevice.cpp in Sources */,
+				EB9EDF6D1BE9421B00E8938F /* MOAIGlyph.cpp in Sources */,
+				EB9EDF6E1BE9421B00E8938F /* MOAIGridSpace.cpp in Sources */,
+				EB9EDF6F1BE9421B00E8938F /* MOAIQuadBrush.cpp in Sources */,
+				EB9EDF701BE9421B00E8938F /* MOAIShaderMgr.cpp in Sources */,
+				EB9EDF711BE9421B00E8938F /* MOAITileFlags.cpp in Sources */,
+				EB9EDF721BE9421B00E8938F /* MOAIVertexFormatMgr.cpp in Sources */,
+				EB9EDF731BE9421B00E8938F /* MOAIBlendMode.cpp in Sources */,
+				EB9EDF741BE9421B00E8938F /* MOAIFrameBuffer.cpp in Sources */,
+				EB9EDF751BE9421B00E8938F /* MOAIPartitionResultBuffer.cpp in Sources */,
+				EB9EDF761BE9421B00E8938F /* MOAIPartitionResultMgr.cpp in Sources */,
+				EB9EDF771BE9421B00E8938F /* USDirectoryItr.cpp in Sources */,
+				EB9EDF781BE9421B00E8938F /* MOAIGfxResource.cpp in Sources */,
+				EB9EDF791BE9421B00E8938F /* MOAILogMessages.cpp in Sources */,
+				EB9EDF7A1BE9421B00E8938F /* MOAIScriptDeck.cpp in Sources */,
+				EB9EDF7B1BE9421B00E8938F /* MOAIBox2DDistanceJoint.cpp in Sources */,
+				EB9EDF7C1BE9421B00E8938F /* MOAIBox2DFrictionJoint.cpp in Sources */,
+				EB9EDF7D1BE9421B00E8938F /* MOAIBox2DGearJoint.cpp in Sources */,
+				EB9EDF7E1BE9421B00E8938F /* MOAIBox2DMouseJoint.cpp in Sources */,
+				EB9EDF7F1BE9421B00E8938F /* MOAIBox2DPrismaticJoint.cpp in Sources */,
+				EB9EDF801BE9421B00E8938F /* MOAIBox2DPulleyJoint.cpp in Sources */,
+				EB9EDF811BE9421B00E8938F /* MOAIBox2DRevoluteJoint.cpp in Sources */,
+				EB9EDF821BE9421B00E8938F /* MOAIBox2DWeldJoint.cpp in Sources */,
+				EB9EDF831BE9421B00E8938F /* MOAIImage-jpg.cpp in Sources */,
+				EB9EDF841BE9421B00E8938F /* MOAIImage-png.cpp in Sources */,
+				EB9EDF851BE9421B00E8938F /* MOAIBox2DRopeJoint.cpp in Sources */,
+				EB9EDF861BE9421B00E8938F /* MOAIBox2DWheelJoint.cpp in Sources */,
+				EB9EDF871BE9421B00E8938F /* MOAICanary.cpp in Sources */,
+				EB9EDF881BE9421B00E8938F /* MOAIDeserializer.cpp in Sources */,
+				EB9EDF891BE9421B00E8938F /* MOAIGlobals.cpp in Sources */,
+				EB9EDF8A1BE9421B00E8938F /* MOAILuaObject.cpp in Sources */,
+				EB9EDF8B1BE9421B00E8938F /* MOAILuaRef.cpp in Sources */,
+				EB9EDF8C1BE9421B00E8938F /* MOAILuaRuntime.cpp in Sources */,
+				EB9EDF8D1BE9421B00E8938F /* MOAILuaState.cpp in Sources */,
+				EB9EDF8E1BE9421B00E8938F /* MOAILuaStateHandle.cpp in Sources */,
+				EB9EDF8F1BE9421B00E8938F /* MOAIEaseBackInOut.cpp in Sources */,
+				EB9EDF901BE9421B00E8938F /* MOAIObject.cpp in Sources */,
+				EB9EDF911BE9421B00E8938F /* MOAIRtti.cpp in Sources */,
+				EB9EDF921BE9421B00E8938F /* MOAISerializerBase.cpp in Sources */,
+				EB9EDF931BE9421B00E8938F /* MOAIWheelSensor.cpp in Sources */,
+				EB9EDF941BE9421B00E8938F /* MOAIEaseSimpleIn.cpp in Sources */,
+				EB9EDF951BE9421B00E8938F /* MOAIGridPathGraph.cpp in Sources */,
+				EB9EDF961BE9421B00E8938F /* MOAIPathFinder.cpp in Sources */,
+				EB9EDF971BE9421B00E8938F /* MOAIPathGraph.cpp in Sources */,
+				EB9EDF981BE9421B00E8938F /* MOAIPathTerrainDeck.cpp in Sources */,
+				EB9EDF991BE9421B00E8938F /* USAdapterInfo_posix.cpp in Sources */,
+				EB9EDF9A1BE9421B00E8938F /* USBox.cpp in Sources */,
+				EB9EDF9B1BE9421B00E8938F /* USCgt.cpp in Sources */,
+				EB9EDF9C1BE9421B00E8938F /* USColor.cpp in Sources */,
+				EB9EDF9D1BE9421B00E8938F /* MOAIEaseElasticInOut.cpp in Sources */,
+				EB9EDF9E1BE9421B00E8938F /* USCurve.cpp in Sources */,
+				EB9EDF9F1BE9421B00E8938F /* USDistance.cpp in Sources */,
+				EB9EDFA01BE9421B00E8938F /* USHexDump.cpp in Sources */,
+				EB9EDFA11BE9421B00E8938F /* MOAIEaseCustom.cpp in Sources */,
+				EB9EDFA21BE9421B00E8938F /* USInterpolate.cpp in Sources */,
+				EB9EDFA31BE9421B00E8938F /* USIntersect.cpp in Sources */,
+				EB9EDFA41BE9421B00E8938F /* MOAICCParticleSystem.cpp in Sources */,
+				EB9EDFA51BE9421B00E8938F /* USLexStream.cpp in Sources */,
+				EB9EDFA61BE9421B00E8938F /* USMercator.cpp in Sources */,
+				EB9EDFA71BE9421B00E8938F /* USParser.cpp in Sources */,
+				EB9EDFA81BE9421B00E8938F /* USPlane.cpp in Sources */,
+				EB9EDFA91BE9421B00E8938F /* USPolar.cpp in Sources */,
+				EB9EDFAA1BE9421B00E8938F /* USQuad.cpp in Sources */,
+				EB9EDFAB1BE9421B00E8938F /* USQuadCoord.cpp in Sources */,
+				EB9EDFAC1BE9421B00E8938F /* MOAICCParticle.cpp in Sources */,
+				EB9EDFAD1BE9421B00E8938F /* USSurface2D.cpp in Sources */,
+				EB9EDFAE1BE9421B00E8938F /* MOAIEaseSineInOut.cpp in Sources */,
+				EB9EDFAF1BE9421B00E8938F /* USSyntaxNode.cpp in Sources */,
+				EB9EDFB01BE9421B00E8938F /* USSyntaxScanner.cpp in Sources */,
+				EB9EDFB11BE9421B00E8938F /* MOAIEaseSimpleInOut.cpp in Sources */,
+				EB9EDFB21BE9421B00E8938F /* USTrig.cpp in Sources */,
+				EB9EDFB31BE9421B00E8938F /* USTypedPtr.cpp in Sources */,
+				EB9EDFB41BE9421B00E8938F /* USXmlReader.cpp in Sources */,
+				EB9EDFB51BE9421B00E8938F /* AKU-audiosampler.cpp in Sources */,
+				EB9EDFB61BE9421B00E8938F /* MOAIAudioSampler.cpp in Sources */,
+				EB9EDFB71BE9421B00E8938F /* MOAIHttpTaskNaCl.cpp in Sources */,
+				EB9EDFB81BE9421B00E8938F /* MOAIUrlMgrNaCl.cpp in Sources */,
+				EB9EDFB91BE9421B00E8938F /* MOAIRenderable.cpp in Sources */,
+				EB9EDFBA1BE9421B00E8938F /* MOAIRenderMgr.cpp in Sources */,
+				EB9EDFBB1BE9421B00E8938F /* USUnique_linux.cpp in Sources */,
+				EB9EDFBC1BE9421B00E8938F /* MOAICrittercismIOS.mm in Sources */,
+				EB9EDFBD1BE9421B00E8938F /* MOAINotificationsIOS.mm in Sources */,
+				EB9EDFBE1BE9421B00E8938F /* MOAIAppIOS.mm in Sources */,
+				EB9EDFBF1BE9421B00E8938F /* MOAIDialogIOS.mm in Sources */,
+				EB9EDFC01BE9421B00E8938F /* MOAIWebViewDelegate.mm in Sources */,
+				EB9EDFC11BE9421B00E8938F /* MOAIGameCenterIOS.mm in Sources */,
+				EB9EDFC21BE9421B00E8938F /* MOAIWebViewIOS.mm in Sources */,
+				EB9EDFC31BE9421B00E8938F /* MOAIKeyboardIOS.mm in Sources */,
+				EB9EDFC41BE9421B00E8938F /* AKU-adcolony.mm in Sources */,
+				EB9EDFC51BE9421B00E8938F /* AKU-chartboost.mm in Sources */,
+				EB9EDFC61BE9421B00E8938F /* MOAIFoo.cpp in Sources */,
+				EB9EDFC71BE9421B00E8938F /* MOAIFooMgr.cpp in Sources */,
+				EB9EDFC81BE9421B00E8938F /* MOAIScissorRect.cpp in Sources */,
+				EB9EDFC91BE9421B00E8938F /* MOAITextBundle.cpp in Sources */,
+				EB9EDFCA1BE9421B00E8938F /* MOAIFont_bmfont.cpp in Sources */,
+				EB9EDFCB1BE9421B00E8938F /* MOAIBoundsDeck.cpp in Sources */,
+				EB9EDFCC1BE9421B00E8938F /* fullluasocket.c in Sources */,
+				EB9EDFCD1BE9421B00E8938F /* luasocketscripts.c in Sources */,
+				EB9EDFCE1BE9421B00E8938F /* USQuaternion.cpp in Sources */,
+				EB9EDFCF1BE9421B00E8938F /* MOAIAnimCurveBase.cpp in Sources */,
+				EB9EDFD01BE9421B00E8938F /* MOAIAnimCurveQuat.cpp in Sources */,
+				EB9EDFD11BE9421B00E8938F /* MOAIAnimCurveVec.cpp in Sources */,
+				EB9EDFD21BE9421B00E8938F /* MOAIDataBufferStream.cpp in Sources */,
+				EB9EDFD31BE9421B00E8938F /* MOAIStreamWriter.cpp in Sources */,
+				EB9EDFD41BE9421B00E8938F /* MOAIStreamReader.cpp in Sources */,
+				EB9EDFD51BE9421B00E8938F /* MOAIFileStream.cpp in Sources */,
+				EB9EDFD61BE9421B00E8938F /* MOAIStream.cpp in Sources */,
+				EB9EDFD71BE9421B00E8938F /* MOAIMemStream.cpp in Sources */,
+				EB9EDFD81BE9421B00E8938F /* USDeflateReader.cpp in Sources */,
+				EB9EDFD91BE9421B00E8938F /* USDeflateWriter.cpp in Sources */,
+				EB9EDFDA1BE9421B00E8938F /* USStreamWriter.cpp in Sources */,
+				EB9EDFDB1BE9421B00E8938F /* USBase64Reader.cpp in Sources */,
+				EB9EDFDC1BE9421B00E8938F /* USBase64Writer.cpp in Sources */,
+				EB9EDFDD1BE9421B00E8938F /* USStreamReader.cpp in Sources */,
+				EB9EDFDE1BE9421B00E8938F /* USBase64Encoder.cpp in Sources */,
+				EB9EDFDF1BE9421B00E8938F /* MOAIGridDeck2D.cpp in Sources */,
+				EB9EDFE01BE9421B00E8938F /* MOAIMoviePlayerIOS.mm in Sources */,
+				EB9EDFE11BE9421B00E8938F /* MOAIHashWriter.cpp in Sources */,
+				EB9EDFE21BE9421B00E8938F /* USHashWriterAdler32.cpp in Sources */,
+				EB9EDFE31BE9421B00E8938F /* USHashWriterCRC32.cpp in Sources */,
+				EB9EDFE41BE9421B00E8938F /* MOAIEaseBackOut.cpp in Sources */,
+				EB9EDFE51BE9421B00E8938F /* USHashWriterMD5.cpp in Sources */,
+				EB9EDFE61BE9421B00E8938F /* USHashWriterSHA1.cpp in Sources */,
+				EB9EDFE71BE9421B00E8938F /* USHashWriterSHA224.cpp in Sources */,
+				EB9EDFE81BE9421B00E8938F /* MOAIEaseElasticIn.cpp in Sources */,
+				EB9EDFE91BE9421B00E8938F /* USHashWriterSHA256.cpp in Sources */,
+				EB9EDFEA1BE9421B00E8938F /* USHashWriterSHA384.cpp in Sources */,
+				EB9EDFEB1BE9421B00E8938F /* USHashWriterSHA512.cpp in Sources */,
+				EB9EDFEC1BE9421B00E8938F /* USHashWriterWhirlpool.cpp in Sources */,
+				EB9EDFED1BE9421B00E8938F /* USHexReader.cpp in Sources */,
+				EB9EDFEE1BE9421B00E8938F /* USHexWriter.cpp in Sources */,
+				EB9EDFEF1BE9421B00E8938F /* USHashWriter.cpp in Sources */,
+				EB9EDFF01BE9421B00E8938F /* MOAIDataIOTask.cpp in Sources */,
+				EB9EDFF11BE9421B00E8938F /* MOAIThread_posix.cpp in Sources */,
+				EB9EDFF21BE9421B00E8938F /* MOAIThread_win32.cpp in Sources */,
+				EB9EDFF31BE9421B00E8938F /* MOAIThread.cpp in Sources */,
+				EB9EDFF41BE9421B00E8938F /* MOAITask.cpp in Sources */,
+				EB9EDFF51BE9421B00E8938F /* MOAITaskQueue.cpp in Sources */,
+				EB9EDFF61BE9421B00E8938F /* MOAITaskSubscriber.cpp in Sources */,
+				EB9EDFF71BE9421B00E8938F /* MOAITaskThread.cpp in Sources */,
+				EB9EDFF81BE9421B00E8938F /* MOAIMutex_posix.cpp in Sources */,
+				EB9EDFF91BE9421B00E8938F /* MOAIMutex_win32.cpp in Sources */,
+				EB9EDFFA1BE9421B00E8938F /* MOAIMutex.cpp in Sources */,
+				EB9EDFFB1BE9421B00E8938F /* MOAITakeCameraListener.mm in Sources */,
+				EB9EDFFC1BE9421B00E8938F /* MOAIMath.cpp in Sources */,
+				EB9EDFFD1BE9421B00E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
+				EB9EDFFE1BE9421B00E8938F /* MOAIEaseLinear.cpp in Sources */,
+				EB9EDFFF1BE9421B00E8938F /* SFMT.c in Sources */,
+				EB9EE0001BE9421B00E8938F /* MOAIAnimCurveCustom.cpp in Sources */,
+				EB9EE0011BE9421B00E8938F /* MOAIFreeTypeFont.cpp in Sources */,
+				EB9EE0021BE9421B00E8938F /* MOAITextRenderer.cpp in Sources */,
+				EB9EE0031BE9421B00E8938F /* MOAITest.cpp in Sources */,
+				EB9EE0041BE9421B00E8938F /* MOAITestMgr.cpp in Sources */,
+				EB9EE0051BE9421B00E8938F /* AKU-test.cpp in Sources */,
+				EB9EE0061BE9421B00E8938F /* MOAIXmlWriter.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE0AB1BE9422800E8938F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE0AC1BE9422800E8938F /* utf8.c in Sources */,
+				EB9EE0AD1BE9422800E8938F /* xmlparse.c in Sources */,
+				EB9EE0AE1BE9422800E8938F /* xmlrole.c in Sources */,
+				EB9EE0AF1BE9422800E8938F /* xmltok.c in Sources */,
+				EB9EE0B01BE9422800E8938F /* xmltok_impl.c in Sources */,
+				EB9EE0B11BE9422800E8938F /* xmltok_ns.c in Sources */,
+				EB9EE0B21BE9422800E8938F /* ftbbox.c in Sources */,
+				EB9EE0B31BE9422800E8938F /* ftgxval.c in Sources */,
+				EB9EE0B41BE9422800E8938F /* ftlcdfil.c in Sources */,
+				EB9EE0B51BE9422800E8938F /* ftmm.c in Sources */,
+				EB9EE0B61BE9422800E8938F /* ftotval.c in Sources */,
+				EB9EE0B71BE9422800E8938F /* ftpatent.c in Sources */,
+				EB9EE0B81BE9422800E8938F /* ftpfr.c in Sources */,
+				EB9EE0B91BE9422800E8938F /* ftsynth.c in Sources */,
+				EB9EE0BA1BE9422800E8938F /* fttype1.c in Sources */,
+				EB9EE0BB1BE9422800E8938F /* ftwinfnt.c in Sources */,
+				EB9EE0BC1BE9422800E8938F /* ftxf86.c in Sources */,
+				EB9EE0BD1BE9422800E8938F /* pcf.c in Sources */,
+				EB9EE0BE1BE9422800E8938F /* pfr.c in Sources */,
+				EB9EE0BF1BE9422800E8938F /* psaux.c in Sources */,
+				EB9EE0C01BE9422800E8938F /* pshinter.c in Sources */,
+				EB9EE0C11BE9422800E8938F /* psmodule.c in Sources */,
+				EB9EE0C21BE9422800E8938F /* raster.c in Sources */,
+				EB9EE0C31BE9422800E8938F /* sfnt.c in Sources */,
+				EB9EE0C41BE9422800E8938F /* truetype.c in Sources */,
+				EB9EE0C51BE9422800E8938F /* type1.c in Sources */,
+				EB9EE0C61BE9422800E8938F /* type1cid.c in Sources */,
+				EB9EE0C71BE9422800E8938F /* type42.c in Sources */,
+				EB9EE0C81BE9422800E8938F /* winfnt.c in Sources */,
+				EB9EE0C91BE9422800E8938F /* autofit.c in Sources */,
+				EB9EE0CA1BE9422800E8938F /* bdf.c in Sources */,
+				EB9EE0CB1BE9422800E8938F /* cff.c in Sources */,
+				EB9EE0CC1BE9422800E8938F /* ftbase.c in Sources */,
+				EB9EE0CD1BE9422800E8938F /* ftbitmap.c in Sources */,
+				EB9EE0CE1BE9422800E8938F /* ftcache.c in Sources */,
+				EB9EE0CF1BE9422800E8938F /* ftdebug.c in Sources */,
+				EB9EE0D01BE9422800E8938F /* ftfstype.c in Sources */,
+				EB9EE0D11BE9422800E8938F /* ftgasp.c in Sources */,
+				EB9EE0D21BE9422800E8938F /* ftglyph.c in Sources */,
+				EB9EE0D31BE9422800E8938F /* ftgzip.c in Sources */,
+				EB9EE0D41BE9422800E8938F /* ftinit.c in Sources */,
+				EB9EE0D51BE9422800E8938F /* ftlzw.c in Sources */,
+				EB9EE0D61BE9422800E8938F /* ftstroke.c in Sources */,
+				EB9EE0D71BE9422800E8938F /* ftsystem.c in Sources */,
+				EB9EE0D81BE9422800E8938F /* smooth.c in Sources */,
+				EB9EE0D91BE9422800E8938F /* png.c in Sources */,
+				EB9EE0DA1BE9422800E8938F /* pngerror.c in Sources */,
+				EB9EE0DB1BE9422800E8938F /* pngget.c in Sources */,
+				EB9EE0DC1BE9422800E8938F /* pngmem.c in Sources */,
+				EB9EE0DD1BE9422800E8938F /* pngpread.c in Sources */,
+				EB9EE0DE1BE9422800E8938F /* pngread.c in Sources */,
+				EB9EE0DF1BE9422800E8938F /* pngrio.c in Sources */,
+				EB9EE0E01BE9422800E8938F /* pngrtran.c in Sources */,
+				EB9EE0E11BE9422800E8938F /* pngrutil.c in Sources */,
+				EB9EE0E21BE9422800E8938F /* pngset.c in Sources */,
+				EB9EE0E31BE9422800E8938F /* pngtrans.c in Sources */,
+				EB9EE0E41BE9422800E8938F /* pngwio.c in Sources */,
+				EB9EE0E51BE9422800E8938F /* pngwrite.c in Sources */,
+				EB9EE0E61BE9422800E8938F /* pngwtran.c in Sources */,
+				EB9EE0E71BE9422800E8938F /* pngwutil.c in Sources */,
+				EB9EE0E81BE9422800E8938F /* tinyxml.cpp in Sources */,
+				EB9EE0E91BE9422800E8938F /* tinyxmlerror.cpp in Sources */,
+				EB9EE0EA1BE9422800E8938F /* tinyxmlparser.cpp in Sources */,
+				EB9EE0EB1BE9422800E8938F /* MOAIISO8601DateFormatter.m in Sources */,
+				EB9EE0EC1BE9422800E8938F /* ls_sqlite3.c in Sources */,
+				EB9EE0ED1BE9422800E8938F /* luasql.c in Sources */,
+				EB9EE0EE1BE9422800E8938F /* dump.c in Sources */,
+				EB9EE0EF1BE9422800E8938F /* error.c in Sources */,
+				EB9EE0F01BE9422800E8938F /* hashtable.c in Sources */,
+				EB9EE0F11BE9422800E8938F /* load.c in Sources */,
+				EB9EE0F21BE9422800E8938F /* memory.c in Sources */,
+				EB9EE0F31BE9422800E8938F /* pack_unpack.c in Sources */,
+				EB9EE0F41BE9422800E8938F /* strbuffer.c in Sources */,
+				EB9EE0F51BE9422800E8938F /* utf.c in Sources */,
+				EB9EE0F61BE9422800E8938F /* value.c in Sources */,
+				EB9EE0F71BE9422800E8938F /* lapi.c in Sources */,
+				EB9EE0F81BE9422800E8938F /* lauxlib.c in Sources */,
+				EB9EE0F91BE9422800E8938F /* lbaselib.c in Sources */,
+				EB9EE0FA1BE9422800E8938F /* lcode.c in Sources */,
+				EB9EE0FB1BE9422800E8938F /* ldblib.c in Sources */,
+				EB9EE0FC1BE9422800E8938F /* ldebug.c in Sources */,
+				EB9EE0FD1BE9422800E8938F /* ldump.c in Sources */,
+				EB9EE0FE1BE9422800E8938F /* lfunc.c in Sources */,
+				EB9EE0FF1BE9422800E8938F /* lgc.c in Sources */,
+				EB9EE1001BE9422800E8938F /* linit.c in Sources */,
+				EB9EE1011BE9422800E8938F /* liolib.c in Sources */,
+				EB9EE1021BE9422800E8938F /* llex.c in Sources */,
+				EB9EE1031BE9422800E8938F /* lmathlib.c in Sources */,
+				EB9EE1041BE9422800E8938F /* lmem.c in Sources */,
+				EB9EE1051BE9422800E8938F /* loadlib.c in Sources */,
+				EB9EE1061BE9422800E8938F /* lobject.c in Sources */,
+				EB9EE1071BE9422800E8938F /* lopcodes.c in Sources */,
+				EB9EE1081BE9422800E8938F /* loslib.c in Sources */,
+				EB9EE1091BE9422800E8938F /* lparser.c in Sources */,
+				EB9EE10A1BE9422800E8938F /* lstate.c in Sources */,
+				EB9EE10B1BE9422800E8938F /* lstring.c in Sources */,
+				EB9EE10C1BE9422800E8938F /* lstrlib.c in Sources */,
+				EB9EE10D1BE9422800E8938F /* ltable.c in Sources */,
+				EB9EE10E1BE9422800E8938F /* ltablib.c in Sources */,
+				EB9EE10F1BE9422800E8938F /* ltm.c in Sources */,
+				EB9EE1101BE9422800E8938F /* lundump.c in Sources */,
+				EB9EE1111BE9422800E8938F /* lvm.c in Sources */,
+				EB9EE1121BE9422800E8938F /* lzio.c in Sources */,
+				EB9EE1131BE9422800E8938F /* print.c in Sources */,
+				EB9EE1141BE9422800E8938F /* jaricom.c in Sources */,
+				EB9EE1151BE9422800E8938F /* jcapimin.c in Sources */,
+				EB9EE1161BE9422800E8938F /* jcapistd.c in Sources */,
+				EB9EE1171BE9422800E8938F /* jcarith.c in Sources */,
+				EB9EE1181BE9422800E8938F /* jccoefct.c in Sources */,
+				EB9EE1191BE9422800E8938F /* jccolor.c in Sources */,
+				EB9EE11A1BE9422800E8938F /* jcdctmgr.c in Sources */,
+				EB9EE11B1BE9422800E8938F /* jchuff.c in Sources */,
+				EB9EE11C1BE9422800E8938F /* jcinit.c in Sources */,
+				EB9EE11D1BE9422800E8938F /* jcmainct.c in Sources */,
+				EB9EE11E1BE9422800E8938F /* jcmarker.c in Sources */,
+				EB9EE11F1BE9422800E8938F /* jcmaster.c in Sources */,
+				EB9EE1201BE9422800E8938F /* jcomapi.c in Sources */,
+				EB9EE1211BE9422800E8938F /* jcparam.c in Sources */,
+				EB9EE1221BE9422800E8938F /* jcprepct.c in Sources */,
+				EB9EE1231BE9422800E8938F /* jcsample.c in Sources */,
+				EB9EE1241BE9422800E8938F /* jctrans.c in Sources */,
+				EB9EE1251BE9422800E8938F /* jdapimin.c in Sources */,
+				EB9EE1261BE9422800E8938F /* jdapistd.c in Sources */,
+				EB9EE1271BE9422800E8938F /* jdarith.c in Sources */,
+				EB9EE1281BE9422800E8938F /* jdatadst.c in Sources */,
+				EB9EE1291BE9422800E8938F /* jdatasrc.c in Sources */,
+				EB9EE12A1BE9422800E8938F /* jdcoefct.c in Sources */,
+				EB9EE12B1BE9422800E8938F /* jdcolor.c in Sources */,
+				EB9EE12C1BE9422800E8938F /* jddctmgr.c in Sources */,
+				EB9EE12D1BE9422800E8938F /* jdhuff.c in Sources */,
+				EB9EE12E1BE9422800E8938F /* jdinput.c in Sources */,
+				EB9EE12F1BE9422800E8938F /* jdmainct.c in Sources */,
+				EB9EE1301BE9422800E8938F /* jdmarker.c in Sources */,
+				EB9EE1311BE9422800E8938F /* jdmaster.c in Sources */,
+				EB9EE1321BE9422800E8938F /* jdmerge.c in Sources */,
+				EB9EE1331BE9422800E8938F /* jdpostct.c in Sources */,
+				EB9EE1341BE9422800E8938F /* jdsample.c in Sources */,
+				EB9EE1351BE9422800E8938F /* jdtrans.c in Sources */,
+				EB9EE1361BE9422800E8938F /* jerror-moai.c in Sources */,
+				EB9EE1371BE9422800E8938F /* jfdctflt.c in Sources */,
+				EB9EE1381BE9422800E8938F /* jfdctfst.c in Sources */,
+				EB9EE1391BE9422800E8938F /* jfdctint.c in Sources */,
+				EB9EE13A1BE9422800E8938F /* jidctflt.c in Sources */,
+				EB9EE13B1BE9422800E8938F /* jidctfst.c in Sources */,
+				EB9EE13C1BE9422800E8938F /* jidctint.c in Sources */,
+				EB9EE13D1BE9422800E8938F /* jmemmgr.c in Sources */,
+				EB9EE13E1BE9422800E8938F /* jmemnobs.c in Sources */,
+				EB9EE13F1BE9422800E8938F /* jquant1.c in Sources */,
+				EB9EE1401BE9422800E8938F /* jquant2.c in Sources */,
+				EB9EE1411BE9422800E8938F /* jutils.c in Sources */,
+				EB9EE1421BE9422800E8938F /* tlsf.c in Sources */,
+				EB9EE1431BE9422800E8938F /* b2BroadPhase.cpp in Sources */,
+				EB9EE1441BE9422800E8938F /* b2CollideCircle.cpp in Sources */,
+				EB9EE1451BE9422800E8938F /* b2CollideEdge.cpp in Sources */,
+				EB9EE1461BE9422800E8938F /* b2CollidePolygon.cpp in Sources */,
+				EB9EE1471BE9422800E8938F /* b2Collision.cpp in Sources */,
+				EB9EE1481BE9422800E8938F /* b2Distance.cpp in Sources */,
+				EB9EE1491BE9422800E8938F /* b2DynamicTree.cpp in Sources */,
+				EB9EE14A1BE9422800E8938F /* b2TimeOfImpact.cpp in Sources */,
+				EB9EE14B1BE9422800E8938F /* b2ChainShape.cpp in Sources */,
+				EB9EE14C1BE9422800E8938F /* b2CircleShape.cpp in Sources */,
+				EB9EE14D1BE9422800E8938F /* b2EdgeShape.cpp in Sources */,
+				EB9EE14E1BE9422800E8938F /* b2PolygonShape.cpp in Sources */,
+				EB9EE14F1BE9422800E8938F /* b2BlockAllocator.cpp in Sources */,
+				EB9EE1501BE9422800E8938F /* b2Draw.cpp in Sources */,
+				EB9EE1511BE9422800E8938F /* b2Math.cpp in Sources */,
+				EB9EE1521BE9422800E8938F /* b2Settings.cpp in Sources */,
+				EB9EE1531BE9422800E8938F /* b2StackAllocator.cpp in Sources */,
+				EB9EE1541BE9422800E8938F /* b2Timer.cpp in Sources */,
+				EB9EE1551BE9422800E8938F /* b2Body.cpp in Sources */,
+				EB9EE1561BE9422800E8938F /* b2ContactManager.cpp in Sources */,
+				EB9EE1571BE9422800E8938F /* b2Fixture.cpp in Sources */,
+				EB9EE1581BE9422800E8938F /* b2Island.cpp in Sources */,
+				EB9EE1591BE9422800E8938F /* b2World.cpp in Sources */,
+				EB9EE15A1BE9422800E8938F /* b2WorldCallbacks.cpp in Sources */,
+				EB9EE15B1BE9422800E8938F /* b2ChainAndCircleContact.cpp in Sources */,
+				EB9EE15C1BE9422800E8938F /* b2ChainAndPolygonContact.cpp in Sources */,
+				EB9EE15D1BE9422800E8938F /* b2CircleContact.cpp in Sources */,
+				EB9EE15E1BE9422800E8938F /* b2Contact.cpp in Sources */,
+				EB9EE15F1BE9422800E8938F /* b2ContactSolver.cpp in Sources */,
+				EB9EE1601BE9422800E8938F /* b2EdgeAndCircleContact.cpp in Sources */,
+				EB9EE1611BE9422800E8938F /* b2EdgeAndPolygonContact.cpp in Sources */,
+				EB9EE1621BE9422800E8938F /* sqlite3.c in Sources */,
+				EB9EE1631BE9422800E8938F /* b2PolygonAndCircleContact.cpp in Sources */,
+				EB9EE1641BE9422800E8938F /* b2PolygonContact.cpp in Sources */,
+				EB9EE1651BE9422800E8938F /* b2DistanceJoint.cpp in Sources */,
+				EB9EE1661BE9422800E8938F /* b2FrictionJoint.cpp in Sources */,
+				EB9EE1671BE9422800E8938F /* b2GearJoint.cpp in Sources */,
+				EB9EE1681BE9422800E8938F /* b2Joint.cpp in Sources */,
+				EB9EE1691BE9422800E8938F /* b2MouseJoint.cpp in Sources */,
+				EB9EE16A1BE9422800E8938F /* b2PrismaticJoint.cpp in Sources */,
+				EB9EE16B1BE9422800E8938F /* b2PulleyJoint.cpp in Sources */,
+				EB9EE16C1BE9422800E8938F /* b2RevoluteJoint.cpp in Sources */,
+				EB9EE16D1BE9422800E8938F /* b2RopeJoint.cpp in Sources */,
+				EB9EE16E1BE9422800E8938F /* b2WeldJoint.cpp in Sources */,
+				EB9EE16F1BE9422800E8938F /* b2WheelJoint.cpp in Sources */,
+				EB9EE1701BE9422800E8938F /* b2Rope.cpp in Sources */,
+				EB9EE1711BE9422800E8938F /* adler32.c in Sources */,
+				EB9EE1721BE9422800E8938F /* compress.c in Sources */,
+				EB9EE1731BE9422800E8938F /* crc32.c in Sources */,
+				EB9EE1741BE9422800E8938F /* deflate.c in Sources */,
+				EB9EE1751BE9422800E8938F /* gzio.c in Sources */,
+				EB9EE1761BE9422800E8938F /* infback.c in Sources */,
+				EB9EE1771BE9422800E8938F /* inffast.c in Sources */,
+				EB9EE1781BE9422800E8938F /* inflate.c in Sources */,
+				EB9EE1791BE9422800E8938F /* inftrees.c in Sources */,
+				EB9EE17A1BE9422800E8938F /* trees.c in Sources */,
+				EB9EE17B1BE9422800E8938F /* uncompr.c in Sources */,
+				EB9EE17C1BE9422800E8938F /* zutil.c in Sources */,
+				EB9EE17D1BE9422800E8938F /* whirlpool.c in Sources */,
+				EB9EE17E1BE9422800E8938F /* MOAIMath.cpp in Sources */,
+				EB9EE17F1BE9422800E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
+				EB9EE1801BE9422800E8938F /* SFMT.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE19D1BE9423500E8938F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE19E1BE9423500E8938F /* lcrypto.c in Sources */,
+				EB9EE19F1BE9423500E8938F /* auxiliar.c in Sources */,
+				EB9EE1A01BE9423500E8938F /* buffer.c in Sources */,
+				EB9EE1A11BE9423500E8938F /* except.c in Sources */,
+				EB9EE1A21BE9423500E8938F /* inet.c in Sources */,
+				EB9EE1A31BE9423500E8938F /* c_hook.c in Sources */,
+				EB9EE1A41BE9423500E8938F /* io.c in Sources */,
+				EB9EE1A51BE9423500E8938F /* luasocket.c in Sources */,
+				EB9EE1A61BE9423500E8938F /* mime.c in Sources */,
+				EB9EE1A71BE9423500E8938F /* options.c in Sources */,
+				EB9EE1A81BE9423500E8938F /* select.c in Sources */,
+				EB9EE1A91BE9423500E8938F /* tcp.c in Sources */,
+				EB9EE1AA1BE9423500E8938F /* timeout.c in Sources */,
+				EB9EE1AB1BE9423500E8938F /* udp.c in Sources */,
+				EB9EE1AC1BE9423500E8938F /* unix.c in Sources */,
+				EB9EE1AD1BE9423500E8938F /* usocket.c in Sources */,
+				EB9EE1AE1BE9423500E8938F /* AKU-luaext.cpp in Sources */,
+				EB9EE1AF1BE9423500E8938F /* lfs.c in Sources */,
+				EB9EE1B01BE9423500E8938F /* MOAICoroutine.cpp in Sources */,
+				EB9EE1B11BE9423500E8938F /* MOAIMath.cpp in Sources */,
+				EB9EE1B21BE9423500E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
+				EB9EE1B31BE9423500E8938F /* SFMT.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB9EE1D61BE9424500E8938F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB9EE1D71BE9424500E8938F /* adler32.c in Sources */,
+				EB9EE1D81BE9424500E8938F /* compress.c in Sources */,
+				EB9EE1D91BE9424500E8938F /* crc32.c in Sources */,
+				EB9EE1DA1BE9424500E8938F /* deflate.c in Sources */,
+				EB9EE1DB1BE9424500E8938F /* gzio.c in Sources */,
+				EB9EE1DC1BE9424500E8938F /* infback.c in Sources */,
+				EB9EE1DD1BE9424500E8938F /* inffast.c in Sources */,
+				EB9EE1DE1BE9424500E8938F /* inflate.c in Sources */,
+				EB9EE1DF1BE9424500E8938F /* inftrees.c in Sources */,
+				EB9EE1E01BE9424500E8938F /* trees.c in Sources */,
+				EB9EE1E11BE9424500E8938F /* uncompr.c in Sources */,
+				EB9EE1E21BE9424500E8938F /* zutil.c in Sources */,
+				EB9EE1E31BE9424500E8938F /* zl_mutex.cpp in Sources */,
+				EB9EE1E41BE9424500E8938F /* zl_util.cpp in Sources */,
+				EB9EE1E51BE9424500E8938F /* zl_vfscanf.cpp in Sources */,
+				EB9EE1E61BE9424500E8938F /* zlcore-pch.cpp in Sources */,
+				EB9EE1E71BE9424500E8938F /* ZLDirectoryItr.cpp in Sources */,
+				EB9EE1E81BE9424500E8938F /* ZLFile.cpp in Sources */,
+				EB9EE1E91BE9424500E8938F /* ZLFileSystem.cpp in Sources */,
+				EB9EE1EA1BE9424500E8938F /* ZLVirtualPath.cpp in Sources */,
+				EB9EE1EB1BE9424500E8938F /* ZLZipArchive.cpp in Sources */,
+				EB9EE1EC1BE9424500E8938F /* ZLZipStream.cpp in Sources */,
+				EB9EE1ED1BE9424500E8938F /* zlcore.cpp in Sources */,
+				EB9EE1EE1BE9424500E8938F /* MOAIMath.cpp in Sources */,
+				EB9EE1EF1BE9424500E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
+				EB9EE1F01BE9424500E8938F /* SFMT.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -8532,6 +10870,291 @@
 			};
 			name = Release;
 		};
+		EB9EE0091BE9421B00E8938F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CE18565F8B00775234 /* libmoai-ios-debug.xcconfig */;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					USE_ARES,
+					USE_OPENSSL,
+					USE_SSLEAY,
+					USE_SSL,
+					BUILDING_LIBCURL,
+					_DEBUG,
+					DEBUG,
+					POSIX,
+					SQLITE_ENABLE_COLUMN_METADATA,
+					"SQLITE_DEFAULT_FOREIGN_KEYS=1",
+					SQLITE_ENABLE_FTS3,
+					SQLITE_ENABLE_FTS3_PARENTHESIS,
+					TIXML_USE_STL,
+					HAVE_MEMMOVE,
+					XML_STATIC,
+					FT_DEBUG_LEVEL_ERROR,
+					FT_DEBUG_LEVEL_TRACE,
+					FT2_BUILD_LIBRARY,
+					DARWIN_NO_CARBON,
+					L_ENDIAN,
+					OPENSSL_NO_GMP,
+					OPENSSL_NO_JPAKE,
+					OPENSSL_NO_MD2,
+					OPENSSL_NO_RC5,
+					OPENSSL_NO_RFC3779,
+					OPENSSL_NO_STORE,
+					DISABLE_CHARTBOOST,
+					DISABLE_TWITTER,
+					DISABLE_FACEBOOK,
+					"USE_CHIPMUNK=0",
+					DISABLE_CRITTERCISM,
+					DISABLE_TAPJOY,
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		EB9EE00A1BE9421B00E8938F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CF18565F8B00775234 /* libmoai-ios-release.xcconfig */;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					USE_ARES,
+					USE_OPENSSL,
+					USE_SSLEAY,
+					USE_SSL,
+					BUILDING_LIBCURL,
+					POSIX,
+					SQLITE_ENABLE_COLUMN_METADATA,
+					"SQLITE_DEFAULT_FOREIGN_KEYS=1",
+					TIXML_USE_STL,
+					HAVE_MEMMOVE,
+					XML_STATIC,
+					FT2_BUILD_LIBRARY,
+					DARWIN_NO_CARBON,
+					L_ENDIAN,
+					OPENSSL_NO_GMP,
+					OPENSSL_NO_JPAKE,
+					OPENSSL_NO_MD2,
+					OPENSSL_NO_RC5,
+					OPENSSL_NO_RFC3779,
+					OPENSSL_NO_STORE,
+					DISABLE_TWITTER,
+					DISABLE_CHARTBOOST,
+					DISABLE_FACEBOOK,
+					"USE_CHIPMUNK=0",
+					DISABLE_CRITTERCISM,
+					DISABLE_TAPJOY,
+					MOAI_NO_DEFAULT_LOG_MESSAGES,
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		EB9EE1831BE9422800E8938F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CE18565F8B00775234 /* libmoai-ios-debug.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_CXX0X_EXTENSIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					USE_ARES,
+					USE_OPENSSL,
+					USE_SSLEAY,
+					USE_SSL,
+					BUILDING_LIBCURL,
+					_DEBUG,
+					DEBUG,
+					POSIX,
+					SQLITE_ENABLE_COLUMN_METADATA,
+					SQLITE_ENABLE_FTS3,
+					SQLITE_ENABLE_FTS3_PARENTHESIS,
+					"SQLITE_DEFAULT_FOREIGN_KEYS=1",
+					TIXML_USE_STL,
+					HAVE_MEMMOVE,
+					XML_STATIC,
+					FT_DEBUG_LEVEL_ERROR,
+					FT_DEBUG_LEVEL_TRACE,
+					FT2_BUILD_LIBRARY,
+					DARWIN_NO_CARBON,
+					L_ENDIAN,
+					OPENSSL_NO_GMP,
+					OPENSSL_NO_JPAKE,
+					OPENSSL_NO_MD2,
+					OPENSSL_NO_RC5,
+					OPENSSL_NO_RFC3779,
+					OPENSSL_NO_STORE,
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Debug;
+		};
+		EB9EE1841BE9422800E8938F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CF18565F8B00775234 /* libmoai-ios-release.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_CXX0X_EXTENSIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					USE_ARES,
+					USE_OPENSSL,
+					USE_SSLEAY,
+					USE_SSL,
+					BUILDING_LIBCURL,
+					POSIX,
+					SQLITE_ENABLE_COLUMN_METADATA,
+					"SQLITE_DEFAULT_FOREIGN_KEYS=1",
+					TIXML_USE_STL,
+					HAVE_MEMMOVE,
+					XML_STATIC,
+					FT2_BUILD_LIBRARY,
+					DARWIN_NO_CARBON,
+					L_ENDIAN,
+					OPENSSL_NO_GMP,
+					OPENSSL_NO_JPAKE,
+					OPENSSL_NO_MD2,
+					OPENSSL_NO_RC5,
+					OPENSSL_NO_RFC3779,
+					OPENSSL_NO_STORE,
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Release;
+		};
+		EB9EE1B61BE9423500E8938F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CE18565F8B00775234 /* libmoai-ios-debug.xcconfig */;
+			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Debug;
+		};
+		EB9EE1B71BE9423500E8938F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CF18565F8B00775234 /* libmoai-ios-release.xcconfig */;
+			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Release;
+		};
+		EB9EE1F31BE9424500E8938F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CE18565F8B00775234 /* libmoai-ios-debug.xcconfig */;
+			buildSettings = {
+				OTHER_CFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Debug;
+		};
+		EB9EE1F41BE9424500E8938F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5751E6CF18565F8B00775234 /* libmoai-ios-release.xcconfig */;
+			buildSettings = {
+				OTHER_CFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-w";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -8612,6 +11235,42 @@
 			buildConfigurations = (
 				CDD06D85139882D900AB0420 /* Debug */,
 				CDD06D86139882D900AB0420 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		EB9EE0081BE9421B00E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB9EE0091BE9421B00E8938F /* Debug */,
+				EB9EE00A1BE9421B00E8938F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		EB9EE1821BE9422800E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-3rdparty" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB9EE1831BE9422800E8938F /* Debug */,
+				EB9EE1841BE9422800E8938F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		EB9EE1B51BE9423500E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-luaext" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB9EE1B61BE9423500E8938F /* Debug */,
+				EB9EE1B71BE9423500E8938F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		EB9EE1F21BE9424500E8938F /* Build configuration list for PBXNativeTarget "libmoai-tvos-zlcore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB9EE1F31BE9424500E8938F /* Debug */,
+				EB9EE1F41BE9424500E8938F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -2971,7 +2971,6 @@
 		EB9EE1051BE9422800E8938F /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490059141AB6EC00913D80 /* loadlib.c */; };
 		EB9EE1061BE9422800E8938F /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005A141AB6EC00913D80 /* lobject.c */; };
 		EB9EE1071BE9422800E8938F /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005C141AB6EC00913D80 /* lopcodes.c */; };
-		EB9EE1081BE9422800E8938F /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005E141AB6EC00913D80 /* loslib.c */; };
 		EB9EE1091BE9422800E8938F /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49005F141AB6EC00913D80 /* lparser.c */; };
 		EB9EE10A1BE9422800E8938F /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490061141AB6EC00913D80 /* lstate.c */; };
 		EB9EE10B1BE9422800E8938F /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = CD490063141AB6EC00913D80 /* lstring.c */; };
@@ -9920,7 +9919,6 @@
 				EB9EE1051BE9422800E8938F /* loadlib.c in Sources */,
 				EB9EE1061BE9422800E8938F /* lobject.c in Sources */,
 				EB9EE1071BE9422800E8938F /* lopcodes.c in Sources */,
-				EB9EE1081BE9422800E8938F /* loslib.c in Sources */,
 				EB9EE1091BE9422800E8938F /* lparser.c in Sources */,
 				EB9EE10A1BE9422800E8938F /* lstate.c in Sources */,
 				EB9EE10B1BE9422800E8938F /* lstring.c in Sources */,

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -10910,7 +10910,9 @@
 				);
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
 		};
@@ -10950,7 +10952,9 @@
 				);
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
 		};
@@ -11010,7 +11014,9 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Debug;
@@ -11066,7 +11072,9 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Release;
@@ -11097,7 +11105,9 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Debug;
@@ -11128,7 +11138,9 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Release;
@@ -11139,7 +11151,9 @@
 			buildSettings = {
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Debug;
@@ -11150,7 +11164,9 @@
 			buildSettings = {
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
 				WARNING_CFLAGS = "-w";
 			};
 			name = Release;

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -3189,8 +3189,7 @@
 		EB9EE1EF1BE9424500E8938F /* MOAIFrameBufferTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD80D67016D8025000C172D2 /* MOAIFrameBufferTexture.cpp */; };
 		EB9EE1F01BE9424500E8938F /* SFMT.c in Sources */ = {isa = PBXBuildFile; fileRef = DD80D69916D8029700C172D2 /* SFMT.c */; };
 		EB9EE1F61BE94DA900E8938F /* AKU-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1D0BA213599FD200802A3C /* AKU-iphone.h */; };
-		EB9EE1F71BE94DB500E8938F /* AKU-iphone.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD1D0BA313599FD200802A3C /* AKU-iphone.mm */; };
-		EB9EE1F81BE94DC800E8938F /* moaiext-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD06ECA1398BA6200AB0420 /* moaiext-iphone.h */; };
+		EB9EE1FB1BE95D4F00E8938F /* moaiext-tvos.h in Headers */ = {isa = PBXBuildFile; fileRef = EB9EE1FA1BE95D4F00E8938F /* moaiext-tvos.h */; };
 		EBC495FA184D21840059FBDE /* MOAITextRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B45A8BEA1829A95C00D2B255 /* MOAITextRenderer.cpp */; };
 		EBC495FB184D21880059FBDE /* MOAITextRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = B45A8BEB1829A95C00D2B255 /* MOAITextRenderer.h */; };
 		F00D616E18C00F1E00625DA9 /* sha1_one.c in Sources */ = {isa = PBXBuildFile; fileRef = F055A9691846ACCF0031F295 /* sha1_one.c */; };
@@ -4395,6 +4394,7 @@
 		EB9EE1851BE9422800E8938F /* liblibmoai-tvos-3rdparty.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-3rdparty.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB9EE1B81BE9423500E8938F /* liblibmoai-tvos-luaext.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-luaext.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB9EE1F51BE9424500E8938F /* liblibmoai-tvos-zlcore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-tvos-zlcore.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB9EE1FA1BE95D4F00E8938F /* moaiext-tvos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "moaiext-tvos.h"; path = "moaiext-tvos/moaiext-tvos.h"; sourceTree = "<group>"; };
 		F055A9491846ABF40031F295 /* sha.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sha.h; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha.h"; sourceTree = "<group>"; };
 		F055A9641846ACA90031F295 /* sha_locl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sha_locl.h; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha_locl.h"; sourceTree = "<group>"; };
 		F055A9661846ACCF0031F295 /* sha_dgst.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sha_dgst.c; path = "../../3rdparty/openssl-1.0.0d/crypto/sha/sha_dgst.c"; sourceTree = "<group>"; };
@@ -4914,6 +4914,7 @@
 				0324E4F913564BC7000ADC60 /* moaicore */,
 				66459FB71511641F0075BF13 /* moaiext-audiosampler */,
 				CD5089FA155E3AC30002FC3B /* moaiext-fmod-ex */,
+				EB9EE1F91BE95C7200E8938F /* moaiext-tvos */,
 				CD524476135982480086DA15 /* moaiext-iphone */,
 				CD07C31713A174EB00C9386C /* moaiext-luaext */,
 				B408CA0918CE607B00F9A780 /* moaiext-test */,
@@ -6424,6 +6425,14 @@
 			name = render;
 			sourceTree = "<group>";
 		};
+		EB9EE1F91BE95C7200E8938F /* moaiext-tvos */ = {
+			isa = PBXGroup;
+			children = (
+				EB9EE1FA1BE95D4F00E8938F /* moaiext-tvos.h */,
+			);
+			name = "moaiext-tvos";
+			sourceTree = "<group>";
+		};
 		F055A9471846ABC30031F295 /* openssl */ = {
 			isa = PBXGroup;
 			children = (
@@ -7661,6 +7670,7 @@
 				EB9EDE0A1BE9421B00E8938F /* USUnion.h in Headers */,
 				EB9EDE0B1BE9421B00E8938F /* USVec2D.h in Headers */,
 				EB9EDE0C1BE9421B00E8938F /* USVec3D.h in Headers */,
+				EB9EE1FB1BE95D4F00E8938F /* moaiext-tvos.h in Headers */,
 				EB9EDE0D1BE9421B00E8938F /* USZip.h in Headers */,
 				EB9EDE0E1BE9421B00E8938F /* USZipFile.h in Headers */,
 				EB9EDE101BE9421B00E8938F /* MOAIEventSource.h in Headers */,
@@ -7718,7 +7728,6 @@
 				EB9EDE441BE9421B00E8938F /* MOAIBox2DRevoluteJoint.h in Headers */,
 				EB9EDE451BE9421B00E8938F /* MOAIBox2DWeldJoint.h in Headers */,
 				EB9EDE461BE9421B00E8938F /* MOAIAttrOp.h in Headers */,
-				EB9EE1F81BE94DC800E8938F /* moaiext-iphone.h in Headers */,
 				EB9EDE471BE9421B00E8938F /* MOAIBox2DRopeJoint.h in Headers */,
 				EB9EDE481BE9421B00E8938F /* MOAIBox2DWheelJoint.h in Headers */,
 				EB9EDE491BE9421B00E8938F /* MOAIEaseElasticBase.h in Headers */,
@@ -9549,7 +9558,6 @@
 				EB9EDEF31BE9421B00E8938F /* MOAITextStyle.cpp in Sources */,
 				EB9EDEF41BE9421B00E8938F /* MOAITextStyler.cpp in Sources */,
 				EB9EDEF51BE9421B00E8938F /* MOAIEaseSineOut.cpp in Sources */,
-				EB9EE1F71BE94DB500E8938F /* AKU-iphone.mm in Sources */,
 				EB9EDEF61BE9421B00E8938F /* MOAIGlyphCache.cpp in Sources */,
 				EB9EDEF71BE9421B00E8938F /* MOAIGlyphCacheBase.cpp in Sources */,
 				EB9EDEF81BE9421B00E8938F /* MOAIGlyphCachePage.cpp in Sources */,

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-3rdparty.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-3rdparty.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0379C3D51333ECD800E89DDC"
-               BuildableName = "libmoai-ios-3rdparty.a"
-               BlueprintName = "libmoai-ios-3rdparty"
+               BlueprintIdentifier = "EB9EE00C1BE9422800E8938F"
+               BuildableName = "liblibmoai-tvos-3rdparty.a"
+               BlueprintName = "libmoai-tvos-3rdparty"
                ReferencedContainer = "container:libmoai.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -25,7 +25,7 @@
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0379C3D51333ECD800E89DDC"
-            BuildableName = "libmoai-ios-3rdparty.a"
-            BlueprintName = "libmoai-ios-3rdparty"
+            BlueprintIdentifier = "EB9EE00C1BE9422800E8938F"
+            BuildableName = "liblibmoai-tvos-3rdparty.a"
+            BlueprintName = "libmoai-tvos-3rdparty"
             ReferencedContainer = "container:libmoai.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,6 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB9EE00C1BE9422800E8938F"
+            BuildableName = "liblibmoai-tvos-3rdparty.a"
+            BlueprintName = "libmoai-tvos-3rdparty"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-3rdparty.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-3rdparty.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0379C3D51333ECD800E89DDC"
+               BuildableName = "libmoai-ios-3rdparty.a"
+               BlueprintName = "libmoai-ios-3rdparty"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0379C3D51333ECD800E89DDC"
+            BuildableName = "libmoai-ios-3rdparty.a"
+            BlueprintName = "libmoai-ios-3rdparty"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-luaext.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-luaext.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CDD06A061398822500AB0420"
-               BuildableName = "libmoai-ios-luaext.a"
-               BlueprintName = "libmoai-ios-luaext"
+               BlueprintIdentifier = "EB9EE1861BE9423500E8938F"
+               BuildableName = "liblibmoai-tvos-luaext.a"
+               BlueprintName = "libmoai-tvos-luaext"
                ReferencedContainer = "container:libmoai.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -25,7 +25,7 @@
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CDD06A061398822500AB0420"
-            BuildableName = "libmoai-ios-luaext.a"
-            BlueprintName = "libmoai-ios-luaext"
+            BlueprintIdentifier = "EB9EE1861BE9423500E8938F"
+            BuildableName = "liblibmoai-tvos-luaext.a"
+            BlueprintName = "libmoai-tvos-luaext"
             ReferencedContainer = "container:libmoai.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,6 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB9EE1861BE9423500E8938F"
+            BuildableName = "liblibmoai-tvos-luaext.a"
+            BlueprintName = "libmoai-tvos-luaext"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-luaext.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-luaext.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDD06A061398822500AB0420"
+               BuildableName = "libmoai-ios-luaext.a"
+               BlueprintName = "libmoai-ios-luaext"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDD06A061398822500AB0420"
+            BuildableName = "libmoai-ios-luaext.a"
+            BlueprintName = "libmoai-ios-luaext"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-zlcore.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-zlcore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD04AABB14725568009C20E5"
-               BuildableName = "libmoai-ios-zlcore.a"
-               BlueprintName = "libmoai-ios-zlcore"
+               BlueprintIdentifier = "EB9EE1B91BE9424500E8938F"
+               BuildableName = "liblibmoai-tvos-zlcore.a"
+               BlueprintName = "libmoai-tvos-zlcore"
                ReferencedContainer = "container:libmoai.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -25,7 +25,7 @@
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD04AABB14725568009C20E5"
-            BuildableName = "libmoai-ios-zlcore.a"
-            BlueprintName = "libmoai-ios-zlcore"
+            BlueprintIdentifier = "EB9EE1B91BE9424500E8938F"
+            BuildableName = "liblibmoai-tvos-zlcore.a"
+            BlueprintName = "libmoai-tvos-zlcore"
             ReferencedContainer = "container:libmoai.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,6 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB9EE1B91BE9424500E8938F"
+            BuildableName = "liblibmoai-tvos-zlcore.a"
+            BlueprintName = "libmoai-tvos-zlcore"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-zlcore.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos-zlcore.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD04AABB14725568009C20E5"
+               BuildableName = "libmoai-ios-zlcore.a"
+               BlueprintName = "libmoai-ios-zlcore"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD04AABB14725568009C20E5"
+            BuildableName = "libmoai-ios-zlcore.a"
+            BlueprintName = "libmoai-ios-zlcore"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03C2F6F3104DE130009A2D5D"
+               BuildableName = "libmoai-ios.a"
+               BlueprintName = "libmoai-ios"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C2F6F3104DE130009A2D5D"
+            BuildableName = "libmoai-ios.a"
+            BlueprintName = "libmoai-ios"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-tvos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "03C2F6F3104DE130009A2D5D"
-               BuildableName = "libmoai-ios.a"
-               BlueprintName = "libmoai-ios"
+               BlueprintIdentifier = "EB9EDD971BE9421B00E8938F"
+               BuildableName = "liblibmoai-tvos.a"
+               BlueprintName = "libmoai-tvos"
                ReferencedContainer = "container:libmoai.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -25,7 +25,7 @@
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "03C2F6F3104DE130009A2D5D"
-            BuildableName = "libmoai-ios.a"
-            BlueprintName = "libmoai-ios"
+            BlueprintIdentifier = "EB9EDD971BE9421B00E8938F"
+            BuildableName = "liblibmoai-tvos.a"
+            BlueprintName = "libmoai-tvos"
             ReferencedContainer = "container:libmoai.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,6 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB9EDD971BE9421B00E8938F"
+            BuildableName = "liblibmoai-tvos.a"
+            BlueprintName = "libmoai-tvos"
+            ReferencedContainer = "container:libmoai.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This is the simplest way I could get Moai to compile on tvOS.  :tv: Most of the changes are just unchecked boxes in the Xcode project.  All changes are on the new targets, so existing platforms shouldn't be affected. :no_entry_sign: :iphone: 
