### PR TITLE
Updating MOAI Xcode sample project settings so they compile again

### DIFF
--- a/xcode/ios/Classes/MoaiAppDelegate.mm
+++ b/xcode/ios/Classes/MoaiAppDelegate.mm
@@ -37,7 +37,7 @@
 	//----------------------------------------------------------------//
 	-( void ) application:( UIApplication* )application didFailToRegisterForRemoteNotificationsWithError:( NSError* )error {
 	
-		AKUNotifyRemoteNotificationRegistrationComplete ( nil );
+//		AKUNotifyRemoteNotificationRegistrationComplete ( nil );
 	}
 
 	//----------------------------------------------------------------//
@@ -73,11 +73,11 @@
 		[ mMoaiView run:@"main.lua" ];
 		
         // check to see if the app was lanuched from a remote notification
-        NSDictionary* pushBundle = [ launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey ];
-        if ( pushBundle != NULL ) {
-            
-            AKUNotifyRemoteNotificationReceived ( pushBundle );
-        }
+//        NSDictionary* pushBundle = [ launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey ];
+//        if ( pushBundle != NULL ) {
+//
+//            AKUNotifyRemoteNotificationReceived ( pushBundle );
+//        }
 		
 		// return
 		return true;
@@ -87,13 +87,13 @@
 	//----------------------------------------------------------------//
 	-( void ) application:( UIApplication* )application didReceiveRemoteNotification:( NSDictionary* )pushBundle {
 		
-		AKUNotifyRemoteNotificationReceived ( pushBundle );
+//		AKUNotifyRemoteNotificationReceived ( pushBundle );
 	}
 	
 	//----------------------------------------------------------------//
 	-( void ) application:( UIApplication* )application didRegisterForRemoteNotificationsWithDeviceToken:( NSData* )deviceToken {
 	
-		AKUNotifyRemoteNotificationRegistrationComplete ( deviceToken );
+//		AKUNotifyRemoteNotificationRegistrationComplete ( deviceToken );
 	}
 	
 	//----------------------------------------------------------------//

--- a/xcode/ios/Classes/MoaiView.mm
+++ b/xcode/ios/Classes/MoaiView.mm
@@ -123,11 +123,14 @@ namespace MoaiInputDeviceSensorID {
 		for ( UITouch* touch in touches ) {
 			
 			CGPoint p = [ touch locationInView:self ];
+            
+            UInt64 touchAddress = (UInt64)touch;
+            int touchID = (int)(touchAddress & UINT32_MAX);
 			
 			AKUEnqueueTouchEvent (
 				MoaiInputDeviceID::DEVICE,
 				MoaiInputDeviceSensorID::TOUCH,
-				( int )touch, // use the address of the touch as a unique id
+				touchID, // use the address of the touch as a unique id
 				down,
 				p.x * [[ UIScreen mainScreen ] scale ],
 				p.y * [[ UIScreen mainScreen ] scale ]

--- a/xcode/ios/Info.plist
+++ b/xcode/ios/Info.plist
@@ -18,19 +18,19 @@
 		<string>Icon-Small@2x.png</string>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.getmoai.samples</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIPrerenderedIcon</key>

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -106,6 +106,34 @@
 			remoteGlobalIDString = CDD06A061398822500AB0420;
 			remoteInfo = "libmoai-iphone-luaext";
 		};
+		4D2019E4258C23140066DD72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE00B1BE9421B00E8938F;
+			remoteInfo = "libmoai-tvos";
+		};
+		4D2019E6258C23140066DD72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1851BE9422800E8938F;
+			remoteInfo = "libmoai-tvos-3rdparty";
+		};
+		4D2019E8258C23140066DD72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1B81BE9423500E8938F;
+			remoteInfo = "libmoai-tvos-luaext";
+		};
+		4D2019EA258C23140066DD72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1F51BE9424500E8938F;
+			remoteInfo = "libmoai-tvos-zlcore";
+		};
 		CD04AF1114725736009C20E5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
@@ -213,6 +241,10 @@
 				03CC90C713B3C39D00B2724C /* libmoai-osx-3rdparty.a */,
 				03CC90C913B3C39D00B2724C /* libmoai-osx-luaext.a */,
 				CD04AF1414725736009C20E5 /* libmoai-osx-zlcore.a */,
