### PR TITLE
[Final] MOAIDraw: New gradient drawing functions

### DIFF
--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -3225,9 +3225,8 @@ void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float x
 	
 	float s = 0;
 	float t = 0;
-	USColorVec interpolatedColor = startColor;
+	USColorVec interpolatedColor;
 	
-	gfxDevice.SetPenColor(interpolatedColor);
 	u32 i;
 	for (i = 0; i <= steps; ++i, thetaStep += theta) {
 		s = Sin ( thetaStep );
@@ -3237,7 +3236,8 @@ void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float x
 							y + ( t * yRad ),
 							0.0f
 							);
-		
+		printf("t: %f \n", t);
+		t = fabs (t);
 		interpolatedColor.Lerp ( startColor, endColor, t );
 		
 		gfxDevice.SetPenColor(interpolatedColor);

--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -864,6 +864,80 @@ int MOAIDraw::_fillCircularSliceGradient(lua_State *L){
 }
 
 //----------------------------------------------------------------//
+/** @name	fillCircularSliceHorizontalGradient
+	
+	@overload
+	@in		number x		x-coordinate of circle
+	@in		number y		y-coordinate of circle
+	@in		number radius
+	@in		number angle		angle of the slice of the circle in degrees
+	@in		number offset		the offset clockwise from positive y axis in degrees.
+	@in		number blurMargin	default to zero
+	@in		number steps
+	@in		number centerR	red of starting color
+	@in		number centerG	green of starting color
+	@in		number centerB  blue of starting color
+	@in		number centerA	alpha of starting color
+	@in		number edgeR	red of ending color
+	@in		number edgeG	green of ending color
+	@in		number edgeB	blue of ending color
+	@in		number edgeA	alpha of ending color
+	@out	nil
+ 
+	@overload
+	@in		number x		x-coordinate of circle
+	@in		number y		y-coordinate of circle
+	@in		number radius
+	@in		number angle		angle of the slice of the circle in degrees
+	@in		number offset		the offset clockwise from positive y axis in degrees.
+	@in		number blurMargin	default to zero
+	@in		number steps
+	@in		MOAIColor startColor
+	@in		MOAIColor endColor
+	@out	nil
+ */
+int MOAIDraw::_fillCircularSliceHorizontalGradient(lua_State *L){
+	
+	MOAILuaState state ( L );
+	
+	float x				= state.GetValue < float >( 1, 0.0f );
+	float y				= state.GetValue < float >( 2, 0.0f );
+	float radius		= state.GetValue < float >( 3, 0.0f );
+	float angle			= state.GetValue < float >( 4, 0.0f );
+	float offset		= state.GetValue < float >( 5, 0.0f );
+	float blurMargin	= state.GetValue < float >( 6, 0.0f );
+	
+	u32	steps			= state.GetValue < u32 > ( 7, DEFAULT_ELLIPSE_STEPS );
+	
+	USColorVec startColor, endColor;
+	MOAIColor *color1, *color2;
+	
+	if ( ( color1 = state.GetLuaObject < MOAIColor > ( 8, false ) ) &&
+		( color2 = state.GetLuaObject < MOAIColor > ( 9, false ) ) ) {
+		startColor = color1->GetColorTrait();
+		endColor = color2->GetColorTrait();
+	}
+	else {
+		float centerR = state.GetValue < float > (8, 1.0f);
+		float centerG = state.GetValue < float > (9, 1.0f);
+		float centerB = state.GetValue < float > (10, 1.0f);
+		float centerA = state.GetValue < float > (11, 1.0f);
+		
+		float edgeR = state.GetValue < float > (12, 1.0f);
+		float edgeG = state.GetValue < float > (13, 1.0f);
+		float edgeB = state.GetValue < float > (14, 1.0f);
+		float edgeA = state.GetValue < float > (15, 1.0f);
+		
+		startColor.Set(centerR, centerG, centerB, centerA);
+		endColor.Set(edgeR, edgeG, edgeB, edgeA);
+	}
+	
+	MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(x, y, radius, radius, angle, offset, blurMargin, steps, startColor, endColor);
+	
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /** @name	fillCircularSliceVerticalGradient
 	
 	@overload
@@ -1374,7 +1448,7 @@ int MOAIDraw::_fillRoundedRectangularGradient ( lua_State *L ) {
 }
 
 //----------------------------------------------------------------//
-/** @name	fillRoundedRectangularGradient
+/** @name	fillRoundedRectangularHorizontalGradient
 	@text	Draw a filled rectangle with rounded corners.  The edge of the rectangle
  is one color and the center is another color.  The center is inset by the
  corner radius.
@@ -1404,8 +1478,84 @@ int MOAIDraw::_fillRoundedRectangularGradient ( lua_State *L ) {
 	@in		number cornerRadius
 	@in		number blurMargin
 	@in		number steps			The number of steps to make each corner.
-	@in		MOAIColor edgeColor
-	@in		MOAIColor centerColor
+	@in		MOAIColor leftColor
+	@in		MOAIColor rightColor
+	@out	nil
+ */
+
+int MOAIDraw::_fillRoundedRectangularHorizontalGradient ( lua_State *L ) {
+	
+	MOAILuaState state ( L );
+	
+	float x0 = state.GetValue < float > ( 1, 0.0f );
+	float y0 = state.GetValue < float > ( 2, 0.0f );
+	float x1 = state.GetValue < float > ( 3, 0.0f );
+	float y1 = state.GetValue < float > ( 4, 0.0f );
+	float cornerRadius = state.GetValue < float > (5, 0.0f);
+	float blurMargin = state.GetValue < float > (6, 0.0f);
+	u32 steps = state.GetValue < u32 > (7, DEFAULT_CURVE_STEPS);
+	
+	USColorVec leftColor, rightColor;
+	MOAIColor *color1, *color2;
+	
+	if ( ( color1 = state.GetLuaObject < MOAIColor > ( 8, false ) ) &&
+		( color2 = state.GetLuaObject < MOAIColor > ( 9, false ) ) ) {
+		leftColor = color1->GetColorTrait();
+		rightColor = color2->GetColorTrait();
+	}
+	else {
+		float centerR = state.GetValue < float > (8, 1.0f);
+		float centerG = state.GetValue < float > (9, 1.0f);
+		float centerB = state.GetValue < float > (10, 1.0f);
+		float centerA = state.GetValue < float > (11, 1.0f);
+		
+		float edgeR = state.GetValue < float > (12, 1.0f);
+		float edgeG = state.GetValue < float > (13, 1.0f);
+		float edgeB = state.GetValue < float > (14, 1.0f);
+		float edgeA = state.GetValue < float > (15, 1.0f);
+		
+		leftColor.Set(centerR, centerG, centerB, centerA);
+		rightColor.Set(edgeR, edgeG, edgeB, edgeA);
+	}
+	
+	MOAIDraw::DrawRoundedRectHorizontalGradientFill(x0, y0, x1, y1, cornerRadius, blurMargin, steps, leftColor, rightColor);
+	
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/** @name	fillRoundedRectangularVerticalGradient
+	@text	Draw a filled rectangle with rounded corners.  The edge of the rectangle
+ is one color and the center is another color.  The center is inset by the
+ corner radius.
+ 
+	@overload
+	@in		x0
+	@in		y0
+	@in		x1
+	@in		y1
+	@in		cornerRadius
+	@in		blurMargin
+	@in		steps			The number of steps to make each corner.
+	@in		number centerR		red of central color
+	@in		number centerG		green of central color
+	@in		number centerB		blue of central color
+	@in		number centerA		alpha of central color
+	@in		number edgeR		red of outer color
+	@in		number edgeG		green of outer color
+	@in		number edgeB		blue of outer color
+	@in		number edgeA		alpha of outer color
+	
+	@overload
+	@in		number x0
+	@in		number y0
+	@in		number x1
+	@in		number y1
+	@in		number cornerRadius
+	@in		number blurMargin
+	@in		number steps			The number of steps to make each corner.
+	@in		MOAIColor topColor
+	@in		MOAIColor bottomColor
 	@out	nil
  */
 
@@ -3205,9 +3355,90 @@ void MOAIDraw::DrawEllipticalSliceGradientFill(float x, float y, float xRad, flo
 }
 
 //----------------------------------------------------------------//
-// NOTE: This function only works for angle values up to and including 90 degrees
-void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor){
+void MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor){
 	
+	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
+	
+	bool renderBlur = blurMargin > 0.0f;
+	
+	float theta = angle * ( float )D2R / ( float )steps;
+	float thetaStep = offset * (float)D2R;
+	
+	USColorVec penColor = gfxDevice.GetPenColor();
+	
+	gfxDevice.BeginPrim( GL_TRIANGLE_FAN );
+	
+	gfxDevice.SetPenColor(startColor);
+	gfxDevice.WriteVtx(x, y, 0.0f);
+	gfxDevice.WriteFinalColor4b();
+	
+	float s = 0;
+	float t = 0;
+	USColorVec interpolatedColor;
+	
+	u32 i;
+	for (i = 0; i <= steps; ++i, thetaStep += theta) {
+		s = Sin ( thetaStep );
+		t = Cos ( thetaStep );
+		gfxDevice.WriteVtx (
+							x + ( s * xRad ),
+							y + ( t * yRad ),
+							0.0f
+							);
+		
+		s = fabs (s);
+		interpolatedColor.Lerp ( startColor, endColor, s );
+		
+		gfxDevice.SetPenColor(interpolatedColor);
+		gfxDevice.WriteFinalColor4b ();
+	}
+	
+	gfxDevice.EndPrim();
+	
+	//	TODO: Implement blur code
+	//	if (renderBlur) {
+	//		USColorVec transColor(edgeColor);
+	//		transColor.mA = 0.0f;
+	//		if (gfxDevice.GetColorPremultiply()) {
+	//			transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
+	//		}
+	//
+	//		thetaStep = offset * (float)D2R;
+	//		// render the arc section
+	//		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+	//		for (i = 0; i <= steps; ++i, thetaStep += theta ) {
+	//
+	//			// point at blur margin
+	//			gfxDevice.SetPenColor(transColor);
+	//			gfxDevice.WriteVtx (
+	//								x + ( Sin ( thetaStep ) * (xRad + blurMargin) ),
+	//								y + ( Cos ( thetaStep ) * (yRad + blurMargin) ),
+	//								0.0f
+	//								);
+	//			gfxDevice.WriteFinalColor4b ();
+	//
+	//
+	//			gfxDevice.SetPenColor(edgeColor);
+	//			gfxDevice.WriteVtx (
+	//								x + ( Sin ( thetaStep ) * xRad ),
+	//								y + ( Cos ( thetaStep ) * yRad ),
+	//								0.0f
+	//								);
+	//			gfxDevice.WriteFinalColor4b ();
+	//
+	//		}
+	//
+	//		gfxDevice.EndPrim();
+	//
+	//	}
+	gfxDevice.SetPenColor(penColor);
+	
+}
+
+
+//----------------------------------------------------------------//
+void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor){
+
 	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
 	
 	bool renderBlur = blurMargin > 0.0f;
@@ -5811,9 +6042,6 @@ void MOAIDraw::DrawRoundedRectGradientFill(float left, float top, float right, f
 		// draw lower right corner
 		offset += angle;
 		MOAIDraw::DrawEllipticalSliceGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, centerColor, edgeColor);
-		
-		
-		
 	}
 	
 	// restor pen color
