### PR TITLE
Remove MOAITextureRaw reference from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,7 +508,6 @@ add_library(moai_dev SHARED
         src/moaicore/MOAITextStyler.cpp
         src/moaicore/MOAITexture.cpp
         src/moaicore/MOAITextureBase.cpp
-        src/moaicore/MOAITextureRaw.cpp
         src/moaicore/MOAIThread.cpp
         src/moaicore/MOAIThread_posix.cpp
         src/moaicore/MOAIThread_win32.cpp


### PR DESCRIPTION
- Remove `MOAITextureRaw` reference from `CMakeLists.txt` since it's unused and so geonosis will build.
- I thought all `MOAITextureRaw` references would be cleaned up in https://github.com/mindsnacks/moai-dev/pull/126.
- Looks like this addition to `CMakeLists.txt` was added later in https://github.com/mindsnacks/moai-dev/pull/120.