+				4D2019E5258C23140066DD72 /* libmoai-tvos.a */,
+				4D2019E7258C23140066DD72 /* libmoai-tvos-3rdparty.a */,
+				4D2019E9258C23140066DD72 /* libmoai-tvos-luaext.a */,
+				4D2019EB258C23140066DD72 /* libmoai-tvos-zlcore.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -428,6 +460,34 @@
 			remoteRef = 03CC90C813B3C39D00B2724C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		4D2019E5258C23140066DD72 /* libmoai-tvos.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos.a";
+			remoteRef = 4D2019E4258C23140066DD72 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D2019E7258C23140066DD72 /* libmoai-tvos-3rdparty.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-3rdparty.a";
+			remoteRef = 4D2019E6258C23140066DD72 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D2019E9258C23140066DD72 /* libmoai-tvos-luaext.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-luaext.a";
+			remoteRef = 4D2019E8258C23140066DD72 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D2019EB258C23140066DD72 /* libmoai-tvos-zlcore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-zlcore.a";
+			remoteRef = 4D2019EA258C23140066DD72 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -525,13 +585,13 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../src\"/**";
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SRCROOT)/../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"$(SRCROOT)/../../3rdparty/facebookiOS-3.0.6.b\"",
@@ -554,14 +614,14 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_ENTITLEMENTS = Entitlements.plist;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../src\"/**";
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SRCROOT)/../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"$(SRCROOT)/../../3rdparty/facebookiOS-3.0.6.b\"",

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
-		665383F3160A798F003D5529 /* FacebookSDKResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 665383F2160A798F003D5529 /* FacebookSDKResources.bundle */; };
 		665383F7160A8466003D5529 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F6160A8466003D5529 /* MessageUI.framework */; };
 		B4D552A51863700E00CB70BD /* lua in Resources */ = {isa = PBXBuildFile; fileRef = 074C469A14240A180066B1EB /* lua */; };
 		CD464CE0147259EA00501E4E /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */; };
@@ -516,7 +515,6 @@
 				03CC905B13B3C1B700B2724C /* Icon-Small@2x.png in Resources */,
 				03CC905C13B3C1B700B2724C /* Icon.png in Resources */,
 				03CC905D13B3C1B700B2724C /* Icon@2x.png in Resources */,
-				665383F3160A798F003D5529 /* FacebookSDKResources.bundle in Resources */,
 				B4D552A51863700E00CB70BD /* lua in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				DEVELOPMENT_TEAM = JG69W4K637;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = "";
@@ -576,6 +577,7 @@
 		1D6058950D05DD3E006BFB54 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				DEVELOPMENT_TEAM = JG69W4K637;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = "";

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.elevate.moaisample;
 				PRODUCT_NAME = moai;
+				VALID_ARCHS = "i386 x86_64 armv7 armv7s arm64";
 			};
 			name = Debug;
 		};
@@ -584,6 +585,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.elevate.moaisample;
 				PRODUCT_NAME = moai;
+				VALID_ARCHS = "i386 x86_64 armv7 armv7s arm64";
 			};
 			name = Release;
 		};

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		03CC910C13B3C48400B2724C /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC910B13B3C48400B2724C /* AudioToolbox.framework */; };
 		03CC911C13B3C49400B2724C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC911B13B3C49400B2724C /* SystemConfiguration.framework */; };
 		03CC912213B3C4A400B2724C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC912113B3C4A400B2724C /* QuartzCore.framework */; };
-		03CC912C13B3C4C000B2724C /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC912B13B3C4C000B2724C /* StoreKit.framework */; };
 		0711070513C637F000EE7C53 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0711070413C637F000EE7C53 /* CoreTelephony.framework */; };
 		078D630113BA9EA30072F273 /* MoaiVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 078D630013BA9EA30072F273 /* MoaiVC.mm */; };
 		079530CE1447A0FF00143A72 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 079530CD1447A0FF00143A72 /* MediaPlayer.framework */; };
@@ -183,7 +182,6 @@
 		03CC910B13B3C48400B2724C /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		03CC911B13B3C49400B2724C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		03CC912113B3C4A400B2724C /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		03CC912B13B3C4C000B2724C /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		0711070413C637F000EE7C53 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		074C469A14240A180066B1EB /* lua */ = {isa = PBXFileReference; lastKnownFileType = folder; path = lua; sourceTree = "<group>"; };
 		078D62FF13BA9EA30072F273 /* MoaiVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoaiVC.h; sourceTree = "<group>"; };
@@ -220,7 +218,6 @@
 				665383F7160A8466003D5529 /* MessageUI.framework in Frameworks */,
 				03CC90F813B3C45A00B2724C /* OpenGLES.framework in Frameworks */,
 				03CC912213B3C4A400B2724C /* QuartzCore.framework in Frameworks */,
