### PR TITLE
[FINAL] `MOAIDraw.fillStrip`

### DIFF
--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -1074,14 +1074,23 @@ int MOAIDraw::_fillEllipticalSliceGradient(lua_State *L){
 	@out	nil
 */
 int MOAIDraw::_fillFan ( lua_State* L ) {
-
-	if ( lua_istable ( L, -1 ) ) {
-		MOAIDraw::DrawLuaArray( L, GL_TRIANGLE_FAN );
-	} else {
-		MOAIDraw::DrawLuaParams( L, GL_TRIANGLE_FAN );
-	}
+	MOAIDraw::DrawFromLua( L, GL_TRIANGLE_FAN );
 	return 0;
 }
+
+//----------------------------------------------------------------//
+/**	@name	fillStrip
+	@text	Draw a filled triangle strip.
+	
+	@in		...		List of vertices (x, y) or an array of vertices
+					 { x0, y0, x1, y1, ... , xn, yn }
+	@out	nil
+ */
+int MOAIDraw::_fillStrip ( lua_State* L ) {
+	MOAIDraw::DrawFromLua( L, GL_TRIANGLE_STRIP );
+	return 0;
+}
+
 //----------------------------------------------------------------//
 /** @name	fillHorizontalRectangularGradient
 	@text	Draw a filled rectangle with a gradient between two colors
@@ -4319,6 +4328,16 @@ void MOAIDraw::DrawLuaArray ( lua_State* L, u32 primType ) {
 }
 
 //----------------------------------------------------------------//
+void MOAIDraw::DrawFromLua ( lua_State* L, u32 primType ) {
+	if ( lua_istable ( L, -1 ) ) {
+		MOAIDraw::DrawLuaArray( L, primType );
+	} else {
+		MOAIDraw::DrawLuaParams( L, primType );
+	}
+}
+
+
+//----------------------------------------------------------------//
 void MOAIDraw::DrawPoint ( const USVec2D& loc ) {
 
 	MOAIDraw::DrawPoint ( loc.mX, loc.mY );
@@ -5808,6 +5827,7 @@ void MOAIDraw::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "fillEllipticalSliceGradient", _fillEllipticalSliceGradient },
 		{ "fillHorizontalRectangularGradient", _fillHorizontalRectangularGradient },
 		{ "fillFan",				_fillFan },
+		{ "fillStrip",				_fillStrip },
 		{ "fillRect",				_fillRect },
 		{ "fillRoundedRect",		_fillRoundedRect },
 		{ "fillRoundedRectangularGradient",		_fillRoundedRectangularGradient },

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -57,6 +57,7 @@ private:
 	static int				_fillEllipticalSliceGradient ( lua_State* L );
 	static int				_fillHorizontalRectangularGradient ( lua_State* L );
 	static int				_fillFan			( lua_State* L );
+	static int				_fillStrip			( lua_State* L );
 	static int				_fillRect			( lua_State* L );
 	static int				_fillRoundedRect	( lua_State* L );
 	static int				_fillRoundedRectangularGradient	( lua_State* L );
@@ -68,6 +69,7 @@ private:
 	//----------------------------------------------------------------//
 	static void			DrawLuaParams			( lua_State* L, u32 primType );
 	static void			DrawLuaArray			( lua_State* L, u32 primType );
+	static void			DrawFromLua				( lua_State* L, u32 primType );
 
 public:
 

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -69,7 +69,7 @@ private:
 	//----------------------------------------------------------------//
 	static void			DrawLuaParams			( lua_State* L, u32 primType );
 	static void			DrawLuaArray			( lua_State* L, u32 primType );
-	static void			DrawFromLua				( lua_State* L, u32 primType );
+	static void			DrawFromLua             ( lua_State* L, u32 primType );
 
 public:
 

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -69,7 +69,7 @@ private:
 	//----------------------------------------------------------------//
 	static void			DrawLuaParams			( lua_State* L, u32 primType );
 	static void			DrawLuaArray			( lua_State* L, u32 primType );
-	static void			DrawFromLua             ( lua_State* L, u32 primType );
+	static void			DrawFromLua 			( lua_State* L, u32 primType );
 
 public:
 


### PR DESCRIPTION
Remember how I talked about `GL_TRIANGLE_FAN` and `GL_TRIANGLE_STRIP` recently? :small_red_triangle: :small_red_triangle_down: :small_red_triangle:  Well--we have two ways of drawing triangles directly in Moai. :moyai:  One is with a `MOAIMesh`, the more complicated way, which is what I used in the demo. :computer:  The other is with `MOAIDraw`, which is what we currently use for all of our graphics primitives (_most_ of the stuff games). :black_square_button:  The thing is, this whole time we've _only_ been using `GL_TRIANGLE_FAN`, because `MOAIDraw` left out a method to draw with `GL_TRIANGLE_STRIP`.  :underage:  This adds it.  :heavy_plus_sign: 
