### PR TITLE
Bug fix for premultiply alpha

### DIFF
--- a/src/uslscore/USColor.cpp
+++ b/src/uslscore/USColor.cpp
@@ -18,23 +18,23 @@
 
 //----------------------------------------------------------------//
 u32 USColor::Average ( u32 c0, u32 c1 ) {
-
+	
 	u32 r = (( c0 & 0xFF ) + ( c1 & 0xFF )) >> 1;
 	u32 g = ((( c0 >> 0x08 ) & 0xFF ) + (( c1 >> 0x08 ) & 0xFF )) >> 1;
 	u32 b = ((( c0 >> 0x10 ) & 0xFF ) + (( c1 >> 0x10 ) & 0xFF )) >> 1;
 	u32 a = ((( c0 >> 0x18 ) & 0xFF ) + (( c1 >> 0x18 ) & 0xFF )) >> 1;
-
+	
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
 //----------------------------------------------------------------//
 u32 USColor::Average ( u32 c0, u32 c1, u32 c2, u32 c3 ) {
-
+	
 	u32 r = (( c0 & 0xFF ) + ( c1 & 0xFF ) + ( c2 & 0xFF ) + ( c3 & 0xFF )) >> 2;
 	u32 g = ((( c0 >> 0x08 ) & 0xFF ) + (( c1 >> 0x08 ) & 0xFF ) + (( c2 >> 0x08 ) & 0xFF ) + (( c3 >> 0x08 ) & 0xFF )) >> 2;
 	u32 b = ((( c0 >> 0x10 ) & 0xFF ) + (( c1 >> 0x10 ) & 0xFF ) + (( c2 >> 0x10 ) & 0xFF ) + (( c3 >> 0x10 ) & 0xFF )) >> 2;
 	u32 a = ((( c0 >> 0x18 ) & 0xFF ) + (( c1 >> 0x18 ) & 0xFF ) + (( c2 >> 0x18 ) & 0xFF ) + (( c3 >> 0x18 ) & 0xFF )) >> 2;
-
+	
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
@@ -43,7 +43,7 @@ u32 USColor::BilerpFixed ( u32 c0, u32 c1, u32 c2, u32 c3, u8 xt, u8 yt ) {
 
 	u32 s0 = USColor::LerpFixed ( c0, c1, xt );
 	u32 s1 = USColor::LerpFixed ( c2, c3, xt );
-
+	
 	return USColor::LerpFixed ( s0, s1, yt );
 }
 
@@ -55,64 +55,64 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 	u32 buffer [ MAX_COLORS ];
 	u32* bufferPtr = buffer;
 	u32 color;
-
+	
 	while ( nColors ) {
-
+	
 		u32 copy = nColors;
 		if ( copy > MAX_COLORS ) {
 			copy = MAX_COLORS;
 		}
 		nColors -= copy;
-
+	
 		switch ( srcFmt ) {
-
+			
 			case A_8:
-
+			
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = *( u8* )src;
 					src = ( void* )(( uintptr )src + 1 );
-
+					
 					buffer [ i ] = color << 0x18;
 				}
 				bufferPtr = buffer;
 				break;
-
+			
 			case RGB_888:
-
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+					
 					color = *( u32* )src;
 					src = ( void* )(( uintptr )src + 3 );
-
+					
 					buffer [ i ]= color | 0xff000000;
 				}
 				bufferPtr = buffer;
 				break;
-
+				
 			case RGB_565:
-
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+					
 					color = *( u16* )src;
 					src = ( void* )(( uintptr )src + 2 );
-
+					
 					buffer [ i ] =	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 									((( color >> 0x05 ) & 0x3F ) << 0x02 ) +
 									((( color >> 0x0B ) & 0x1F ) << 0x03 ) +
 									0xff000000;
-
+					
 				}
 				bufferPtr = buffer;
 				break;
-
-			case RGBA_5551:
-
+			
+			case RGBA_5551: 
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = *( u16* )src;
 					src = ( void* )(( uintptr )src + 2 );
-
+					
 					buffer [ i ] =	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 									((( color >> 0x05 ) & 0x1F ) << 0x0B ) +
 									((( color >> 0x0A ) & 0x1F ) << 0x13 ) +
@@ -122,12 +122,12 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_4444:
-
+			
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = *( u32* )src;
 					src = ( void* )(( uintptr )src + 2 );
-
+					
 					buffer [ i ] =	((( color >> 0x00 ) & 0x0F ) << 0x04 ) +
 									((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 									((( color >> 0x08 ) & 0x0F ) << 0x14 ) +
@@ -139,56 +139,56 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 			case RGBA_8888:
 				bufferPtr = ( u32* )src;
 				break;
-
+			
 			default:
 				return;
 		}
-
+		
 		switch ( destFmt ) {
-
+		
 			case A_8:
-
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = bufferPtr [ i ];
-
+					
 					(( u8* )dest )[ 0 ] = ( color >> 0x18 ) & 0xFF;
 					dest = ( void* )(( uintptr )dest + 1 );
 				}
 				break;
-
+		
 			case RGB_888:
-
+			
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = bufferPtr [ i ];
-
+					
 					(( u8* )dest )[ 0 ] = color & 0xFF;
 					(( u8* )dest )[ 1 ] = ( color >> 8 ) & 0xFF;
 					(( u8* )dest )[ 2 ] = ( color >> 16 ) & 0xFF;
 					dest = ( void* )(( uintptr )dest + 3 );
 				}
 				break;
-
+				
 			case RGB_565:
-
+			
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = bufferPtr [ i ];
-
+					
 					*( u16* )dest =	((( color >> 0x03 ) & 0x1F ) << 0x0B ) +
 									((( color >> 0x0A ) & 0x3F ) << 0x05 ) +
 									((( color >> 0x13 ) & 0x1F ) << 0x00 );
 					dest = ( void* )(( uintptr )dest + 2 );
 				}
 				break;