-				03CC912C13B3C4C000B2724C /* StoreKit.framework in Frameworks */,
 				03CC911C13B3C49400B2724C /* SystemConfiguration.framework in Frameworks */,
 				07EF3E44147BAAA5006CFDCE /* Twitter.framework in Frameworks */,
 				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
@@ -334,7 +331,6 @@
 				1D30AB110D05D00D00671497 /* Foundation.framework */,
 				03CC90F713B3C45A00B2724C /* OpenGLES.framework */,
 				03CC912113B3C4A400B2724C /* QuartzCore.framework */,
-				03CC912B13B3C4C000B2724C /* StoreKit.framework */,
 				03CC911B13B3C49400B2724C /* SystemConfiguration.framework */,
 				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
 				07EF3E43147BAAA5006CFDCE /* Twitter.framework */,
@@ -391,6 +387,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0420;
+				TargetAttributes = {
+					1D6058900D05DD3D006BFB54 = {
+						DevelopmentTeam = JG69W4K637;
+					};
+				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MoaiSample" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -565,9 +566,11 @@
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = JG69W4K637;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.elevate.moaisample;
 				PRODUCT_NAME = moai;
 			};
 			name = Debug;
@@ -575,9 +578,11 @@
 		1D6058950D05DD3E006BFB54 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = JG69W4K637;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.elevate.moaisample;
 				PRODUCT_NAME = moai;
 			};
 			name = Release;

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -604,10 +604,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
-				OTHER_LDFLAGS = (
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libmoai-ios-tapjoy.a\"",
-				);
+				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -634,10 +631,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
-				OTHER_LDFLAGS = (
-					"-force_load",
-					"\"$(BUILT_PRODUCTS_DIR)/libmoai-ios-tapjoy.a\"",
-				);
+				OTHER_LDFLAGS = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -10381,7 +10381,7 @@
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"../../3rdparty/sfmt-1.4/",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = (
 					"-include",
@@ -10605,7 +10605,7 @@
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"../../3rdparty/sfmt-1.4/",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -10382,6 +10382,7 @@
 					"../../3rdparty/sfmt-1.4/",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = (
 					"-include",
 					"\"zlcore/zl_replace.h\"",
@@ -10605,6 +10606,7 @@
 					"../../3rdparty/sfmt-1.4/",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-include",

--- a/xcode/osx/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/osx/MoaiSample.xcodeproj/project.pbxproj
@@ -12,8 +12,6 @@
 		0300CF5D140DC53C00ABCC5B /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDEE22E613543D8600C2E04C /* OpenGL.framework */; };
 		0300CF5E140DC53C00ABCC5B /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDEE22E413543D6600C2E04C /* GLUT.framework */; };
 		0300CF5F140DC53C00ABCC5B /* libSystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0324CC63135643FD000ADC60 /* libSystem.dylib */; };
-		0300CF60140DC53C00ABCC5B /* libcrypto.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CD74EA2B137807E40093EE68 /* libcrypto.dylib */; };
-		0300CF61140DC53C00ABCC5B /* libssl.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CD74EA311378080E0093EE68 /* libssl.dylib */; };
 		0300CF62140DC53C00ABCC5B /* libmoai-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0324E2C21356485F000ADC60 /* libmoai-osx.a */; };
 		0300CF63140DC53C00ABCC5B /* libmoai-osx-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0324E2C01356485F000ADC60 /* libmoai-osx-3rdparty.a */; };
 		0300CF64140DC53C00ABCC5B /* libmoai-osx-luaext.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD07C41713A185E200C9386C /* libmoai-osx-luaext.a */; };
@@ -138,6 +136,34 @@
 			proxyType = 1;
 			remoteGlobalIDString = CD04ACB51472557F009C20E5;
 			remoteInfo = "libmoai-osx-zlcore";
+		};
+		4D9F419B258C06430015F224 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE00B1BE9421B00E8938F;
+			remoteInfo = "libmoai-tvos";
+		};
+		4D9F419D258C06430015F224 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1851BE9422800E8938F;
+			remoteInfo = "libmoai-tvos-3rdparty";
+		};
+		4D9F419F258C06430015F224 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1B81BE9423500E8938F;
+			remoteInfo = "libmoai-tvos-luaext";
+		};
+		4D9F41A1258C06430015F224 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB9EE1F51BE9424500E8938F;
+			remoteInfo = "libmoai-tvos-zlcore";
 		};
 		CD07C41213A185E200C9386C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -276,8 +302,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0300CF5F140DC53C00ABCC5B /* libSystem.dylib in Frameworks */,
