### PR TITLE
Support desktop 64 bit architecture for android

### DIFF
--- a/ant/libmoai/build.sh
+++ b/ant/libmoai/build.sh
@@ -57,7 +57,7 @@
 		echo $usage
 		exit 1
 	elif [ x"$arm_arch" = xall ]; then
-		arm_arch="armeabi-v7a arm64-v8a x86"
+		arm_arch="armeabi-v7a arm64-v8a x86 x86_64"
 	fi
 
 	# TODO: Validate app_platform


### PR DESCRIPTION
Since the play store added requirements that require builds to have 64 bit native libraries for any 32 bit versions, we also need to add the desktop 64 bit architecture.