### PR TITLE
Change STL and platform to support latest android versions

### DIFF
--- a/ant/libmoai/build.sh
+++ b/ant/libmoai/build.sh
@@ -13,7 +13,7 @@
 	verbose=
 	arm_mode="arm"
 	arm_arch="armeabi-v7a"
-	app_platform="android-10"
+	app_platform="android-16"
 	use_fmod="false"
 	use_untz="true"
 	adcolony_flags=

--- a/ant/libmoai/jni/Application.mk
+++ b/ant/libmoai/jni/Application.mk
@@ -10,7 +10,7 @@
 	APP_ABI 		:= $(MY_ARM_ARCH)
 	APP_CFLAGS		:= -w -DANDROID_NDK -DDISABLE_IMPORTGL -DUSE_CHIPMUNK=0
 	APP_PLATFORM 	:= $(MY_APP_PLATFORM)
-	APP_STL 		:= gnustl_static
+	APP_STL 		:= c++_static
 
 	ifeq ($(NDK_DEBUG),1)
 	    APP_OPTIM := debug

--- a/ant/make-host.sh
+++ b/ant/make-host.sh
@@ -13,7 +13,7 @@
 	package_name=
 	arm_mode="arm"
 	arm_arch="armeabi-v7a"
-	app_platform="android-10"
+	app_platform="android-16"
 	use_fmod="false"
 	use_untz="true"
 	adcolony_flags=


### PR DESCRIPTION
Changing to the latest NDK on android failed to build moai because `gnustl_static` was deprecated. Switched to the newer `c++_static`. There seemed to be a bunch of changes but I don't think those should affect us.

Also updated app platform in moai build scripts to fix a warning saying that the ndk min supported version is 16