### PR TITLE
Bug fix for Premultiplied Alpha PNGs

### DIFF
--- a/src/uslscore/USColor.cpp
+++ b/src/uslscore/USColor.cpp
@@ -453,9 +453,9 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u32* )colors;
 				alpha = ( color >> 0x18 ) & 0xFF;
-				*( u32* )colors =	((((( color >> 0x00 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x00 ) +
-									((((( color >> 0x08 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x08 ) +
-									((((( color >> 0x10 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x10 ) +
+				*( u32* )colors =	((((( color >> 0x00 ) & 0xFF ) * alpha ) / 255 ) << 0x00 ) +
+									((((( color >> 0x08 ) & 0xFF ) * alpha ) / 255 ) << 0x08 ) +
+									((((( color >> 0x10 ) & 0xFF ) * alpha ) / 255 ) << 0x10 ) +
 									( alpha << 0x18 );
 				colors = ( void* )(( uintptr )colors + 4 );
 			}


### PR DESCRIPTION
If a PNG MOAIImage is created using the `MOAIImage.PREMULTIPLY_ALPHA` flag, the color of the PNG is slightly washed out by 1 RGB value. This causes an almost imperceptible color change against programmatically-created colors if the colors are trying to be matched. For example, the background of a PNG image's color is trying to be matched to the `FilledRectangle` color that encompasses the PNG. This fix divides the bitwise operations by 255 instead of 256.