-				0300CF60140DC53C00ABCC5B /* libcrypto.dylib in Frameworks */,
-				0300CF61140DC53C00ABCC5B /* libssl.dylib in Frameworks */,
 				0300CF62140DC53C00ABCC5B /* libmoai-osx.a in Frameworks */,
 				0300CF63140DC53C00ABCC5B /* libmoai-osx-3rdparty.a in Frameworks */,
 				0300CF64140DC53C00ABCC5B /* libmoai-osx-luaext.a in Frameworks */,
@@ -356,6 +380,10 @@
 				0324E2C01356485F000ADC60 /* libmoai-osx-3rdparty.a */,
 				CD07C41713A185E200C9386C /* libmoai-osx-luaext.a */,
 				1B70C4D21475F198009C6869 /* libmoai-osx-zlcore.a */,
+				4D9F419C258C06430015F224 /* libmoai-tvos.a */,
+				4D9F419E258C06430015F224 /* libmoai-tvos-3rdparty.a */,
+				4D9F41A0258C06430015F224 /* libmoai-tvos-luaext.a */,
+				4D9F41A2258C06430015F224 /* libmoai-tvos-zlcore.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -490,7 +518,6 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = NO;
 				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MoaiSample" */;
@@ -571,6 +598,34 @@
 			fileType = archive.ar;
 			path = "libmoai-osx-zlcore.a";
 			remoteRef = 1B70C4D11475F198009C6869 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D9F419C258C06430015F224 /* libmoai-tvos.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos.a";
+			remoteRef = 4D9F419B258C06430015F224 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D9F419E258C06430015F224 /* libmoai-tvos-3rdparty.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-3rdparty.a";
+			remoteRef = 4D9F419D258C06430015F224 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D9F41A0258C06430015F224 /* libmoai-tvos-luaext.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-luaext.a";
+			remoteRef = 4D9F419F258C06430015F224 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D9F41A2258C06430015F224 /* libmoai-tvos-zlcore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-tvos-zlcore.a";
+			remoteRef = 4D9F41A1258C06430015F224 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		CD07C41313A185E200C9386C /* libmoai-ios-luaext.a */ = {
@@ -705,8 +760,10 @@
 					DARWIN_NO_CARBON,
 					GLUTHOST_USE_LUAEXT,
 					GLUTHOST_USE_MOAI_TEST,
+					GL_SILENCE_DEPRECATION,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/system";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = "";
 			};
@@ -728,7 +785,8 @@
 					DARWIN_NO_CARBON,
 					GLUTHOST_USE_LUAEXT,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/system";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = "";
 			};

--- a/xcode/osx/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
+++ b/xcode/osx/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
@@ -23,12 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,17 +36,22 @@
             ReferencedContainer = "container:MoaiSample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "YES"
-      buildConfiguration = "Debug"
+      customWorkingDirectory = "$PROJECT_DIR/../../samples/anim/anim-basic"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0300CF4F140DC53C00ABCC5B"
@@ -63,16 +66,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0300CF4F140DC53C00ABCC5B"


### PR DESCRIPTION
The first step in getting MOAI to run with MetalANGLE on the `mindsnacks-dev` branch is to get MOAI's sample Xcode projects (included in this repository) to compile again.  They haven't been updated in years, and stopped working a long time ago. 🏛️  Many changes were made to the `moai-dev` develop branch since we forked off from it.  🍴 I've been trying to figure out which changes to copy over from the Xcode projects on the main fork to make our Xcode projects compile again.  ⬅️

This PR is what I *think* is the minimum set of changes needed to get just the iOS Xcode project to run. 📱 The iOS project currently compiles and installs on my iPhone, but it won't open when I install from my work computer. ⚠️  I'm sure this is happening because I don't have my provisioning profiles set up correctly, but it should work fine once we sort that out.  🔀 

I haven't tried getting the "`osx`" project to work yet, but I should be able to follow similar steps to get it working. 💻 

Note that in order to get the iOS sample project to run, you must copy the contents of a Lua example folder from the `samples` directory into `xcode/ios/lua`.  I think the `anim-basic` folder is a good one to use because it doesn't try to do anything fancy.  🚫🧐 

Also note that this PR does *not* include any of the changes needed to get MetalANGLE running.  🙅 Those changes are on a separate branch on top of this PR that I'm still working on... but I'm optimistic that I can get something working soon.  🤞🤞

Also also note that we'll want to do some cleanup before we merge this PR.  🧹 I just wanted to get the changes out there for now.  👐