@@ -5821,6 +6049,236 @@ void MOAIDraw::DrawRoundedRectGradientFill(float left, float top, float right, f
 	
 }
 
+//----------------------------------------------------------------//
+void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &leftColor, const USColorVec &rightColor){
+	
+	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
+	
+	bool renderBlur = blurMargin > 0.0f;
+	// make sure left is less than right
+	if (left > right) {
+		float temp = left;
+		left = right;
+		right = temp;
+	}
+	
+	// make sure bottom is less than top
+	if (bottom > top) {
+		float temp = top;
+		top = bottom;
+		bottom = temp;
+	}
+	
+	if (steps == 0){
+		steps = 1;
+	}
+	
+	float width = right - left;
+	
+	USColorVec penColor = gfxDevice.GetPenColor();
+	USColorVec workingColor = penColor;
+	//	USColorVec transColor(edgeColor);
+	
+	//	transColor.mA = 0.0f;
+	//	if (gfxDevice.GetColorPremultiply()) {
+	//		transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
+	//	}
+	
+	
+	// draw rect in center (left + cornerRadius, bottom + cornerRadius, right - cornerRadius, top - cornerRadius)
+	gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+	
+	float t = cornerRadius / width;
+	workingColor.Lerp (leftColor, rightColor, t);
+	gfxDevice.SetPenColor(workingColor);
+	
+	gfxDevice.WriteVtx(left + cornerRadius, bottom + cornerRadius);
+	gfxDevice.WriteFinalColor4b();
+	
+	gfxDevice.WriteVtx(left + cornerRadius, top - cornerRadius);
+	gfxDevice.WriteFinalColor4b();
+	
+	t = (right - cornerRadius) / width;
+	workingColor.Lerp (leftColor, rightColor, t);
+	gfxDevice.SetPenColor(workingColor);
+	
+	gfxDevice.WriteVtx(right - cornerRadius, bottom + cornerRadius);
+	gfxDevice.WriteFinalColor4b();
+	
+	gfxDevice.WriteVtx(right - cornerRadius, top - cornerRadius);
+	gfxDevice.WriteFinalColor4b();
+	
+	gfxDevice.EndPrim();
+	
+	if (cornerRadius > 0.0f) {
+		// draw top rect (left + cornerRadius, top - cornerRadius, right - cornerRadius, top)
+		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+		
+		t = cornerRadius / width;
+		workingColor.Lerp (leftColor, rightColor, t);
+		
+		gfxDevice.SetPenColor(workingColor);
+		gfxDevice.WriteVtx(left + cornerRadius, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(left + cornerRadius, top);
+		gfxDevice.WriteFinalColor4b();
+		
+		t = (right - cornerRadius) / width;
+		workingColor.Lerp(leftColor, rightColor, t);
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(right - cornerRadius, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(right - cornerRadius, top);
+		gfxDevice.WriteFinalColor4b();
+		
+		//		if (renderBlur) {
+		//			gfxDevice.SetPenColor(transColor);
+		//			gfxDevice.WriteVtx(left + cornerRadius, top + blurMargin);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//			gfxDevice.WriteVtx(right - cornerRadius, top + blurMargin);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//		}
+		
+		gfxDevice.EndPrim();
+		
+		// draw bottom rect (left + cornerRadius, bottom , right - cornerRadius, bottom + cornerRadius)
+		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+		
+		//		if (renderBlur) {
+		//			gfxDevice.SetPenColor(transColor);
+		//			gfxDevice.WriteVtx(left + cornerRadius, bottom - blurMargin);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//			gfxDevice.WriteVtx(right - cornerRadius, bottom - blurMargin);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//		}
+		
+		t = cornerRadius / width;
+		workingColor.Lerp(leftColor, rightColor, t);
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(left + cornerRadius, bottom);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(left + cornerRadius, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		t = (right - cornerRadius) / width;
+		workingColor.Lerp (leftColor, rightColor, t);
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(right - cornerRadius, bottom);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(right - cornerRadius, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.EndPrim();
+		
+		// draw left rect (left, bottom + cornerRadius, left + cornerRadius, top - cornerRadius)
+		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+		
+		//		if (renderBlur) {
+		//			gfxDevice.SetPenColor(transColor);
+		//			gfxDevice.WriteVtx(left - blurMargin, bottom + cornerRadius);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//			gfxDevice.WriteVtx(left - blurMargin, top - cornerRadius);
+		//			gfxDevice.WriteFinalColor4b();
+		//		}
+		
+		workingColor = leftColor;
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(left, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(left, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		t = cornerRadius / width;
+		workingColor.Lerp (leftColor, rightColor, t);
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(left + cornerRadius, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+	
+		gfxDevice.WriteVtx(left + cornerRadius, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.EndPrim();
+		
+		// draw right rect (right - cornerRadius, bottom + cornerRadius, right, top - cornerRadius )
+		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
+		
+		t = (right - cornerRadius) / width;
+		workingColor.Lerp (leftColor, rightColor, t);
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(right - cornerRadius, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(right - cornerRadius, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		workingColor = rightColor;
+		gfxDevice.SetPenColor(workingColor);
+		
+		gfxDevice.WriteVtx(right, bottom + cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		gfxDevice.WriteVtx(right, top - cornerRadius);
+		gfxDevice.WriteFinalColor4b();
+		
+		//		if (renderBlur) {
+		//			gfxDevice.SetPenColor(transColor);
+		//			gfxDevice.WriteVtx(right + blurMargin, bottom + cornerRadius);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//			gfxDevice.WriteVtx(right + blurMargin, top - cornerRadius);
+		//			gfxDevice.WriteFinalColor4b();
+		//
+		//		}
+		
+		gfxDevice.EndPrim();
+		
+		float angle = 90.0f;
+		float offset = 0.0f;
+		
+		USColorVec cornerStartColor = leftColor;
+		USColorVec cornerEndColor = rightColor;
+		
+		// draw upper right corner
+		t = (right - cornerRadius) / width;
+		cornerStartColor.Lerp (leftColor, rightColor, t);
+		MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(right - cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
+		
+		// draw lower right corner
+		offset += angle;
+		MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
+		
+		// draw lower left corner
+		t = cornerRadius / width;
+		cornerStartColor.Lerp (leftColor, rightColor, t);
+		cornerEndColor = leftColor;
+		offset += angle;
+		MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(left + cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
+		
+		// draw upper left corner
+		offset += angle;
+		MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(left + cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
+	}
+	
+	// restor pen color
+	gfxDevice.SetPenColor(penColor);
+	
+}
 
 //----------------------------------------------------------------//
 void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &topColor, const USColorVec &bottomColor){
@@ -6024,28 +6482,28 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 		float angle = 90.0f;
 		float offset = -90;
 		
-		USColorVec cornerTopColor = topColor;
-		USColorVec cornerBottomColor = bottomColor;
+		USColorVec cornerStartColor = bottomColor;
+		USColorVec cornerEndColor = topColor;
 		
 		// draw upper left corner
 		t = (top - cornerRadius) / height;
-		cornerBottomColor.Lerp (bottomColor, topColor, t);
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerBottomColor, cornerTopColor);
+		cornerStartColor.Lerp (bottomColor, topColor, t);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
 		
 		// draw upper right corner
 		offset += angle;
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerBottomColor, cornerTopColor);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, top - cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
 		
 		// draw lower right corner
 		t = cornerRadius / height;
-		cornerTopColor.Lerp (bottomColor, topColor, t);
-		cornerBottomColor = bottomColor;
+		cornerStartColor.Lerp (bottomColor, topColor, t);
+		cornerEndColor = bottomColor;
 		offset += angle;
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerTopColor, cornerBottomColor);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
 		
 		// draw lower left corner
 		offset += angle;
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerTopColor, cornerBottomColor);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerStartColor, cornerEndColor);
 	}
 	
 	// restor pen color
@@ -6285,6 +6743,7 @@ void MOAIDraw::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "fillCircularGradient",	_fillCircularGradient },
 		{ "fillCircularSlice",		_fillCircularSlice },
 		{ "fillCircularSliceGradient", _fillCircularSliceGradient },
+		{ "fillCircularSliceHorizontalGradient", _fillCircularSliceHorizontalGradient},
 		{ "fillCircularSliceVerticalGradient", _fillCircularSliceVerticalGradient},
 		{ "fillEllipse",			_fillEllipse },
 		{ "fillEllipticalGradient",	_fillEllipticalGradient },
@@ -6296,6 +6755,7 @@ void MOAIDraw::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "fillRect",				_fillRect },
 		{ "fillRoundedRect",		_fillRoundedRect },
 		{ "fillRoundedRectangularGradient",		_fillRoundedRectangularGradient },
+		{ "fillRoundedRectangularHorizontalGradient",	_fillRoundedRectangularHorizontalGradient},
 		{ "fillRoundedRectangularVerticalGradient",	_fillRoundedRectangularVerticalGradient},
 		{ "fillTriangularGradient", _fillTriangularGradient },
 		{ "fillVerticalRectangularGradient", _fillVerticalRectangularGradient },

--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -3236,7 +3236,7 @@ void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float x
 							y + ( t * yRad ),
 							0.0f
 							);
-		printf("t: %f \n", t);
+
 		t = fabs (t);
 		interpolatedColor.Lerp ( startColor, endColor, t );
 		
@@ -6041,11 +6041,11 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 		cornerTopColor.Lerp (bottomColor, topColor, t);
 		cornerBottomColor = bottomColor;
 		offset += angle;
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerBottomColor, cornerTopColor);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(right - cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerTopColor, cornerBottomColor);
 		
 		// draw lower left corner
 		offset += angle;
-		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerBottomColor, cornerTopColor);
+		MOAIDraw::DrawEllipticalSliceVerticalGradientFill(left + cornerRadius, bottom + cornerRadius, cornerRadius, cornerRadius, angle, offset, blurMargin, steps, cornerTopColor, cornerBottomColor);
 	}
 	
 	// restor pen color

--- a/src/moaicore/MOAIDraw.cpp
+++ b/src/moaicore/MOAIDraw.cpp
@@ -1461,14 +1461,14 @@ int MOAIDraw::_fillRoundedRectangularGradient ( lua_State *L ) {
 	@in		cornerRadius
 	@in		blurMargin
 	@in		steps			The number of steps to make each corner.
-	@in		number centerR		red of central color
-	@in		number centerG		green of central color
-	@in		number centerB		blue of central color
-	@in		number centerA		alpha of central color
-	@in		number edgeR		red of outer color
-	@in		number edgeG		green of outer color
-	@in		number edgeB		blue of outer color
-	@in		number edgeA		alpha of outer color
+	@in		number centerR		red of left color
+	@in		number centerG		green of left color
+	@in		number centerB		blue of left color
+	@in		number centerA		alpha of left color
+	@in		number edgeR		red of right color
+	@in		number edgeG		green of right color
+	@in		number edgeB		blue of right color
+	@in		number edgeA		alpha of right color
 	
 	@overload
 	@in		number x0
@@ -1537,14 +1537,14 @@ int MOAIDraw::_fillRoundedRectangularHorizontalGradient ( lua_State *L ) {
 	@in		cornerRadius
 	@in		blurMargin
 	@in		steps			The number of steps to make each corner.
-	@in		number centerR		red of central color
-	@in		number centerG		green of central color
-	@in		number centerB		blue of central color
-	@in		number centerA		alpha of central color
-	@in		number edgeR		red of outer color
-	@in		number edgeG		green of outer color
-	@in		number edgeB		blue of outer color
-	@in		number edgeA		alpha of outer color
+	@in		number centerR		red of top color
+	@in		number centerG		green of top color
+	@in		number centerB		blue of top color
+	@in		number centerA		alpha of top color
+	@in		number edgeR		red of bottom color
+	@in		number edgeG		green of bottom color
+	@in		number edgeB		blue of bottom color
+	@in		number edgeA		alpha of bottom color
 	
 	@overload
 	@in		number x0
@@ -3359,8 +3359,6 @@ void MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(float x, float y, float
 	
 	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
 	
-	bool renderBlur = blurMargin > 0.0f;
-	
 	float theta = angle * ( float )D2R / ( float )steps;
 	float thetaStep = offset * (float)D2R;
 	
@@ -3396,41 +3394,6 @@ void MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(float x, float y, float
 	gfxDevice.EndPrim();
 	
 	//	TODO: Implement blur code
-	//	if (renderBlur) {
-	//		USColorVec transColor(edgeColor);
-	//		transColor.mA = 0.0f;
-	//		if (gfxDevice.GetColorPremultiply()) {
-	//			transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
-	//		}
-	//
-	//		thetaStep = offset * (float)D2R;
-	//		// render the arc section
-	//		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-	//		for (i = 0; i <= steps; ++i, thetaStep += theta ) {
-	//
-	//			// point at blur margin
-	//			gfxDevice.SetPenColor(transColor);
-	//			gfxDevice.WriteVtx (
-	//								x + ( Sin ( thetaStep ) * (xRad + blurMargin) ),
-	//								y + ( Cos ( thetaStep ) * (yRad + blurMargin) ),
-	//								0.0f
-	//								);
-	//			gfxDevice.WriteFinalColor4b ();
-	//
-	//
-	//			gfxDevice.SetPenColor(edgeColor);
-	//			gfxDevice.WriteVtx (
-	//								x + ( Sin ( thetaStep ) * xRad ),
-	//								y + ( Cos ( thetaStep ) * yRad ),
-	//								0.0f
-	//								);
-	//			gfxDevice.WriteFinalColor4b ();
-	//
-	//		}
-	//
-	//		gfxDevice.EndPrim();
-	//
-	//	}
 	gfxDevice.SetPenColor(penColor);
 	
 }
@@ -3440,8 +3403,6 @@ void MOAIDraw::DrawEllipticalSliceHorizontalGradientFill(float x, float y, float
 void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor){
 
 	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
-	
-	bool renderBlur = blurMargin > 0.0f;
 	
 	float theta = angle * ( float )D2R / ( float )steps;
 	float thetaStep = offset * (float)D2R;
@@ -3477,42 +3438,7 @@ void MOAIDraw::DrawEllipticalSliceVerticalGradientFill(float x, float y, float x
 	
 	gfxDevice.EndPrim();
 
-//	TODO: Implement blur code
-//	if (renderBlur) {
-//		USColorVec transColor(edgeColor);
-//		transColor.mA = 0.0f;
-//		if (gfxDevice.GetColorPremultiply()) {
-//			transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
-//		}
-//		
-//		thetaStep = offset * (float)D2R;
-//		// render the arc section
-//		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-//		for (i = 0; i <= steps; ++i, thetaStep += theta ) {
-//			
-//			// point at blur margin
-//			gfxDevice.SetPenColor(transColor);
-//			gfxDevice.WriteVtx (
-//								x + ( Sin ( thetaStep ) * (xRad + blurMargin) ),
-//								y + ( Cos ( thetaStep ) * (yRad + blurMargin) ),
-//								0.0f
-//								);
-//			gfxDevice.WriteFinalColor4b ();
-//			
-//			
-//			gfxDevice.SetPenColor(edgeColor);
-//			gfxDevice.WriteVtx (
-//								x + ( Sin ( thetaStep ) * xRad ),
-//								y + ( Cos ( thetaStep ) * yRad ),
-//								0.0f
-//								);
-//			gfxDevice.WriteFinalColor4b ();
-//			
-//		}
-//		
-//		gfxDevice.EndPrim();
-//		
-//	}
+	//	TODO: Implement blur code
 	gfxDevice.SetPenColor(penColor);
 	
 }
@@ -6054,7 +5980,6 @@ void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, floa
 	
 	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
 	
-	bool renderBlur = blurMargin > 0.0f;
 	// make sure left is less than right
 	if (left > right) {
 		float temp = left;
@@ -6075,15 +6000,9 @@ void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, floa
 	
 	float width = right - left;
 	
+	// TODO: Implement blur code
 	USColorVec penColor = gfxDevice.GetPenColor();
 	USColorVec workingColor = penColor;
-	//	USColorVec transColor(edgeColor);
-	
-	//	transColor.mA = 0.0f;
-	//	if (gfxDevice.GetColorPremultiply()) {
-	//		transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
-	//	}
-	
 	
 	// draw rect in center (left + cornerRadius, bottom + cornerRadius, right - cornerRadius, top - cornerRadius)
 	gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
@@ -6134,30 +6053,10 @@ void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, floa
 		gfxDevice.WriteVtx(right - cornerRadius, top);
 		gfxDevice.WriteFinalColor4b();
 		
-		//		if (renderBlur) {
-		//			gfxDevice.SetPenColor(transColor);
-		//			gfxDevice.WriteVtx(left + cornerRadius, top + blurMargin);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//			gfxDevice.WriteVtx(right - cornerRadius, top + blurMargin);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//		}
-		
 		gfxDevice.EndPrim();
 		
 		// draw bottom rect (left + cornerRadius, bottom , right - cornerRadius, bottom + cornerRadius)
 		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-		
-		//		if (renderBlur) {
-		//			gfxDevice.SetPenColor(transColor);
-		//			gfxDevice.WriteVtx(left + cornerRadius, bottom - blurMargin);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//			gfxDevice.WriteVtx(right - cornerRadius, bottom - blurMargin);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//		}
 		
 		t = cornerRadius / width;
 		workingColor.Lerp(leftColor, rightColor, t);
@@ -6183,15 +6082,6 @@ void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, floa
 		
 		// draw left rect (left, bottom + cornerRadius, left + cornerRadius, top - cornerRadius)
 		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-		
-		//		if (renderBlur) {
-		//			gfxDevice.SetPenColor(transColor);
-		//			gfxDevice.WriteVtx(left - blurMargin, bottom + cornerRadius);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//			gfxDevice.WriteVtx(left - blurMargin, top - cornerRadius);
-		//			gfxDevice.WriteFinalColor4b();
-		//		}
 		
 		workingColor = leftColor;
 		gfxDevice.SetPenColor(workingColor);
@@ -6236,16 +6126,6 @@ void MOAIDraw::DrawRoundedRectHorizontalGradientFill(float left, float top, floa
 		gfxDevice.WriteVtx(right, top - cornerRadius);
 		gfxDevice.WriteFinalColor4b();
 		
-		//		if (renderBlur) {
-		//			gfxDevice.SetPenColor(transColor);
-		//			gfxDevice.WriteVtx(right + blurMargin, bottom + cornerRadius);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//			gfxDevice.WriteVtx(right + blurMargin, top - cornerRadius);
-		//			gfxDevice.WriteFinalColor4b();
-		//
-		//		}
-		
 		gfxDevice.EndPrim();
 		
 		float angle = 90.0f;
@@ -6285,7 +6165,6 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 	
 	MOAIGfxDevice& gfxDevice = MOAIGfxDevice::Get ();
 	
-	bool renderBlur = blurMargin > 0.0f;
 	// make sure left is less than right
 	if (left > right) {
 		float temp = left;
@@ -6306,15 +6185,10 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 	
 	float height = top - bottom;
 	
+	// TODO: Implement blur code
+	
 	USColorVec penColor = gfxDevice.GetPenColor();
 	USColorVec workingColor = penColor;
-//	USColorVec transColor(edgeColor);
-	
-//	transColor.mA = 0.0f;
-//	if (gfxDevice.GetColorPremultiply()) {
-//		transColor.Set(0.0f, 0.0f, 0.0f, 0.0f);
-//	}
-	
 	
 	// draw rect in center (left + cornerRadius, bottom + cornerRadius, right - cornerRadius, top - cornerRadius)
 	gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
@@ -6364,30 +6238,10 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 		gfxDevice.WriteVtx(right - cornerRadius, top);
 		gfxDevice.WriteFinalColor4b();
 		
-//		if (renderBlur) {
-//			gfxDevice.SetPenColor(transColor);
-//			gfxDevice.WriteVtx(left + cornerRadius, top + blurMargin);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//			gfxDevice.WriteVtx(right - cornerRadius, top + blurMargin);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//		}
-		
 		gfxDevice.EndPrim();
 		
 		// draw bottom rect (left + cornerRadius, bottom , right - cornerRadius, bottom + cornerRadius)
 		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-		
-//		if (renderBlur) {
-//			gfxDevice.SetPenColor(transColor);
-//			gfxDevice.WriteVtx(left + cornerRadius, bottom - blurMargin);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//			gfxDevice.WriteVtx(right - cornerRadius, bottom - blurMargin);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//		}
 		
 		workingColor = bottomColor;
 		
@@ -6412,15 +6266,6 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 		
 		// draw left rect (left, bottom + cornerRadius, left + cornerRadius, top - cornerRadius)
 		gfxDevice.BeginPrim( GL_TRIANGLE_STRIP );
-		
-//		if (renderBlur) {
-//			gfxDevice.SetPenColor(transColor);
-//			gfxDevice.WriteVtx(left - blurMargin, bottom + cornerRadius);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//			gfxDevice.WriteVtx(left - blurMargin, top - cornerRadius);
-//			gfxDevice.WriteFinalColor4b();
-//		}
 		
 		t = cornerRadius / height;
 		workingColor.Lerp (bottomColor, topColor, t);
@@ -6466,16 +6311,6 @@ void MOAIDraw::DrawRoundedRectVerticalGradientFill(float left, float top, float 
 		
 		gfxDevice.WriteVtx(right, top - cornerRadius);
 		gfxDevice.WriteFinalColor4b();
-		
-//		if (renderBlur) {
-//			gfxDevice.SetPenColor(transColor);
-//			gfxDevice.WriteVtx(right + blurMargin, bottom + cornerRadius);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//			gfxDevice.WriteVtx(right + blurMargin, top - cornerRadius);
-//			gfxDevice.WriteFinalColor4b();
-//			
-//		}
 		
 		gfxDevice.EndPrim();
 		

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -52,6 +52,7 @@ private:
 	static int				_fillCircularSlice	( lua_State* L );
 	static int				_fillCircularSliceGradient	( lua_State* L );
 	static int				_fillCircularSliceVerticalGradient	( lua_State* L );
+	static int				_fillCircularSliceHorizontalGradient	( lua_State* L );
 	static int				_fillEllipse		( lua_State* L );
 	static int				_fillEllipticalGradient	( lua_State* L );
 	static int				_fillEllipticalSlice( lua_State* L );
@@ -63,6 +64,7 @@ private:
 	static int				_fillRoundedRect	( lua_State* L );
 	static int				_fillRoundedRectangularGradient	( lua_State* L );
 	static int				_fillRoundedRectangularVerticalGradient	( lua_State* L );
+	static int				_fillRoundedRectangularHorizontalGradient	( lua_State* L );
 	static int				_fillTriangularGradient ( lua_State* L );
 	static int				_fillVerticalRectangularGradient ( lua_State* L );
 	static int				_drawTexture		( lua_State* L );
@@ -99,6 +101,7 @@ public:
 	static void			DrawEllipticalSliceFill		( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps );
 	static void			DrawEllipticalSliceGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
 	static void			DrawEllipticalSliceVerticalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
+	static void			DrawEllipticalSliceHorizontalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
 	static void			DrawGrid				( const USRect& rect, u32 xCells, u32 yCells );
 	static void			DrawJoinedCorner		( float x0, float y0, float x1, float y1, float x2, float y2, float lineWidth, float blurMargin );
 	static void			DrawJoinedLine			( lua_State* L, float lineWidth, float blurMargin );
@@ -123,6 +126,7 @@ public:
 	static void			DrawRoundedRectFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps );
 	static void			DrawRoundedRectGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
 	static void			DrawRoundedRectVerticalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &topColor, const USColorVec &bottomColor );
+	static void			DrawRoundedRectHorizontalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &leftColor, const USColorVec &rightColor );
 	static void			DrawRoundedRectOutline	( float left, float top, float right, float bottom, float cornerRadius, u32 steps );
 	static void			DrawTexture				( float left, float top, float right, float bottom, MOAITexture* texture );
 	static void			DrawTriangularGradientFill (const USVec2D& v0, const USVec2D& v1, const USVec2D& v2, const USColorVec &color0, const USColorVec &color1, const USColorVec &color2);

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -51,8 +51,8 @@ private:
 	static int				_fillCircularGradient ( lua_State* L );
 	static int				_fillCircularSlice	( lua_State* L );
 	static int				_fillCircularSliceGradient	( lua_State* L );
-	static int				_fillCircularSliceVerticalGradient	( lua_State* L );
 	static int				_fillCircularSliceHorizontalGradient	( lua_State* L );
+	static int				_fillCircularSliceVerticalGradient	( lua_State* L );
 	static int				_fillEllipse		( lua_State* L );
 	static int				_fillEllipticalGradient	( lua_State* L );
 	static int				_fillEllipticalSlice( lua_State* L );
@@ -63,8 +63,8 @@ private:
 	static int				_fillRect			( lua_State* L );
 	static int				_fillRoundedRect	( lua_State* L );
 	static int				_fillRoundedRectangularGradient	( lua_State* L );
-	static int				_fillRoundedRectangularVerticalGradient	( lua_State* L );
 	static int				_fillRoundedRectangularHorizontalGradient	( lua_State* L );
+	static int				_fillRoundedRectangularVerticalGradient	( lua_State* L );
 	static int				_fillTriangularGradient ( lua_State* L );
 	static int				_fillVerticalRectangularGradient ( lua_State* L );
 	static int				_drawTexture		( lua_State* L );
@@ -100,8 +100,8 @@ public:
 	static void			DrawEllipticalGradientFill ( float x, float y, float xRad, float yRad, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
 	static void			DrawEllipticalSliceFill		( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps );
 	static void			DrawEllipticalSliceGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
-	static void			DrawEllipticalSliceVerticalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
 	static void			DrawEllipticalSliceHorizontalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
+	static void			DrawEllipticalSliceVerticalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
 	static void			DrawGrid				( const USRect& rect, u32 xCells, u32 yCells );
 	static void			DrawJoinedCorner		( float x0, float y0, float x1, float y1, float x2, float y2, float lineWidth, float blurMargin );
 	static void			DrawJoinedLine			( lua_State* L, float lineWidth, float blurMargin );
@@ -125,8 +125,8 @@ public:
 	static void			DrawRoundBeveledLine	( lua_State* L, float lineWidth, float blurMargin, u32 steps );
 	static void			DrawRoundedRectFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps );
 	static void			DrawRoundedRectGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
-	static void			DrawRoundedRectVerticalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &topColor, const USColorVec &bottomColor );
 	static void			DrawRoundedRectHorizontalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &leftColor, const USColorVec &rightColor );
+	static void			DrawRoundedRectVerticalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &topColor, const USColorVec &bottomColor );
 	static void			DrawRoundedRectOutline	( float left, float top, float right, float bottom, float cornerRadius, u32 steps );
 	static void			DrawTexture				( float left, float top, float right, float bottom, MOAITexture* texture );
 	static void			DrawTriangularGradientFill (const USVec2D& v0, const USVec2D& v1, const USVec2D& v2, const USColorVec &color0, const USColorVec &color1, const USColorVec &color2);

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -62,6 +62,7 @@ private:
 	static int				_fillRect			( lua_State* L );
 	static int				_fillRoundedRect	( lua_State* L );
 	static int				_fillRoundedRectangularGradient	( lua_State* L );
+	static int				_fillRoundedRectangularVerticalGradient	( lua_State* L );
 	static int				_fillTriangularGradient ( lua_State* L );
 	static int				_fillVerticalRectangularGradient ( lua_State* L );
 	static int				_drawTexture		( lua_State* L );
@@ -121,6 +122,7 @@ public:
 	static void			DrawRoundBeveledLine	( lua_State* L, float lineWidth, float blurMargin, u32 steps );
 	static void			DrawRoundedRectFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps );
 	static void			DrawRoundedRectGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
+	static void			DrawRoundedRectVerticalGradientFill		( float left, float top, float right, float bottom, float cornerRadius, float blurMargin, u32 steps, const USColorVec &topColor, const USColorVec &bottomColor );
 	static void			DrawRoundedRectOutline	( float left, float top, float right, float bottom, float cornerRadius, u32 steps );
 	static void			DrawTexture				( float left, float top, float right, float bottom, MOAITexture* texture );
 	static void			DrawTriangularGradientFill (const USVec2D& v0, const USVec2D& v1, const USVec2D& v2, const USColorVec &color0, const USColorVec &color1, const USColorVec &color2);

--- a/src/moaicore/MOAIDraw.h
+++ b/src/moaicore/MOAIDraw.h
@@ -51,6 +51,7 @@ private:
 	static int				_fillCircularGradient ( lua_State* L );
 	static int				_fillCircularSlice	( lua_State* L );
 	static int				_fillCircularSliceGradient	( lua_State* L );
+	static int				_fillCircularSliceVerticalGradient	( lua_State* L );
 	static int				_fillEllipse		( lua_State* L );
 	static int				_fillEllipticalGradient	( lua_State* L );
 	static int				_fillEllipticalSlice( lua_State* L );
@@ -96,6 +97,7 @@ public:
 	static void			DrawEllipticalGradientFill ( float x, float y, float xRad, float yRad, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
 	static void			DrawEllipticalSliceFill		( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps );
 	static void			DrawEllipticalSliceGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &centerColor, const USColorVec &edgeColor );
+	static void			DrawEllipticalSliceVerticalGradientFill ( float x, float y, float xRad, float yRad, float angle, float offset, float blurMargin, u32 steps, const USColorVec &startColor, const USColorVec &endColor );
 	static void			DrawGrid				( const USRect& rect, u32 xCells, u32 yCells );
 	static void			DrawJoinedCorner		( float x0, float y0, float x1, float y1, float x2, float y2, float lineWidth, float blurMargin );
 	static void			DrawJoinedLine			( lua_State* L, float lineWidth, float blurMargin );


### PR DESCRIPTION
### Description

PR adds functionality for drawing rounded rectangle gradients, specifically vertical and horizontal gradients. Part of that also meant implementing vertical and horizontal circle segment gradients as well. While gradients did exist for both of these kinds of shapes already, they were only centered gradients.
### User facing changes

Should be none at the moment.
### Best way to test for this change

Need to test on a device to make sure these new functions work properly, but at the moment they're not used anywhere.
### Required items
- [ ] https://github.com/mindsnacks/wonder_content/pull/1717 is needed to make use of these changes, but this PR needs to be merged first
