### PR TITLE
[FINAL] Plug two tiny leaks in MOAIFreeTypeFont

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -343,10 +343,10 @@ int MOAIFreeTypeFont::_setDefaultSize(lua_State *L){
 FT_Face MOAIFreeTypeFont::AffirmFreeTypeFace () {
 	
 	if (!this->mFreeTypeFace) {
-		FT_Library library;
-		FT_Error error = FT_Init_FreeType( &library );
+		this->mLibrary = new FT_Library();
+		FT_Error error = FT_Init_FreeType( this->mLibrary );
 		CHECK_ERROR(error);
-		return this->LoadFreeTypeFace( &library );
+		return this->LoadFreeTypeFace( this->mLibrary );
 	}
 	else{
 		return this->mFreeTypeFace;
@@ -1037,6 +1037,7 @@ FT_Face MOAIFreeTypeFont::LoadFreeTypeFace ( FT_Library *library )
 MOAIFreeTypeFont::MOAIFreeTypeFont():
 	mDefaultSize( 0.0f ),
 	mFreeTypeFace( NULL ),
+	mLibrary( NULL ),
     mBitmapData( NULL ),
 	mBitmapWidth(0.0f),
 	mBitmapHeight(0.0f),
@@ -1050,6 +1051,14 @@ MOAIFreeTypeFont::MOAIFreeTypeFont():
 
 MOAIFreeTypeFont::~MOAIFreeTypeFont(){
 	this->ResetBitmapData();
+	if (this->mFreeTypeFace) {
+		FT_Done_Face(this->mFreeTypeFace);
+	}
+	
+	if (this->mLibrary) {
+		FT_Done_FreeType(*this->mLibrary);
+		delete this->mLibrary;
+	}
 }
 
 /*
@@ -1737,7 +1746,8 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	
 	delete [] positions;
 	deleteGlyphArray(glyphs, numGlyphs);
-	
+	delete [] xAdvances;
+	delete [] xOffsets;
 	
 	delete [] wideString; 
 	wideString = NULL;

--- a/src/moaicore/MOAIFreeTypeFont.h
+++ b/src/moaicore/MOAIFreeTypeFont.h
@@ -60,6 +60,8 @@ protected:
 		
 	FT_Face mFreeTypeFace;
 	
+	FT_Library *mLibrary;
+	
 	unsigned char* mBitmapData;
 	u32 mBitmapWidth;
 	u32 mBitmapHeight;


### PR DESCRIPTION
A while ago, I asked my brother to run another pass over the text system we added to Moai to be sure it's not leaking anything.  :potable_water:  He ran a bunch of tests and determined that--for the most part--it was indeed cleaning up after itself.  But, when we added the `xAdvances` and `xOffsets` arrays, there was one case where we forgot to `delete` them.  :speak_no_evil:  So that was leaking a few bytes.  :floppy_disk: 

Also, it turns out that when you're done using FreeType, you need to call `FT_Done_FreeType` to clean up any data that the library has cached.  :books:  Since we weren't calling this in `MOAIFreeTypeFont`'s destructor, a few more bytes were being leaked between games.  :scream_cat: 

This PR plugs the leaks.  :man: :wrench:  
