### PR TITLE
ENG-4130: meditation loader shaking bug fix

### DIFF
--- a/src/moaicore/shaders/MOAIDeck2DShader-vsh.h
+++ b/src/moaicore/shaders/MOAIDeck2DShader-vsh.h
@@ -13,7 +13,7 @@ static cc8* _deck2DShaderVSH = SHADER (
 	attribute vec4 color;
 
 	varying LOWP vec4 colorVarying;
-	varying MEDP vec2 uvVarying;
+	varying HIGHP vec2 uvVarying;
 
 	void main () {
 		gl_Position = position;


### PR DESCRIPTION
### Description
In order for higher resolution devices to display animations properly, the image shader needs `HIGHP` quality for the `uvVarying` fragments.

[JIRA](https://elevatelabs.atlassian.net/browse/ENG-4130)

### User facing changes
1. Run Balance and open Foundations 1 Day 2.
2. Skip to the end of the lesson so as to see the meditation loading screen. The animation should not shake.
3. Open Wind Down as a new or been awhile user. Get to the last card with the audio animation. It should not shake.
4. Get to the meditation portion of Wind Down. The blue blob should not shake.

### Required items
Any other PRs or actions that need to be taken for this PR.
- [ ] Tatooine PR (TBD)
- [ ] Kamino PR (TBD)
- [ ] Geonosis PR (TBD)