### PR TITLE
[FINAL] Use ndk location in ANDROID_NDK_HOME

### DIFF
--- a/ant/libmoai/build.sh
+++ b/ant/libmoai/build.sh
@@ -223,7 +223,7 @@
 	
 	# build libmoai
 	pushd jni > /dev/null
-		ndk-build $verbose NDK_DEBUG=$NDK_DEBUG -j 4
+		$ANDROID_NDK_HOME/ndk-build $verbose NDK_DEBUG=$NDK_DEBUG -j 4
 	popd > /dev/null
 
 	# remove temp files

--- a/ant/libmoai/jni/crypto/build.sh
+++ b/ant/libmoai/jni/crypto/build.sh
@@ -14,7 +14,7 @@
 
 		# build libcrypto-a, libcrypto-b, and libcrypto-c
 		pushd jni > /dev/null
-			ndk-build
+			$ANDROID_NDK_HOME/ndk-build
 		popd > /dev/null
 
 		# combine libs into final libcrypto
@@ -36,7 +36,7 @@
 		
 		# build libcrypto
 		pushd jni > /dev/null
-			ndk-build
+			$ANDROID_NDK_HOME/ndk-build
 		popd > /dev/null
 	fi
 


### PR DESCRIPTION
Change to use the ndk specified in ANDROID_NDK_HOME