-
-			case RGBA_5551:
-
+						
+			case RGBA_5551: 
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = bufferPtr [ i ];
-
+					
 					*( u16* )dest =		((( color >> 0x03 ) & 0x1F ) << 0x00 ) +
 										((( color >> 0x0B ) & 0x1F ) << 0x05 ) +
 										((( color >> 0x13 ) & 0x1F ) << 0x0A ) +
@@ -198,11 +198,11 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_4444:
-
+				
 				for ( u32 i = 0; i < copy; ++i ) {
-
+				
 					color = bufferPtr [ i ];
-
+					
 					*( u16* )dest =		((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 										((( color >> 0x0C ) & 0x0F ) << 0x08 ) +
 										((( color >> 0x14 ) & 0x0F ) << 0x04 ) +
@@ -212,11 +212,11 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_8888:
-
+				
 				memcpy ( dest, bufferPtr, copy * sizeof ( u32 ));
 				dest = ( void* )(( uintptr )dest + ( copy * sizeof ( u32 )));
 				break;
-
+			
 			default:
 				break;
 		}
@@ -227,28 +227,28 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 
 	switch ( format ) {
-
+		
 		case A_8:
 			return ( color >> 0x18 ) & 0x000000FF;
-
+		
 		case RGB_888:
 			return color & 0x00FFFFFF;
-
+			
 		case RGB_565:
-
+		
 			return	((( color >> 0x03 ) & 0x1F ) << 0x0B ) +
 					((( color >> 0x0A ) & 0x3F ) << 0x05 ) +
 					((( color >> 0x13 ) & 0x1F ) << 0x00 );
-
-		case RGBA_5551:
-
+					
+		case RGBA_5551: 
+			
 			return	((( color >> 0x03 ) & 0x1F ) << 0x00 ) +
 					((( color >> 0x0B ) & 0x1F ) << 0x05 ) +
 					((( color >> 0x13 ) & 0x1F ) << 0x0A ) +
 					(((( color >> 0x1C ) & 0x0F ) ? 0x01 : 0x00 ) << 0x0F );
 
 		case RGBA_4444:
-
+			
 			return	((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 					((( color >> 0x0C ) & 0x0F ) << 0x08 ) +
 					((( color >> 0x14 ) & 0x0F ) << 0x04 ) +
@@ -256,11 +256,11 @@ u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 
 		case RGBA_8888:
 			return color;
-
+		
 		default:
 			break;
 	}
-
+	
 	return 0;
 }
 
@@ -268,29 +268,29 @@ u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 u32 USColor::ConvertToRGBA ( u32 color, Format format ) {
 
 	switch ( format ) {
-
+		
 		case A_8:
 			return ( color << 0x18 ) & 0xFF000000;
-
+		
 		case RGB_888:
 			return color | 0xFF000000;
-
+			
 		case RGB_565:
-
+		
 			return	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 					((( color >> 0x05 ) & 0x3F ) << 0x02 ) +
 					((( color >> 0x0B ) & 0x1F ) << 0x03 ) +
 					0xff000000;
-
-		case RGBA_5551:
-
+					
+		case RGBA_5551: 
+			
 			return	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 					((( color >> 0x05 ) & 0x1F ) << 0x0B ) +
 					((( color >> 0x0A ) & 0x1F ) << 0x13 ) +
 					(((( color >> 0x0F ) & 0xff ) ? 0xff : 0x00 ) << 0x18 );
 
 		case RGBA_4444:
-
+		
 			return	((( color >> 0x00 ) & 0x0F ) << 0x04 ) +
 					((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 					((( color >> 0x08 ) & 0x0F ) << 0x14 ) +
@@ -298,11 +298,11 @@ u32 USColor::ConvertToRGBA ( u32 color, Format format ) {
 
 		case RGBA_8888:
 			return color;
-
+		
 		default:
 			break;
 	}
-
+	
 	return 0;
 }
 
@@ -353,22 +353,22 @@ u32 USColor::GetSize ( Format format ) {
 
 //----------------------------------------------------------------//
 u32 USColor::LerpFixed ( u32 c0, u32 c1, u8 t ) {
-
+	
 	u32 r0 = ( c0 ) & 0xFF;
 	u32 g0 = ( c0 >> 0x08 ) & 0xFF;
 	u32 b0 = ( c0 >> 0x10 ) & 0xFF;
 	u32 a0 = ( c0 >> 0x18 ) & 0xFF;
-
+	
 	u32 r1 = ( c1 ) & 0xFF;
 	u32 g1 = ( c1 >> 0x08 ) & 0xFF;
 	u32 b1 = ( c1 >> 0x10 ) & 0xFF;
 	u32 a1 = ( c1 >> 0x18 ) & 0xFF;
-
+	
 	u32 r = r0 + ((( r1 - r0 ) * t ) >> 0x08 );
 	u32 g = g0 + ((( g1 - g0 ) * t ) >> 0x08 );
 	u32 b = b0 + ((( b1 - b0 ) * t ) >> 0x08 );
 	u32 a = a0 + ((( a1 - a0 ) * t ) >> 0x08 );
-
+	
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
@@ -410,20 +410,20 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 
 	u32 color;
 	u32 alpha;
-
+	
 	switch ( format ) {
-
+		
 		case A_8:
 			break;
-
+		
 		case RGB_888:
 			break;
-
+			
 		case RGB_565:
 			break;
-
-		case RGBA_5551:
-
+		
+		case RGBA_5551: 
+			
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u16* )colors;
 				alpha = ( color >> 0x0F ) & 0x01;
@@ -436,7 +436,7 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 			break;
 
 		case RGBA_4444:
-
+		
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u16* )colors;
 				alpha = color & 0x0F;
@@ -449,18 +449,18 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 			break;
 
 		case RGBA_8888:
-
+		
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u32* )colors;
 				alpha = ( color >> 0x18 ) & 0xFF;
 				*( u32* )colors =	( ((( color >> 0x00 ) & 0xFF ) * alpha ) >> 0x08 ) +
-									((((( color >> 0x08 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x08 ) +
-									((((( color >> 0x10 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x10 ) +
-									( alpha << 0x18 );
+									  ((((( color >> 0x08 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x08 ) +
+									  ((((( color >> 0x10 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x10 ) +
+									  ( alpha << 0x18 );
 				colors = ( void* )(( uintptr )colors + 4 );
 			}
 			break;
-
+		
 		default:
 			break;
 	}
@@ -475,13 +475,13 @@ u32 USColor::ReadRGBA ( const void* stream, Format format ) {
 
 //----------------------------------------------------------------//
 USColorVec USColor::Set ( u32 c0 ) {
-
+	
 	USColorVec color (
 		(( c0 & ( 255 << 0x00 )) >> 0x00 ) / 255.0f,
 		(( c0 & ( 255 << 0x08 )) >> 0x08 ) / 255.0f,
 		(( c0 & ( 255 << 0x10 )) >> 0x10 ) / 255.0f,
 		(( c0 & ( 255 << 0x18 )) >> 0x18 ) / 255.0f );
-
+	
 	return color;
 }
 
@@ -558,7 +558,7 @@ u32 USPixel::ReadPixel ( const void* stream, u32 nBytes ) {
 	u32 shift = 0;
 
 	switch ( nBytes ) {
-
+		
 		case 4:
 			pixel += ( *( bytes++ )) << shift;
 			shift += 0x08;
@@ -571,7 +571,7 @@ u32 USPixel::ReadPixel ( const void* stream, u32 nBytes ) {
 		case 1:
 			pixel += ( *( bytes++ )) << shift;
 	}
-
+	
 	return pixel;
 }
 
@@ -585,9 +585,9 @@ void USPixel::ToTrueColor ( void* destColors, const void* srcColors, const void*
 	}
 
 	for ( u32 i = 0; i < nColors; ++i ) {
-
+	
 		u32 index = 0;
-
+	
 		if ( pixelFormat == INDEX_4 ) {
 			index = *( const u8* )(( size_t )srcColors + ( i >> 1 ));
 			index = ( i & 1 ) ? ( index >> 4 ) : index;
@@ -596,7 +596,7 @@ void USPixel::ToTrueColor ( void* destColors, const void* srcColors, const void*
 		else {
 			index = *( const u8* )(( size_t )srcColors + i );
 		}
-
+		
 		memcpy ( destColors, ( const void* )(( size_t )palette + ( colorSize * index )), colorSize );
 		destColors = ( void* )(( size_t )destColors + colorSize );
 	}
@@ -715,7 +715,7 @@ void USColorVec::SetWhite () {
 
 //----------------------------------------------------------------//
 void USColorVec::ToYUV ( float& y, float& u, float& v ) {
-
+	
 	y = ( WR * this->mR ) + ( WG * this->mG ) + ( WB * this->mB );
 	u = U_MAX * (( this->mB - y ) / ( 1.0f - WB ));
 	v = V_MAX * (( this->mR - y ) / ( 1.0f - WR ));

--- a/src/uslscore/USColor.cpp
+++ b/src/uslscore/USColor.cpp
@@ -18,23 +18,23 @@
 
 //----------------------------------------------------------------//
 u32 USColor::Average ( u32 c0, u32 c1 ) {
-	
+
 	u32 r = (( c0 & 0xFF ) + ( c1 & 0xFF )) >> 1;
 	u32 g = ((( c0 >> 0x08 ) & 0xFF ) + (( c1 >> 0x08 ) & 0xFF )) >> 1;
 	u32 b = ((( c0 >> 0x10 ) & 0xFF ) + (( c1 >> 0x10 ) & 0xFF )) >> 1;
 	u32 a = ((( c0 >> 0x18 ) & 0xFF ) + (( c1 >> 0x18 ) & 0xFF )) >> 1;
-	
+
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
 //----------------------------------------------------------------//
 u32 USColor::Average ( u32 c0, u32 c1, u32 c2, u32 c3 ) {
-	
+
 	u32 r = (( c0 & 0xFF ) + ( c1 & 0xFF ) + ( c2 & 0xFF ) + ( c3 & 0xFF )) >> 2;
 	u32 g = ((( c0 >> 0x08 ) & 0xFF ) + (( c1 >> 0x08 ) & 0xFF ) + (( c2 >> 0x08 ) & 0xFF ) + (( c3 >> 0x08 ) & 0xFF )) >> 2;
 	u32 b = ((( c0 >> 0x10 ) & 0xFF ) + (( c1 >> 0x10 ) & 0xFF ) + (( c2 >> 0x10 ) & 0xFF ) + (( c3 >> 0x10 ) & 0xFF )) >> 2;
 	u32 a = ((( c0 >> 0x18 ) & 0xFF ) + (( c1 >> 0x18 ) & 0xFF ) + (( c2 >> 0x18 ) & 0xFF ) + (( c3 >> 0x18 ) & 0xFF )) >> 2;
-	
+
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
@@ -43,7 +43,7 @@ u32 USColor::BilerpFixed ( u32 c0, u32 c1, u32 c2, u32 c3, u8 xt, u8 yt ) {
 
 	u32 s0 = USColor::LerpFixed ( c0, c1, xt );
 	u32 s1 = USColor::LerpFixed ( c2, c3, xt );
-	
+
 	return USColor::LerpFixed ( s0, s1, yt );
 }
 
@@ -55,64 +55,64 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 	u32 buffer [ MAX_COLORS ];
 	u32* bufferPtr = buffer;
 	u32 color;
-	
+
 	while ( nColors ) {
-	
+
 		u32 copy = nColors;
 		if ( copy > MAX_COLORS ) {
 			copy = MAX_COLORS;
 		}
 		nColors -= copy;
-	
+
 		switch ( srcFmt ) {
-			
+
 			case A_8:
-			
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = *( u8* )src;
 					src = ( void* )(( uintptr )src + 1 );
-					
+
 					buffer [ i ] = color << 0x18;
 				}
 				bufferPtr = buffer;
 				break;
-			
+
 			case RGB_888:
-				
+
 				for ( u32 i = 0; i < copy; ++i ) {
-					
+
 					color = *( u32* )src;
 					src = ( void* )(( uintptr )src + 3 );
-					
+
 					buffer [ i ]= color | 0xff000000;
 				}
 				bufferPtr = buffer;
 				break;
-				
+
 			case RGB_565:
-				
+
 				for ( u32 i = 0; i < copy; ++i ) {
-					
+
 					color = *( u16* )src;
 					src = ( void* )(( uintptr )src + 2 );
-					
+
 					buffer [ i ] =	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 									((( color >> 0x05 ) & 0x3F ) << 0x02 ) +
 									((( color >> 0x0B ) & 0x1F ) << 0x03 ) +
 									0xff000000;
-					
+
 				}
 				bufferPtr = buffer;
 				break;
-			
-			case RGBA_5551: 
-				
+
+			case RGBA_5551:
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = *( u16* )src;
 					src = ( void* )(( uintptr )src + 2 );
-					
+
 					buffer [ i ] =	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 									((( color >> 0x05 ) & 0x1F ) << 0x0B ) +
 									((( color >> 0x0A ) & 0x1F ) << 0x13 ) +
@@ -122,12 +122,12 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_4444:
-			
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = *( u32* )src;
 					src = ( void* )(( uintptr )src + 2 );
-					
+
 					buffer [ i ] =	((( color >> 0x00 ) & 0x0F ) << 0x04 ) +
 									((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 									((( color >> 0x08 ) & 0x0F ) << 0x14 ) +
@@ -139,56 +139,56 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 			case RGBA_8888:
 				bufferPtr = ( u32* )src;
 				break;
-			
+
 			default:
 				return;
 		}
-		
+
 		switch ( destFmt ) {
-		
+
 			case A_8:
-				
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = bufferPtr [ i ];
-					
+
 					(( u8* )dest )[ 0 ] = ( color >> 0x18 ) & 0xFF;
 					dest = ( void* )(( uintptr )dest + 1 );
 				}
 				break;
-		
+
 			case RGB_888:
-			
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = bufferPtr [ i ];
-					
+
 					(( u8* )dest )[ 0 ] = color & 0xFF;
 					(( u8* )dest )[ 1 ] = ( color >> 8 ) & 0xFF;
 					(( u8* )dest )[ 2 ] = ( color >> 16 ) & 0xFF;
 					dest = ( void* )(( uintptr )dest + 3 );
 				}
 				break;
-				
+
 			case RGB_565:
-			
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = bufferPtr [ i ];
-					
+
 					*( u16* )dest =	((( color >> 0x03 ) & 0x1F ) << 0x0B ) +
 									((( color >> 0x0A ) & 0x3F ) << 0x05 ) +
 									((( color >> 0x13 ) & 0x1F ) << 0x00 );
 					dest = ( void* )(( uintptr )dest + 2 );
 				}
 				break;
-						
-			case RGBA_5551: 
-				
+
+			case RGBA_5551:
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = bufferPtr [ i ];
-					
+
 					*( u16* )dest =		((( color >> 0x03 ) & 0x1F ) << 0x00 ) +
 										((( color >> 0x0B ) & 0x1F ) << 0x05 ) +
 										((( color >> 0x13 ) & 0x1F ) << 0x0A ) +
@@ -198,11 +198,11 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_4444:
-				
+
 				for ( u32 i = 0; i < copy; ++i ) {
-				
+
 					color = bufferPtr [ i ];
-					
+
 					*( u16* )dest =		((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 										((( color >> 0x0C ) & 0x0F ) << 0x08 ) +
 										((( color >> 0x14 ) & 0x0F ) << 0x04 ) +
@@ -212,11 +212,11 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				break;
 
 			case RGBA_8888:
-				
+
 				memcpy ( dest, bufferPtr, copy * sizeof ( u32 ));
 				dest = ( void* )(( uintptr )dest + ( copy * sizeof ( u32 )));
 				break;
-			
+
 			default:
 				break;
 		}
@@ -227,28 +227,28 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 
 	switch ( format ) {
-		
+
 		case A_8:
 			return ( color >> 0x18 ) & 0x000000FF;
-		
+
 		case RGB_888:
 			return color & 0x00FFFFFF;
-			
+
 		case RGB_565:
-		
+
 			return	((( color >> 0x03 ) & 0x1F ) << 0x0B ) +
 					((( color >> 0x0A ) & 0x3F ) << 0x05 ) +
 					((( color >> 0x13 ) & 0x1F ) << 0x00 );
-					
-		case RGBA_5551: 
-			
+
+		case RGBA_5551:
+
 			return	((( color >> 0x03 ) & 0x1F ) << 0x00 ) +
 					((( color >> 0x0B ) & 0x1F ) << 0x05 ) +
 					((( color >> 0x13 ) & 0x1F ) << 0x0A ) +
 					(((( color >> 0x1C ) & 0x0F ) ? 0x01 : 0x00 ) << 0x0F );
 
 		case RGBA_4444:
-			
+
 			return	((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 					((( color >> 0x0C ) & 0x0F ) << 0x08 ) +
 					((( color >> 0x14 ) & 0x0F ) << 0x04 ) +
@@ -256,11 +256,11 @@ u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 
 		case RGBA_8888:
 			return color;
-		
+
 		default:
 			break;
 	}
-	
+
 	return 0;
 }
 
@@ -268,29 +268,29 @@ u32 USColor::ConvertFromRGBA ( u32 color, Format format ) {
 u32 USColor::ConvertToRGBA ( u32 color, Format format ) {
 
 	switch ( format ) {
-		
+
 		case A_8:
 			return ( color << 0x18 ) & 0xFF000000;
-		
+
 		case RGB_888:
 			return color | 0xFF000000;
-			
+
 		case RGB_565:
-		
+
 			return	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 					((( color >> 0x05 ) & 0x3F ) << 0x02 ) +
 					((( color >> 0x0B ) & 0x1F ) << 0x03 ) +
 					0xff000000;
-					
-		case RGBA_5551: 
-			
+
+		case RGBA_5551:
+
 			return	((( color >> 0x00 ) & 0x1F ) << 0x03 ) +
 					((( color >> 0x05 ) & 0x1F ) << 0x0B ) +
 					((( color >> 0x0A ) & 0x1F ) << 0x13 ) +
 					(((( color >> 0x0F ) & 0xff ) ? 0xff : 0x00 ) << 0x18 );
 
 		case RGBA_4444:
-		
+
 			return	((( color >> 0x00 ) & 0x0F ) << 0x04 ) +
 					((( color >> 0x04 ) & 0x0F ) << 0x0C ) +
 					((( color >> 0x08 ) & 0x0F ) << 0x14 ) +
@@ -298,11 +298,11 @@ u32 USColor::ConvertToRGBA ( u32 color, Format format ) {
 
 		case RGBA_8888:
 			return color;
-		
+
 		default:
 			break;
 	}
-	
+
 	return 0;
 }
 
@@ -353,22 +353,22 @@ u32 USColor::GetSize ( Format format ) {
 
 //----------------------------------------------------------------//
 u32 USColor::LerpFixed ( u32 c0, u32 c1, u8 t ) {
-	
+
 	u32 r0 = ( c0 ) & 0xFF;
 	u32 g0 = ( c0 >> 0x08 ) & 0xFF;
 	u32 b0 = ( c0 >> 0x10 ) & 0xFF;
 	u32 a0 = ( c0 >> 0x18 ) & 0xFF;
-	
+
 	u32 r1 = ( c1 ) & 0xFF;
 	u32 g1 = ( c1 >> 0x08 ) & 0xFF;
 	u32 b1 = ( c1 >> 0x10 ) & 0xFF;
 	u32 a1 = ( c1 >> 0x18 ) & 0xFF;
-	
+
 	u32 r = r0 + ((( r1 - r0 ) * t ) >> 0x08 );
 	u32 g = g0 + ((( g1 - g0 ) * t ) >> 0x08 );
 	u32 b = b0 + ((( b1 - b0 ) * t ) >> 0x08 );
 	u32 a = a0 + ((( a1 - a0 ) * t ) >> 0x08 );
-	
+
 	return r + ( g << 0x08 ) + ( b << 0x10 ) + ( a << 0x18 );
 }
 
@@ -410,20 +410,20 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 
 	u32 color;
 	u32 alpha;
-	
+
 	switch ( format ) {
-		
+
 		case A_8:
 			break;
-		
+
 		case RGB_888:
 			break;
-			
+
 		case RGB_565:
 			break;
-		
-		case RGBA_5551: 
-			
+
+		case RGBA_5551:
+
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u16* )colors;
 				alpha = ( color >> 0x0F ) & 0x01;
@@ -436,7 +436,7 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 			break;
 
 		case RGBA_4444:
-		
+
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u16* )colors;
 				alpha = color & 0x0F;
@@ -449,18 +449,18 @@ void USColor::PremultiplyAlpha ( void* colors, Format format, u32 nColors ) {
 			break;
 
 		case RGBA_8888:
-		
+
 			for ( u32 i = 0; i < nColors; ++i ) {
 				color = *( u32* )colors;
 				alpha = ( color >> 0x18 ) & 0xFF;
-				*( u32* )colors =	((((( color >> 0x00 ) & 0xFF ) * alpha ) / 255 ) << 0x00 ) +
-									((((( color >> 0x08 ) & 0xFF ) * alpha ) / 255 ) << 0x08 ) +
-									((((( color >> 0x10 ) & 0xFF ) * alpha ) / 255 ) << 0x10 ) +
+				*( u32* )colors =	( ((( color >> 0x00 ) & 0xFF ) * alpha ) >> 0x08 ) +
+									((((( color >> 0x08 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x08 ) +
+									((((( color >> 0x10 ) & 0xFF ) * alpha ) >> 0x08 ) << 0x10 ) +
 									( alpha << 0x18 );
 				colors = ( void* )(( uintptr )colors + 4 );
 			}
 			break;
-		
+
 		default:
 			break;
 	}
@@ -475,13 +475,13 @@ u32 USColor::ReadRGBA ( const void* stream, Format format ) {
 
 //----------------------------------------------------------------//
 USColorVec USColor::Set ( u32 c0 ) {
-	
+
 	USColorVec color (
 		(( c0 & ( 255 << 0x00 )) >> 0x00 ) / 255.0f,
 		(( c0 & ( 255 << 0x08 )) >> 0x08 ) / 255.0f,
 		(( c0 & ( 255 << 0x10 )) >> 0x10 ) / 255.0f,
 		(( c0 & ( 255 << 0x18 )) >> 0x18 ) / 255.0f );
-	
+
 	return color;
 }
 
@@ -558,7 +558,7 @@ u32 USPixel::ReadPixel ( const void* stream, u32 nBytes ) {
 	u32 shift = 0;
 
 	switch ( nBytes ) {
-		
+
 		case 4:
 			pixel += ( *( bytes++ )) << shift;
 			shift += 0x08;
@@ -571,7 +571,7 @@ u32 USPixel::ReadPixel ( const void* stream, u32 nBytes ) {
 		case 1:
 			pixel += ( *( bytes++ )) << shift;
 	}
-	
+
 	return pixel;
 }
 
@@ -585,9 +585,9 @@ void USPixel::ToTrueColor ( void* destColors, const void* srcColors, const void*
 	}
 
 	for ( u32 i = 0; i < nColors; ++i ) {
-	
+
 		u32 index = 0;
-	
+
 		if ( pixelFormat == INDEX_4 ) {
 			index = *( const u8* )(( size_t )srcColors + ( i >> 1 ));
 			index = ( i & 1 ) ? ( index >> 4 ) : index;
@@ -596,7 +596,7 @@ void USPixel::ToTrueColor ( void* destColors, const void* srcColors, const void*
 		else {
 			index = *( const u8* )(( size_t )srcColors + i );
 		}
-		
+
 		memcpy ( destColors, ( const void* )(( size_t )palette + ( colorSize * index )), colorSize );
 		destColors = ( void* )(( size_t )destColors + colorSize );
 	}
@@ -715,7 +715,7 @@ void USColorVec::SetWhite () {
 
 //----------------------------------------------------------------//
 void USColorVec::ToYUV ( float& y, float& u, float& v ) {
-	
+
 	y = ( WR * this->mR ) + ( WG * this->mG ) + ( WB * this->mB );
 	u = U_MAX * (( this->mB - y ) / ( 1.0f - WB ));
 	v = V_MAX * (( this->mR - y ) / ( 1.0f - WR ));


### PR DESCRIPTION
### Description
I took the code from MOAI 2.0 to update the premultiply alpha code as the previous fix didn't actually fix the issue, despite thinking it did when I did testing. Converted the 255 divisions into their bitwise operations. The bug was that an extra `<< 0x00` was added into the first bit shifting.

Where the code was taken from: https://github.com/moai/moai-dev/blob/0ba7c678311d1fa9dbc091f60665e95e54169fdf/src/zl-util/ZLColor.cpp