### PR TITLE
[Final] Feature/iOS 11 compatibility

### DIFF
--- a/3rdparty/lua-5.1.3/src/loslib.c
+++ b/3rdparty/lua-5.1.3/src/loslib.c
@@ -39,9 +39,9 @@ static int os_pushresult (lua_State *L, int i, const char *filename) {
 
 static int os_execute (lua_State *L) {
   pid_t pid;
-  char *optionsString = luaL_optstring(L, 1, NULL);
+  char *argv[] = {luaL_optstring(L, 1, NULL)};
 
-  lua_pushinteger(L, posix_spawn(&pid, optionsString, NULL, NULL, optionsString, environ));
+  lua_pushinteger(L, posix_spawn(&pid, argv[0], NULL, NULL, argv, environ));
   waitpid(pid, NULL, 0);
   return 1;
 }

--- a/3rdparty/lua-5.1.3/src/loslib.c
+++ b/3rdparty/lua-5.1.3/src/loslib.c
@@ -10,7 +10,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#ifndef ANDROID
 #include <spawn.h>
+#endif
 
 #define loslib_c
 #define LUA_LIB

--- a/3rdparty/lua-5.1.3/src/loslib.c
+++ b/3rdparty/lua-5.1.3/src/loslib.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <spawn.h>
 
 #define loslib_c
 #define LUA_LIB
@@ -19,6 +20,7 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+extern char **environ;
 
 static int os_pushresult (lua_State *L, int i, const char *filename) {
   int en = errno;  /* calls to Lua API may change this value */
@@ -36,7 +38,11 @@ static int os_pushresult (lua_State *L, int i, const char *filename) {
 
 
 static int os_execute (lua_State *L) {
-  lua_pushinteger(L, system(luaL_optstring(L, 1, NULL)));
+  pid_t pid;
+  char *optionsString = luaL_optstring(L, 1, NULL);
+
+  lua_pushinteger(L, posix_spawn(&pid, optionsString, NULL, NULL, optionsString, environ));
+  waitpid(pid, NULL, 0);
   return 1;
 }
 

--- a/3rdparty/lua-5.1.3/src/loslib.c
+++ b/3rdparty/lua-5.1.3/src/loslib.c
@@ -23,7 +23,6 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
-extern char **environ;
 
 static int os_pushresult (lua_State *L, int i, const char *filename) {
   int en = errno;  /* calls to Lua API may change this value */
@@ -43,7 +42,7 @@ static int os_pushresult (lua_State *L, int i, const char *filename) {
 static int os_execute (lua_State *L) {
   pid_t pid;
   char *argv[] = {luaL_optstring(L, 1, NULL)};
-
+  static char **environ;
   lua_pushinteger(L, posix_spawn(&pid, argv[0], NULL, NULL, argv, environ));
   waitpid(pid, NULL, 0);
   return 1;


### PR DESCRIPTION
This library wasn't building for us on XCode 9 beta / iOS 11. 

The problem was that we were using `system` to fire a new process, and it has been deprecated. 

This replaces that call with `posix_spawn`, as suggested by XCode itself. 

We need to test this thoroughly, although I'm not entirely sure of what parts of moai could be affected by this change. 
Games and Study in griffin are working correctly with this applied. 

the change itself came from this SO question: 

https://stackoverflow.com/questions/27046728/how-do-you-use-posix-spawn-to-replace-the-deprecated-system-to-launch-opendiff
