### PR TITLE
[FINAL] Remove deprecated UILocalNotification

### DIFF
--- a/src/aku/AKU-iphone.h
+++ b/src/aku/AKU-iphone.h
@@ -27,7 +27,6 @@ void			AKUAppOpenFromURL								( NSURL* url );
 void			AKUAppWillEndSession							();
 const char*		AKUGetGUID										();
 void			AKUIphoneInit									( UIApplication* application );
-void			AKUNotifyLocalNotificationReceived				( UILocalNotification* notification );
 void			AKUNotifyRemoteNotificationReceived				( NSDictionary* notification );
 void			AKUNotifyRemoteNotificationRegistrationComplete	( NSData* deviceToken );
 void			AKUSetConnectionType							( long type );

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -90,14 +90,6 @@ void AKUIphoneInit ( UIApplication* application ) {
 }
 
 //----------------------------------------------------------------//
-void AKUNotifyLocalNotificationReceived ( UILocalNotification* notification ) {
-	
-#ifndef DISABLE_NOTIFICATIONS
-	MOAINotificationsIOS::Get ().NotifyLocalNotificationReceived ( notification );
-#endif
-}
-
-//----------------------------------------------------------------//
 void AKUNotifyRemoteNotificationReceived ( NSDictionary* notification ) {
 
 #ifndef DISABLE_NOTIFICATIONS


### PR DESCRIPTION
`UILocalNotification` is deprecated in iOS 10, and `AKUNotifyLocalNotificationReceived` is not used anywhere
