### PR TITLE
WebP Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/libwebp"]
+	path = 3rdparty/libwebp
+	url = https://chromium.googlesource.com/webm/libwebp

--- a/src/moai-image-webp/MOAIImageFormatWebP.cpp
+++ b/src/moai-image-webp/MOAIImageFormatWebP.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2010-2017 Zipline Games, Inc. All Rights Reserved.
+// http://getmoai.com
+
+#include <moai-image-webp/MOAIImageFormatWebP.h>
+
+extern "C" {
+	#include "libwebp-0.4.1/src/webp/demux.h"
+	#include "libwebp-0.4.1/src/webp/decode.h"
+}
+
+//================================================================//
+// MOAIImageFormatWebP
+//================================================================//
+
+//----------------------------------------------------------------//
+bool MOAIImageFormatWebP::CheckHeader ( const void* buffer ) {
+
+	return ((( u32* )buffer )[ 0 ] == *(( u32* )"RIFF" ) && (( u32* )buffer )[ 2 ] == *(( u32* )"WEBP" ));
+}
+
+//----------------------------------------------------------------//
+bool MOAIImageFormatWebP::CreateTexture ( MOAITextureBase& texture, const void* data, size_t size ) {
+	UNUSED ( texture );
+	UNUSED ( data );
+	UNUSED ( size );
+	
+	return false;
+}
+
+//----------------------------------------------------------------//
+size_t MOAIImageFormatWebP::GetHeaderSize () {
+
+	return HEADER_SIZE;
+}
+
+//----------------------------------------------------------------//
+MOAIImageFormatWebP::MOAIImageFormatWebP () {
+}
+
+//----------------------------------------------------------------//
+MOAIImageFormatWebP::~MOAIImageFormatWebP () {
+}
+
+//----------------------------------------------------------------//
+bool MOAIImageFormatWebP::ReadImage ( MOAIImage& image, ZLStream& stream, u32 transform ) {
+
+	// Copy data from stream to WebPData object
+	WebPData data;
+	data.size = stream.GetLength ();
+	data.bytes = ( uint8_t* )malloc ( data.size );
+	if ( !data.bytes ) return false;
+	stream.ReadBytes ( ( void* )data.bytes, data.size );
+
+	// Create demuxer
+	WebPDemuxer* demux = WebPDemux ( &data );
+
+	// Read first frame (ignore any additional frames)
+	WebPIterator iter;
+	if ( WebPDemuxGetFrame ( demux, 1, &iter ) ) {
+		this->ReadImageWebP ( image, iter.fragment.bytes, iter.fragment.size, iter.width, iter.height, iter.has_alpha != 0, transform );
+	}
+
+	// Clean up
+	WebPDemuxReleaseIterator ( &iter );
+	WebPDemuxDelete ( demux );
+	WebPDataClear ( &data );
+	
+	return true;
+}
+
+//----------------------------------------------------------------//
+void MOAIImageFormatWebP::ReadImageWebP ( MOAIImage& image, u8 const* data, size_t dataSize, int width, int height, bool hasAlpha, u32 transform ) {
+
+	// Pad to POT dimensions, if requested
+	bool isPadded = this->SetDimensions ( image, width, height, transform );
+
+	// Set pixel and color format
+	this->SetPixelFormat ( image, MOAIImage::TRUECOLOR );
+	bool quantize = ( transform & MOAIImageTransform::QUANTIZE ) != 0;
+	if ( hasAlpha ) {
+		this->SetColorFormat ( image, quantize ? ZLColor::RGBA_4444 : ZLColor::RGBA_8888 );
+	}
+	else {
+		this->SetColorFormat ( image, quantize ? ZLColor::RGB_565 : ZLColor::RGB_888 );
+	}
+
+	// Initialize image buffer
+	this->Alloc ( image );
+	
+	if ( isPadded ) {
+		image.ClearBitmap ();
+	}
+
+	// Create decoder configuration
+	WebPDecoderConfig config;
+	if ( !WebPInitDecoderConfig ( &config ) ) return;
+	bool premultiply = (transform & MOAIImageTransform::PREMULTIPLY_ALPHA) != 0;
+	switch ( image.GetColorFormat ()) {
+		case ZLColor::RGBA_8888:
+			config.output.colorspace = premultiply ? MODE_rgbA : MODE_RGBA;
+			break;
+		case ZLColor::RGBA_4444:
+			config.output.colorspace = premultiply ? MODE_rgbA_4444 : MODE_RGBA_4444;
+			break;
+		case ZLColor::RGB_888:
+			config.output.colorspace = MODE_RGB;
+			break;
+		case ZLColor::RGB_565:
+			config.output.colorspace = MODE_RGB_565;
+			break;
+	}
+	config.output.u.RGBA.rgba = ( u8* )this->GetBitmap ( image );
+	config.output.u.RGBA.stride = ( int )image.GetRowSize ();
+	config.output.u.RGBA.size = image.GetBitmapSize ();
+	config.output.is_external_memory = true;
+
+	// Decode the image
+	WebPDecode ( data, dataSize, &config );
+
+	// Clean up
+	WebPFreeDecBuffer ( &config.output );
+}
+
+//----------------------------------------------------------------//
+bool MOAIImageFormatWebP::WriteImage ( const MOAIImage& image, ZLStream& stream ) {
+	UNUSED ( image );
+	UNUSED ( stream );
+	return false;
+}

--- a/src/moai-image-webp/MOAIImageFormatWebP.h
+++ b/src/moai-image-webp/MOAIImageFormatWebP.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2010-2017 Zipline Games, Inc. All Rights Reserved.
+// http://getmoai.com
+
+#ifndef	MOAIIMAGEFORMATWEBP_H
+#define	MOAIIMAGEFORMATWEBP_H
+
+#include <moai-sim/headers.h>
+
+//================================================================//
+// MOAIImageFormatWebP
+//================================================================//
+class MOAIImageFormatWebP :
+	public MOAIImageFormat {
+private:
+
+	static const u32 HEADER_SIZE = 12;
+
+	//----------------------------------------------------------------//
+	void			ReadImageWebP				( MOAIImage& image, u8 const* data, size_t dataSize, int width, int height, bool hasAlpha, u32 transform );
+
+public:
+
+	//----------------------------------------------------------------//
+	bool			CheckHeader					( const void* buffer );
+	bool			CreateTexture				( MOAITextureBase& texture, const void* data, size_t size );
+	size_t			GetHeaderSize				();
+					MOAIImageFormatWebP			();
+					~MOAIImageFormatWebP		();
+	bool			ReadImage					( MOAIImage& image, ZLStream& stream, u32 transform );
+	bool			WriteImage					( const MOAIImage& image, ZLStream& stream );
+};
+
+#endif

--- a/src/moaicore/MOAIImage-webp.cpp
+++ b/src/moaicore/MOAIImage-webp.cpp
@@ -1,9 +1,5 @@
-//
-//  MOAIImage-webp.cpp
-//  libmoai
-//
-//  Created by Aaron Barrett on 8/30/21.
-//
+// Copyright (c) 2010-2017 Zipline Games, Inc. All Rights Reserved.
+// http://getmoai.com
 
 #include "pch.h"
 #include <moaicore/MOAILogMessages.h>

--- a/src/moaicore/MOAIImage-webp.cpp
+++ b/src/moaicore/MOAIImage-webp.cpp
@@ -1,0 +1,108 @@
+//
+//  MOAIImage-webp.cpp
+//  libmoai
+//
+//  Created by Aaron Barrett on 8/30/21.
+//
+
+#include "pch.h"
+#include <moaicore/MOAILogMessages.h>
+#include <moaicore/MOAIImage.h>
+
+extern "C" {
+	#include "webp/decode.h"
+	#include "webp/demux.h"
+}
+
+void MOAIImage::LoadWebP( USStream& stream, u32 transform ) {
+	WebPData data;
+	data.size = stream.GetLength ();
+	data.bytes = ( uint8_t* )malloc ( data.size );
+	if ( !data.bytes ) return;
+	stream.ReadBytes ( ( void* )data.bytes, data.size );
+
+	// Create demuxer
+	WebPDemuxer* demux = WebPDemux ( &data );
+
+	// Read first frame (ignore any additional frames)
+	WebPIterator iter;
+	if ( WebPDemuxGetFrame ( demux, 1, &iter ) ) {
+		this->LoadWebP ( iter.fragment.bytes, iter.fragment.size, iter.width, iter.height, iter.has_alpha != 0, transform );
+	}
+
+	// Clean up
+	WebPDemuxReleaseIterator ( &iter );
+	WebPDemuxDelete ( demux );
+	WebPDataClear ( &data );
+}
+
+void MOAIImage::LoadWebP( const u8 *data, size_t dataSize, int width, int height, bool hasAlpha, u32 transform ) {
+	bool isPadded = false;
+	if ( (transform & MOAIImageTransform::POW_TWO) != 0 ) {
+		this->mWidth = this->GetMinPowerOfTwo(width);
+		this->mHeight = this->GetMinPowerOfTwo(height);
+		isPadded = true;
+	} else {
+		this->mWidth = width;
+		this->mHeight = height;
+	}
+	
+	this->mPixelFormat = USPixel::TRUECOLOR;
+	bool quantize = (transform & MOAIImageTransform::QUANTIZE) != 0;
+	if ( hasAlpha ) {
+		if ( quantize ) {
+			this->mColorFormat = USColor::RGBA_4444;
+		} else {
+			this->mColorFormat = USColor::RGBA_8888;
+		}
+	} else {
+		if ( quantize ) {
+			this->mColorFormat = USColor::RGB_565;
+		} else {
+			this->mColorFormat = USColor::RGB_888;
+		}
+	}
+	
+	
+	this->Alloc ();
+	if ( isPadded ) {
+		this->ClearBitmap ();
+	}
+	
+	WebPDecoderConfig config;
+	if ( !WebPInitDecoderConfig ( &config ) ) return;
+	bool premultiply = (transform & MOAIImageTransform::PREMULTIPLY_ALPHA) != 0;
+	switch ( this->mColorFormat ) {
+		case USColor::RGBA_8888:
+			if ( premultiply ) {
+				config.output.colorspace = MODE_rgbA;
+			} else {
+				config.output.colorspace = MODE_RGBA;
+			}
+			break;
+		case USColor::RGBA_4444:
+			if ( premultiply ) {
+				config.output.colorspace = MODE_rgbA_4444;
+			} else {
+				config.output.colorspace = MODE_RGBA_4444;
+			}
+			break;
+		case USColor::RGB_888:
+			config.output.colorspace = MODE_RGB;
+			break;
+		case USColor::RGB_565:
+			config.output.colorspace = MODE_RGB_565;
+			break;
+		default:
+			break;
+	}
+	config.output.u.RGBA.rgba = (u8 *) this->mBitmap;
+	config.output.u.RGBA.stride = this->GetRowSize();
+	config.output.u.RGBA.size = this->GetBitmapSize();
+	config.output.is_external_memory = true;
+	
+	WebPDecode ( data, dataSize, &config );
+	
+	WebPFreeDecBuffer ( &config.output );
+	
+}

--- a/src/moaicore/MOAIImage.cpp
+++ b/src/moaicore/MOAIImage.cpp
@@ -1565,6 +1565,19 @@ bool MOAIImage::IsPng ( USStream& stream ) {
 }
 
 //----------------------------------------------------------------//
+bool MOAIImage::IsWebP( USStream &stream ) {
+	char buffer [ 12 ];
+	u32 size = (u32) stream.PeekBytes( buffer, 12 );
+	if ( size < 12 ) return false;
+	
+	const char *riffHeader = "RIFF";
+	const char *webpHeader = "WEBP";
+	
+	return ( memcmp( buffer, riffHeader, 4 ) == 0 ) &&
+		( memcmp( &(buffer[8]), webpHeader, 4 ) == 0) ;
+}
+
+//----------------------------------------------------------------//
 void MOAIImage::Load ( cc8* filename, u32 transform ) {
 
 	this->Clear ();
@@ -1588,6 +1601,9 @@ void MOAIImage::Load ( USStream& stream, u32 transform ) {
 	}
 	else if ( MOAIImage::IsJpg ( stream )) {
 		this->LoadJpg ( stream, transform );
+	}
+	else if ( MOAIImage::IsWebP( stream )) {
+		this->LoadWebP( stream, transform );
 	}
 }
 

--- a/src/moaicore/MOAIImage.h
+++ b/src/moaicore/MOAIImage.h
@@ -86,10 +86,13 @@ private:
 	void			Init				( void* bitmap, u32 width, u32 height, USColor::Format colorFmt, bool copy );
 	static bool		IsJpg				( USStream& stream );
 	static bool		IsPng				( USStream& stream );
+	static bool     IsWebP              ( USStream& stream );
 	void			LoadJpg				( USStream& stream, u32 transform );
 	void			LoadJpg				( void* jpgInfoParam, u32 transform );
 	void			LoadPng				( USStream& stream, u32 transform );
 	void			LoadPng				( void* pngParam, void* pngInfoParam, u32 transform );
+	void            LoadWebP            ( USStream& stream, u32 transform );
+	void            LoadWebP            ( u8 const* data, size_t dataSize, int width, int height, bool hasAlpha, u32 transform );
 
 public:
 	

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -734,6 +734,483 @@
 		07FAC91613B8F1CA00AFD0B3 /* moaicore-pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07FAC91513B8F1CA00AFD0B3 /* moaicore-pch.cpp */; };
 		07FAC91813B8F1E000AFD0B3 /* uslscore-pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07FAC91713B8F1E000AFD0B3 /* uslscore-pch.cpp */; };
 		357DE8D31BFA7EE300C4CE8D /* USUnique.h in Headers */ = {isa = PBXBuildFile; fileRef = CD19AA07151AF7E2006A1F9D /* USUnique.h */; };
+		4D08134326DD9121001BF800 /* muxread.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E026DD9120001BF800 /* muxread.c */; };
+		4D08134426DD9121001BF800 /* muxread.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E026DD9120001BF800 /* muxread.c */; };
+		4D08134526DD9121001BF800 /* muxread.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E026DD9120001BF800 /* muxread.c */; };
+		4D08134626DD9121001BF800 /* muxinternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E126DD9120001BF800 /* muxinternal.c */; };
+		4D08134726DD9121001BF800 /* muxinternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E126DD9120001BF800 /* muxinternal.c */; };
+		4D08134826DD9121001BF800 /* muxinternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E126DD9120001BF800 /* muxinternal.c */; };
+		4D08134926DD9121001BF800 /* anim_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E426DD9120001BF800 /* anim_encode.c */; };
+		4D08134A26DD9121001BF800 /* anim_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E426DD9120001BF800 /* anim_encode.c */; };
+		4D08134B26DD9121001BF800 /* anim_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E426DD9120001BF800 /* anim_encode.c */; };
+		4D08134C26DD9121001BF800 /* animi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E526DD9120001BF800 /* animi.h */; };
+		4D08134D26DD9121001BF800 /* animi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E526DD9120001BF800 /* animi.h */; };
+		4D08134E26DD9121001BF800 /* animi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E526DD9120001BF800 /* animi.h */; };
+		4D08134F26DD9121001BF800 /* muxedit.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E726DD9120001BF800 /* muxedit.c */; };
+		4D08135026DD9121001BF800 /* muxedit.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E726DD9120001BF800 /* muxedit.c */; };
+		4D08135126DD9121001BF800 /* muxedit.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811E726DD9120001BF800 /* muxedit.c */; };
+		4D08135226DD9121001BF800 /* muxi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E826DD9120001BF800 /* muxi.h */; };
+		4D08135326DD9121001BF800 /* muxi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E826DD9120001BF800 /* muxi.h */; };
+		4D08135426DD9121001BF800 /* muxi.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811E826DD9120001BF800 /* muxi.h */; };
+		4D08135526DD9121001BF800 /* bit_writer_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811ED26DD9120001BF800 /* bit_writer_utils.c */; };
+		4D08135626DD9121001BF800 /* bit_writer_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811ED26DD9120001BF800 /* bit_writer_utils.c */; };
+		4D08135726DD9121001BF800 /* bit_writer_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811ED26DD9120001BF800 /* bit_writer_utils.c */; };
+		4D08135826DD9121001BF800 /* endian_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811EE26DD9120001BF800 /* endian_inl_utils.h */; };
+		4D08135926DD9121001BF800 /* endian_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811EE26DD9120001BF800 /* endian_inl_utils.h */; };
+		4D08135A26DD9121001BF800 /* endian_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811EE26DD9120001BF800 /* endian_inl_utils.h */; };
+		4D08135B26DD9121001BF800 /* thread_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811EF26DD9120001BF800 /* thread_utils.c */; };
+		4D08135C26DD9121001BF800 /* thread_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811EF26DD9120001BF800 /* thread_utils.c */; };
+		4D08135D26DD9121001BF800 /* thread_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811EF26DD9120001BF800 /* thread_utils.c */; };
+		4D08135E26DD9121001BF800 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F026DD9120001BF800 /* utils.h */; };
+		4D08135F26DD9121001BF800 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F026DD9120001BF800 /* utils.h */; };
+		4D08136026DD9121001BF800 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F026DD9120001BF800 /* utils.h */; };
+		4D08136126DD9121001BF800 /* bit_reader_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F126DD9120001BF800 /* bit_reader_utils.h */; };
+		4D08136226DD9121001BF800 /* bit_reader_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F126DD9120001BF800 /* bit_reader_utils.h */; };
+		4D08136326DD9121001BF800 /* bit_reader_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F126DD9120001BF800 /* bit_reader_utils.h */; };
+		4D08136426DD9121001BF800 /* bit_reader_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F226DD9120001BF800 /* bit_reader_inl_utils.h */; };
+		4D08136526DD9121001BF800 /* bit_reader_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F226DD9120001BF800 /* bit_reader_inl_utils.h */; };
+		4D08136626DD9121001BF800 /* bit_reader_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F226DD9120001BF800 /* bit_reader_inl_utils.h */; };
+		4D08136726DD9121001BF800 /* rescaler_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F326DD9120001BF800 /* rescaler_utils.c */; };
+		4D08136826DD9121001BF800 /* rescaler_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F326DD9120001BF800 /* rescaler_utils.c */; };
+		4D08136926DD9121001BF800 /* rescaler_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F326DD9120001BF800 /* rescaler_utils.c */; };
+		4D08136A26DD9121001BF800 /* quant_levels_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F426DD9120001BF800 /* quant_levels_utils.h */; };
+		4D08136B26DD9121001BF800 /* quant_levels_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F426DD9120001BF800 /* quant_levels_utils.h */; };
+		4D08136C26DD9121001BF800 /* quant_levels_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F426DD9120001BF800 /* quant_levels_utils.h */; };
+		4D08136D26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F526DD9120001BF800 /* quant_levels_dec_utils.h */; };
+		4D08136E26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F526DD9120001BF800 /* quant_levels_dec_utils.h */; };
+		4D08136F26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F526DD9120001BF800 /* quant_levels_dec_utils.h */; };
+		4D08137026DD9121001BF800 /* huffman_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F626DD9120001BF800 /* huffman_utils.c */; };
+		4D08137126DD9121001BF800 /* huffman_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F626DD9120001BF800 /* huffman_utils.c */; };
+		4D08137226DD9122001BF800 /* huffman_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F626DD9120001BF800 /* huffman_utils.c */; };
+		4D08137326DD9122001BF800 /* color_cache_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F726DD9120001BF800 /* color_cache_utils.h */; };
+		4D08137426DD9122001BF800 /* color_cache_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F726DD9120001BF800 /* color_cache_utils.h */; };
+		4D08137526DD9122001BF800 /* color_cache_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F726DD9120001BF800 /* color_cache_utils.h */; };
+		4D08137626DD9122001BF800 /* filters_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F826DD9120001BF800 /* filters_utils.h */; };
+		4D08137726DD9122001BF800 /* filters_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F826DD9120001BF800 /* filters_utils.h */; };
+		4D08137826DD9122001BF800 /* filters_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811F826DD9120001BF800 /* filters_utils.h */; };
+		4D08137926DD9122001BF800 /* huffman_encode_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F926DD9120001BF800 /* huffman_encode_utils.c */; };
+		4D08137A26DD9122001BF800 /* huffman_encode_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F926DD9120001BF800 /* huffman_encode_utils.c */; };
+		4D08137B26DD9122001BF800 /* huffman_encode_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811F926DD9120001BF800 /* huffman_encode_utils.c */; };
+		4D08137C26DD9122001BF800 /* random_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FA26DD9120001BF800 /* random_utils.h */; };
+		4D08137D26DD9122001BF800 /* random_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FA26DD9120001BF800 /* random_utils.h */; };
+		4D08137E26DD9122001BF800 /* random_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FA26DD9120001BF800 /* random_utils.h */; };
+		4D08137F26DD9122001BF800 /* rescaler_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FB26DD9120001BF800 /* rescaler_utils.h */; };
+		4D08138026DD9122001BF800 /* rescaler_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FB26DD9120001BF800 /* rescaler_utils.h */; };
+		4D08138126DD9122001BF800 /* rescaler_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0811FB26DD9120001BF800 /* rescaler_utils.h */; };
+		4D08138226DD9122001BF800 /* quant_levels_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FD26DD9120001BF800 /* quant_levels_utils.c */; };
+		4D08138326DD9122001BF800 /* quant_levels_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FD26DD9120001BF800 /* quant_levels_utils.c */; };
+		4D08138426DD9122001BF800 /* quant_levels_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FD26DD9120001BF800 /* quant_levels_utils.c */; };
+		4D08138526DD9122001BF800 /* quant_levels_dec_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FE26DD9120001BF800 /* quant_levels_dec_utils.c */; };
+		4D08138626DD9122001BF800 /* quant_levels_dec_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FE26DD9120001BF800 /* quant_levels_dec_utils.c */; };
+		4D08138726DD9122001BF800 /* quant_levels_dec_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FE26DD9120001BF800 /* quant_levels_dec_utils.c */; };
+		4D08138826DD9122001BF800 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FF26DD9120001BF800 /* bit_reader_utils.c */; };
+		4D08138926DD9122001BF800 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FF26DD9120001BF800 /* bit_reader_utils.c */; };
+		4D08138A26DD9122001BF800 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D0811FF26DD9120001BF800 /* bit_reader_utils.c */; };
+		4D08138B26DD9122001BF800 /* thread_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120026DD9120001BF800 /* thread_utils.h */; };
+		4D08138C26DD9122001BF800 /* thread_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120026DD9120001BF800 /* thread_utils.h */; };
+		4D08138D26DD9122001BF800 /* thread_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120026DD9120001BF800 /* thread_utils.h */; };
+		4D08138E26DD9122001BF800 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120126DD9120001BF800 /* utils.c */; };
+		4D08138F26DD9122001BF800 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120126DD9120001BF800 /* utils.c */; };
+		4D08139026DD9122001BF800 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120126DD9120001BF800 /* utils.c */; };
+		4D08139126DD9122001BF800 /* bit_writer_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120226DD9120001BF800 /* bit_writer_utils.h */; };
+		4D08139226DD9122001BF800 /* bit_writer_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120226DD9120001BF800 /* bit_writer_utils.h */; };
+		4D08139326DD9122001BF800 /* bit_writer_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120226DD9120001BF800 /* bit_writer_utils.h */; };
+		4D08139426DD9122001BF800 /* huffman_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120326DD9120001BF800 /* huffman_utils.h */; };
+		4D08139526DD9122001BF800 /* huffman_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120326DD9120001BF800 /* huffman_utils.h */; };
+		4D08139626DD9122001BF800 /* huffman_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120326DD9120001BF800 /* huffman_utils.h */; };
+		4D08139726DD9122001BF800 /* huffman_encode_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120426DD9120001BF800 /* huffman_encode_utils.h */; };
+		4D08139826DD9122001BF800 /* huffman_encode_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120426DD9120001BF800 /* huffman_encode_utils.h */; };
+		4D08139926DD9122001BF800 /* huffman_encode_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120426DD9120001BF800 /* huffman_encode_utils.h */; };
+		4D08139A26DD9122001BF800 /* color_cache_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120526DD9120001BF800 /* color_cache_utils.c */; };
+		4D08139B26DD9122001BF800 /* color_cache_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120526DD9120001BF800 /* color_cache_utils.c */; };
+		4D08139C26DD9122001BF800 /* color_cache_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120526DD9120001BF800 /* color_cache_utils.c */; };
+		4D08139D26DD9122001BF800 /* filters_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120626DD9120001BF800 /* filters_utils.c */; };
+		4D08139E26DD9122001BF800 /* filters_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120626DD9120001BF800 /* filters_utils.c */; };
+		4D08139F26DD9122001BF800 /* filters_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120626DD9120001BF800 /* filters_utils.c */; };
+		4D0813A026DD9122001BF800 /* random_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120726DD9120001BF800 /* random_utils.c */; };
+		4D0813A126DD9122001BF800 /* random_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120726DD9120001BF800 /* random_utils.c */; };
+		4D0813A226DD9122001BF800 /* random_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08120726DD9120001BF800 /* random_utils.c */; };
+		4D0813A326DD9122001BF800 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120926DD9120001BF800 /* format_constants.h */; };
+		4D0813A426DD9122001BF800 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120926DD9120001BF800 /* format_constants.h */; };
+		4D0813A526DD9122001BF800 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120926DD9120001BF800 /* format_constants.h */; };
+		4D0813A626DD9122001BF800 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120A26DD9120001BF800 /* mux.h */; };
+		4D0813A726DD9122001BF800 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120A26DD9120001BF800 /* mux.h */; };
+		4D0813A826DD9122001BF800 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120A26DD9120001BF800 /* mux.h */; };
+		4D0813A926DD9122001BF800 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120B26DD9120001BF800 /* types.h */; };
+		4D0813AA26DD9122001BF800 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120B26DD9120001BF800 /* types.h */; };
+		4D0813AB26DD9122001BF800 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120B26DD9120001BF800 /* types.h */; };
+		4D0813AC26DD9122001BF800 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120C26DD9120001BF800 /* demux.h */; };
+		4D0813AD26DD9122001BF800 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120C26DD9120001BF800 /* demux.h */; };
+		4D0813AE26DD9122001BF800 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120C26DD9120001BF800 /* demux.h */; };
+		4D0813AF26DD9122001BF800 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120D26DD9120001BF800 /* mux_types.h */; };
+		4D0813B026DD9122001BF800 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120D26DD9120001BF800 /* mux_types.h */; };
+		4D0813B126DD9122001BF800 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120D26DD9120001BF800 /* mux_types.h */; };
+		4D0813B226DD9122001BF800 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120E26DD9120001BF800 /* encode.h */; };
+		4D0813B326DD9122001BF800 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120E26DD9120001BF800 /* encode.h */; };
+		4D0813B426DD9122001BF800 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120E26DD9120001BF800 /* encode.h */; };
+		4D0813B526DD9122001BF800 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120F26DD9120001BF800 /* decode.h */; };
+		4D0813B626DD9122001BF800 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120F26DD9120001BF800 /* decode.h */; };
+		4D0813B726DD9122001BF800 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08120F26DD9120001BF800 /* decode.h */; };
+		4D0813B826DD9122001BF800 /* iterator_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121226DD9120001BF800 /* iterator_enc.c */; };
+		4D0813B926DD9122001BF800 /* iterator_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121226DD9120001BF800 /* iterator_enc.c */; };
+		4D0813BA26DD9122001BF800 /* iterator_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121226DD9120001BF800 /* iterator_enc.c */; };
+		4D0813BB26DD9122001BF800 /* backward_references_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121326DD9120001BF800 /* backward_references_enc.h */; };
+		4D0813BC26DD9122001BF800 /* backward_references_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121326DD9120001BF800 /* backward_references_enc.h */; };
+		4D0813BD26DD9122001BF800 /* backward_references_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121326DD9120001BF800 /* backward_references_enc.h */; };
+		4D0813BE26DD9122001BF800 /* cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121426DD9120001BF800 /* cost_enc.c */; };
+		4D0813BF26DD9122001BF800 /* cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121426DD9120001BF800 /* cost_enc.c */; };
+		4D0813C026DD9122001BF800 /* cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121426DD9120001BF800 /* cost_enc.c */; };
+		4D0813C126DD9122001BF800 /* alpha_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121526DD9120001BF800 /* alpha_enc.c */; };
+		4D0813C226DD9122001BF800 /* alpha_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121526DD9120001BF800 /* alpha_enc.c */; };
+		4D0813C326DD9122001BF800 /* alpha_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121526DD9120001BF800 /* alpha_enc.c */; };
+		4D0813C426DD9122001BF800 /* histogram_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121626DD9120001BF800 /* histogram_enc.h */; };
+		4D0813C526DD9122001BF800 /* histogram_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121626DD9120001BF800 /* histogram_enc.h */; };
+		4D0813C626DD9122001BF800 /* histogram_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121626DD9120001BF800 /* histogram_enc.h */; };
+		4D0813C726DD9122001BF800 /* picture_psnr_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121726DD9120001BF800 /* picture_psnr_enc.c */; };
+		4D0813C826DD9122001BF800 /* picture_psnr_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121726DD9120001BF800 /* picture_psnr_enc.c */; };
+		4D0813C926DD9122001BF800 /* picture_psnr_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121726DD9120001BF800 /* picture_psnr_enc.c */; };
+		4D0813CA26DD9122001BF800 /* token_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121826DD9120001BF800 /* token_enc.c */; };
+		4D0813CB26DD9122001BF800 /* token_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121826DD9120001BF800 /* token_enc.c */; };
+		4D0813CC26DD9122001BF800 /* token_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121826DD9120001BF800 /* token_enc.c */; };
+		4D0813CD26DD9122001BF800 /* vp8i_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121926DD9120001BF800 /* vp8i_enc.h */; };
+		4D0813CE26DD9122001BF800 /* vp8i_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121926DD9120001BF800 /* vp8i_enc.h */; };
+		4D0813CF26DD9122001BF800 /* vp8i_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121926DD9120001BF800 /* vp8i_enc.h */; };
+		4D0813D026DD9122001BF800 /* tree_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121A26DD9120001BF800 /* tree_enc.c */; };
+		4D0813D126DD9122001BF800 /* tree_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121A26DD9120001BF800 /* tree_enc.c */; };
+		4D0813D226DD9122001BF800 /* tree_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121A26DD9120001BF800 /* tree_enc.c */; };
+		4D0813D326DD9122001BF800 /* filter_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121B26DD9120001BF800 /* filter_enc.c */; };
+		4D0813D426DD9122001BF800 /* filter_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121B26DD9120001BF800 /* filter_enc.c */; };
+		4D0813D526DD9122001BF800 /* filter_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121B26DD9120001BF800 /* filter_enc.c */; };
+		4D0813D626DD9122001BF800 /* picture_csp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121C26DD9120001BF800 /* picture_csp_enc.c */; };
+		4D0813D726DD9122001BF800 /* picture_csp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121C26DD9120001BF800 /* picture_csp_enc.c */; };
+		4D0813D826DD9122001BF800 /* picture_csp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121C26DD9120001BF800 /* picture_csp_enc.c */; };
+		4D0813D926DD9122001BF800 /* frame_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121D26DD9120001BF800 /* frame_enc.c */; };
+		4D0813DA26DD9122001BF800 /* frame_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121D26DD9120001BF800 /* frame_enc.c */; };
+		4D0813DB26DD9122001BF800 /* frame_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121D26DD9120001BF800 /* frame_enc.c */; };
+		4D0813DC26DD9122001BF800 /* syntax_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121E26DD9120001BF800 /* syntax_enc.c */; };
+		4D0813DD26DD9122001BF800 /* syntax_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121E26DD9120001BF800 /* syntax_enc.c */; };
+		4D0813DE26DD9122001BF800 /* syntax_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08121E26DD9120001BF800 /* syntax_enc.c */; };
+		4D0813DF26DD9122001BF800 /* cost_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121F26DD9120001BF800 /* cost_enc.h */; };
+		4D0813E026DD9122001BF800 /* cost_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121F26DD9120001BF800 /* cost_enc.h */; };
+		4D0813E126DD9122001BF800 /* cost_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08121F26DD9120001BF800 /* cost_enc.h */; };
+		4D0813E226DD9122001BF800 /* predictor_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122126DD9120001BF800 /* predictor_enc.c */; };
+		4D0813E326DD9122001BF800 /* predictor_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122126DD9120001BF800 /* predictor_enc.c */; };
+		4D0813E426DD9122001BF800 /* predictor_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122126DD9120001BF800 /* predictor_enc.c */; };
+		4D0813E526DD9122001BF800 /* config_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122226DD9120001BF800 /* config_enc.c */; };
+		4D0813E626DD9122001BF800 /* config_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122226DD9120001BF800 /* config_enc.c */; };
+		4D0813E726DD9122001BF800 /* config_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122226DD9120001BF800 /* config_enc.c */; };
+		4D0813E826DD9122001BF800 /* backward_references_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122326DD9120001BF800 /* backward_references_enc.c */; };
+		4D0813E926DD9122001BF800 /* backward_references_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122326DD9120001BF800 /* backward_references_enc.c */; };
+		4D0813EA26DD9122001BF800 /* backward_references_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122326DD9120001BF800 /* backward_references_enc.c */; };
+		4D0813EB26DD9122001BF800 /* picture_tools_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122426DD9120001BF800 /* picture_tools_enc.c */; };
+		4D0813EC26DD9122001BF800 /* picture_tools_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122426DD9120001BF800 /* picture_tools_enc.c */; };
+		4D0813ED26DD9122001BF800 /* picture_tools_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122426DD9120001BF800 /* picture_tools_enc.c */; };
+		4D0813EE26DD9122001BF800 /* webp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122526DD9120001BF800 /* webp_enc.c */; };
+		4D0813EF26DD9122001BF800 /* webp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122526DD9120001BF800 /* webp_enc.c */; };
+		4D0813F026DD9122001BF800 /* webp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122526DD9120001BF800 /* webp_enc.c */; };
+		4D0813F126DD9122001BF800 /* vp8l_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122626DD9120001BF800 /* vp8l_enc.c */; };
+		4D0813F226DD9122001BF800 /* vp8l_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122626DD9120001BF800 /* vp8l_enc.c */; };
+		4D0813F326DD9122001BF800 /* vp8l_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122626DD9120001BF800 /* vp8l_enc.c */; };
+		4D0813F426DD9122001BF800 /* histogram_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122726DD9120001BF800 /* histogram_enc.c */; };
+		4D0813F526DD9122001BF800 /* histogram_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122726DD9120001BF800 /* histogram_enc.c */; };
+		4D0813F626DD9122001BF800 /* histogram_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122726DD9120001BF800 /* histogram_enc.c */; };
+		4D0813F726DD9122001BF800 /* analysis_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122826DD9120001BF800 /* analysis_enc.c */; };
+		4D0813F826DD9122001BF800 /* analysis_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122826DD9120001BF800 /* analysis_enc.c */; };
+		4D0813F926DD9122001BF800 /* analysis_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122826DD9120001BF800 /* analysis_enc.c */; };
+		4D0813FA26DD9122001BF800 /* vp8li_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08122926DD9120001BF800 /* vp8li_enc.h */; };
+		4D0813FB26DD9122001BF800 /* vp8li_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08122926DD9120001BF800 /* vp8li_enc.h */; };
+		4D0813FC26DD9122001BF800 /* vp8li_enc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08122926DD9120001BF800 /* vp8li_enc.h */; };
+		4D0813FD26DD9122001BF800 /* quant_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122A26DD9120001BF800 /* quant_enc.c */; };
+		4D0813FE26DD9122001BF800 /* quant_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122A26DD9120001BF800 /* quant_enc.c */; };
+		4D0813FF26DD9122001BF800 /* quant_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122A26DD9120001BF800 /* quant_enc.c */; };
+		4D08140026DD9122001BF800 /* near_lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122B26DD9120001BF800 /* near_lossless_enc.c */; };
+		4D08140126DD9122001BF800 /* near_lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122B26DD9120001BF800 /* near_lossless_enc.c */; };
+		4D08140226DD9122001BF800 /* near_lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122B26DD9120001BF800 /* near_lossless_enc.c */; };
+		4D08140326DD9122001BF800 /* picture_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122C26DD9120001BF800 /* picture_enc.c */; };
+		4D08140426DD9122001BF800 /* picture_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122C26DD9120001BF800 /* picture_enc.c */; };
+		4D08140526DD9122001BF800 /* picture_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122C26DD9120001BF800 /* picture_enc.c */; };
+		4D08140626DD9122001BF800 /* backward_references_cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122D26DD9120001BF800 /* backward_references_cost_enc.c */; };
+		4D08140726DD9122001BF800 /* backward_references_cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122D26DD9120001BF800 /* backward_references_cost_enc.c */; };
+		4D08140826DD9122001BF800 /* backward_references_cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122D26DD9120001BF800 /* backward_references_cost_enc.c */; };
+		4D08140926DD9122001BF800 /* picture_rescale_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122E26DD9120001BF800 /* picture_rescale_enc.c */; };
+		4D08140A26DD9122001BF800 /* picture_rescale_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122E26DD9120001BF800 /* picture_rescale_enc.c */; };
+		4D08140B26DD9122001BF800 /* picture_rescale_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08122E26DD9120001BF800 /* picture_rescale_enc.c */; };
+		4D08140C26DD9122001BF800 /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123026DD9120001BF800 /* demux.c */; };
+		4D08140D26DD9122001BF800 /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123026DD9120001BF800 /* demux.c */; };
+		4D08140E26DD9122001BF800 /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123026DD9120001BF800 /* demux.c */; };
+		4D08140F26DD9122001BF800 /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123326DD9120001BF800 /* anim_decode.c */; };
+		4D08141026DD9122001BF800 /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123326DD9120001BF800 /* anim_decode.c */; };
+		4D08141126DD9122001BF800 /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123326DD9120001BF800 /* anim_decode.c */; };
+		4D08141226DD9122001BF800 /* io_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123726DD9120001BF800 /* io_dec.c */; };
+		4D08141326DD9122001BF800 /* io_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123726DD9120001BF800 /* io_dec.c */; };
+		4D08141426DD9122001BF800 /* io_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123726DD9120001BF800 /* io_dec.c */; };
+		4D08141526DD9122001BF800 /* frame_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123826DD9120001BF800 /* frame_dec.c */; };
+		4D08141626DD9122001BF800 /* frame_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123826DD9120001BF800 /* frame_dec.c */; };
+		4D08141726DD9122001BF800 /* frame_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123826DD9120001BF800 /* frame_dec.c */; };
+		4D08141826DD9122001BF800 /* tree_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123926DD9120001BF800 /* tree_dec.c */; };
+		4D08141926DD9122001BF800 /* tree_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123926DD9120001BF800 /* tree_dec.c */; };
+		4D08141A26DD9122001BF800 /* tree_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123926DD9120001BF800 /* tree_dec.c */; };
+		4D08141B26DD9122001BF800 /* vp8i_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123A26DD9120001BF800 /* vp8i_dec.h */; };
+		4D08141C26DD9122001BF800 /* vp8i_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123A26DD9120001BF800 /* vp8i_dec.h */; };
+		4D08141D26DD9122001BF800 /* vp8i_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123A26DD9120001BF800 /* vp8i_dec.h */; };
+		4D08141E26DD9122001BF800 /* vp8_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123B26DD9120001BF800 /* vp8_dec.h */; };
+		4D08141F26DD9122001BF800 /* vp8_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123B26DD9120001BF800 /* vp8_dec.h */; };
+		4D08142026DD9122001BF800 /* vp8_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123B26DD9120001BF800 /* vp8_dec.h */; };
+		4D08142126DD9122001BF800 /* alpha_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123C26DD9120001BF800 /* alpha_dec.c */; };
+		4D08142226DD9122001BF800 /* alpha_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123C26DD9120001BF800 /* alpha_dec.c */; };
+		4D08142326DD9122001BF800 /* alpha_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123C26DD9120001BF800 /* alpha_dec.c */; };
+		4D08142426DD9122001BF800 /* common_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123D26DD9120001BF800 /* common_dec.h */; };
+		4D08142526DD9122001BF800 /* common_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123D26DD9120001BF800 /* common_dec.h */; };
+		4D08142626DD9122001BF800 /* common_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08123D26DD9120001BF800 /* common_dec.h */; };
+		4D08142726DD9122001BF800 /* buffer_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123F26DD9120001BF800 /* buffer_dec.c */; };
+		4D08142826DD9122001BF800 /* buffer_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123F26DD9120001BF800 /* buffer_dec.c */; };
+		4D08142926DD9122001BF800 /* buffer_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08123F26DD9120001BF800 /* buffer_dec.c */; };
+		4D08142A26DD9122001BF800 /* quant_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124026DD9120001BF800 /* quant_dec.c */; };
+		4D08142B26DD9122001BF800 /* quant_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124026DD9120001BF800 /* quant_dec.c */; };
+		4D08142C26DD9123001BF800 /* quant_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124026DD9120001BF800 /* quant_dec.c */; };
+		4D08142D26DD9123001BF800 /* vp8li_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124126DD9120001BF800 /* vp8li_dec.h */; };
+		4D08142E26DD9123001BF800 /* vp8li_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124126DD9120001BF800 /* vp8li_dec.h */; };
+		4D08142F26DD9123001BF800 /* vp8li_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124126DD9120001BF800 /* vp8li_dec.h */; };
+		4D08143026DD9123001BF800 /* idec_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124226DD9120001BF800 /* idec_dec.c */; };
+		4D08143126DD9123001BF800 /* idec_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124226DD9120001BF800 /* idec_dec.c */; };
+		4D08143226DD9123001BF800 /* idec_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124226DD9120001BF800 /* idec_dec.c */; };
+		4D08143326DD9123001BF800 /* webp_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124326DD9120001BF800 /* webp_dec.c */; };
+		4D08143426DD9123001BF800 /* webp_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124326DD9120001BF800 /* webp_dec.c */; };
+		4D08143526DD9123001BF800 /* webp_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124326DD9120001BF800 /* webp_dec.c */; };
+		4D08143626DD9123001BF800 /* vp8l_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124426DD9120001BF800 /* vp8l_dec.c */; };
+		4D08143726DD9123001BF800 /* vp8l_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124426DD9120001BF800 /* vp8l_dec.c */; };
+		4D08143826DD9123001BF800 /* vp8l_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124426DD9120001BF800 /* vp8l_dec.c */; };
+		4D08143926DD9123001BF800 /* alphai_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124526DD9120001BF800 /* alphai_dec.h */; };
+		4D08143A26DD9123001BF800 /* alphai_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124526DD9120001BF800 /* alphai_dec.h */; };
+		4D08143B26DD9123001BF800 /* alphai_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124526DD9120001BF800 /* alphai_dec.h */; };
+		4D08143C26DD9123001BF800 /* vp8_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124626DD9120001BF800 /* vp8_dec.c */; };
+		4D08143D26DD9123001BF800 /* vp8_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124626DD9120001BF800 /* vp8_dec.c */; };
+		4D08143E26DD9123001BF800 /* vp8_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124626DD9120001BF800 /* vp8_dec.c */; };
+		4D08143F26DD9123001BF800 /* webpi_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124726DD9120001BF800 /* webpi_dec.h */; };
+		4D08144026DD9123001BF800 /* webpi_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124726DD9120001BF800 /* webpi_dec.h */; };
+		4D08144126DD9123001BF800 /* webpi_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124726DD9120001BF800 /* webpi_dec.h */; };
+		4D08144226DD9123001BF800 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124926DD9120001BF800 /* upsampling.c */; };
+		4D08144326DD9123001BF800 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124926DD9120001BF800 /* upsampling.c */; };
+		4D08144426DD9123001BF800 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124926DD9120001BF800 /* upsampling.c */; };
+		4D08144526DD9123001BF800 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124A26DD9120001BF800 /* lossless_sse2.c */; };
+		4D08144626DD9123001BF800 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124A26DD9120001BF800 /* lossless_sse2.c */; };
+		4D08144726DD9123001BF800 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124A26DD9120001BF800 /* lossless_sse2.c */; };
+		4D08144826DD9123001BF800 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124B26DD9120001BF800 /* lossless.h */; };
+		4D08144926DD9123001BF800 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124B26DD9120001BF800 /* lossless.h */; };
+		4D08144A26DD9123001BF800 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124B26DD9120001BF800 /* lossless.h */; };
+		4D08144B26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124C26DD9120001BF800 /* lossless_enc_mips_dsp_r2.c */; };
+		4D08144C26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124C26DD9120001BF800 /* lossless_enc_mips_dsp_r2.c */; };
+		4D08144D26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124C26DD9120001BF800 /* lossless_enc_mips_dsp_r2.c */; };
+		4D08144E26DD9123001BF800 /* enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124D26DD9120001BF800 /* enc_msa.c */; };
+		4D08144F26DD9123001BF800 /* enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124D26DD9120001BF800 /* enc_msa.c */; };
+		4D08145026DD9123001BF800 /* enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08124D26DD9120001BF800 /* enc_msa.c */; };
+		4D08145126DD9123001BF800 /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124E26DD9120001BF800 /* msa_macro.h */; };
+		4D08145226DD9123001BF800 /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124E26DD9120001BF800 /* msa_macro.h */; };
+		4D08145326DD9123001BF800 /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124E26DD9120001BF800 /* msa_macro.h */; };
+		4D08145426DD9123001BF800 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124F26DD9120001BF800 /* neon.h */; };
+		4D08145526DD9123001BF800 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124F26DD9120001BF800 /* neon.h */; };
+		4D08145626DD9123001BF800 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08124F26DD9120001BF800 /* neon.h */; };
+		4D08145726DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125026DD9120001BF800 /* filters_mips_dsp_r2.c */; };
+		4D08145826DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125026DD9120001BF800 /* filters_mips_dsp_r2.c */; };
+		4D08145926DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125026DD9120001BF800 /* filters_mips_dsp_r2.c */; };
+		4D08145A26DD9123001BF800 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125126DD9120001BF800 /* rescaler.c */; };
+		4D08145B26DD9123001BF800 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125126DD9120001BF800 /* rescaler.c */; };
+		4D08145C26DD9123001BF800 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125126DD9120001BF800 /* rescaler.c */; };
+		4D08145D26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125226DD9120001BF800 /* dec_mips_dsp_r2.c */; };
+		4D08145E26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125226DD9120001BF800 /* dec_mips_dsp_r2.c */; };
+		4D08145F26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125226DD9120001BF800 /* dec_mips_dsp_r2.c */; };
+		4D08146026DD9123001BF800 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125326DD9120001BF800 /* rescaler_neon.c */; };
+		4D08146126DD9123001BF800 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125326DD9120001BF800 /* rescaler_neon.c */; };
+		4D08146226DD9123001BF800 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125326DD9120001BF800 /* rescaler_neon.c */; };
+		4D08146326DD9123001BF800 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125426DD9120001BF800 /* cost_sse2.c */; };
+		4D08146426DD9123001BF800 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125426DD9120001BF800 /* cost_sse2.c */; };
+		4D08146526DD9123001BF800 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125426DD9120001BF800 /* cost_sse2.c */; };
+		4D08146626DD9123001BF800 /* upsampling_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125526DD9120001BF800 /* upsampling_sse41.c */; };
+		4D08146726DD9123001BF800 /* upsampling_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125526DD9120001BF800 /* upsampling_sse41.c */; };
+		4D08146826DD9123001BF800 /* upsampling_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125526DD9120001BF800 /* upsampling_sse41.c */; };
+		4D08146926DD9123001BF800 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125626DD9120001BF800 /* enc_sse41.c */; };
+		4D08146A26DD9123001BF800 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125626DD9120001BF800 /* enc_sse41.c */; };
+		4D08146B26DD9123001BF800 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125626DD9120001BF800 /* enc_sse41.c */; };
+		4D08146C26DD9123001BF800 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125726DD9120001BF800 /* lossless_enc_sse41.c */; };
+		4D08146D26DD9123001BF800 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125726DD9120001BF800 /* lossless_enc_sse41.c */; };
+		4D08146E26DD9123001BF800 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125726DD9120001BF800 /* lossless_enc_sse41.c */; };
+		4D08146F26DD9123001BF800 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125826DD9120001BF800 /* upsampling_neon.c */; };
+		4D08147026DD9123001BF800 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125826DD9120001BF800 /* upsampling_neon.c */; };
+		4D08147126DD9123001BF800 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125826DD9120001BF800 /* upsampling_neon.c */; };
+		4D08147226DD9123001BF800 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125926DD9120001BF800 /* filters_sse2.c */; };
+		4D08147326DD9123001BF800 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125926DD9120001BF800 /* filters_sse2.c */; };
+		4D08147426DD9123001BF800 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125926DD9120001BF800 /* filters_sse2.c */; };
+		4D08147526DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125A26DD9120001BF800 /* lossless_mips_dsp_r2.c */; };
+		4D08147626DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125A26DD9120001BF800 /* lossless_mips_dsp_r2.c */; };
+		4D08147726DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125A26DD9120001BF800 /* lossless_mips_dsp_r2.c */; };
+		4D08147826DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125B26DD9120001BF800 /* enc_mips_dsp_r2.c */; };
+		4D08147926DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125B26DD9120001BF800 /* enc_mips_dsp_r2.c */; };
+		4D08147A26DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125B26DD9120001BF800 /* enc_mips_dsp_r2.c */; };
+		4D08147B26DD9123001BF800 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125C26DD9120001BF800 /* cpu.c */; };
+		4D08147C26DD9123001BF800 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125C26DD9120001BF800 /* cpu.c */; };
+		4D08147D26DD9123001BF800 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125C26DD9120001BF800 /* cpu.c */; };
+		4D08147E26DD9123001BF800 /* yuv_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125D26DD9120001BF800 /* yuv_neon.c */; };
+		4D08147F26DD9123001BF800 /* yuv_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125D26DD9120001BF800 /* yuv_neon.c */; };
+		4D08148026DD9123001BF800 /* yuv_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125D26DD9120001BF800 /* yuv_neon.c */; };
+		4D08148126DD9123001BF800 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125E26DD9120001BF800 /* alpha_processing.c */; };
+		4D08148226DD9123001BF800 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125E26DD9120001BF800 /* alpha_processing.c */; };
+		4D08148326DD9123001BF800 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08125E26DD9120001BF800 /* alpha_processing.c */; };
+		4D08148426DD9123001BF800 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08125F26DD9120001BF800 /* yuv.h */; };
+		4D08148526DD9123001BF800 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08125F26DD9120001BF800 /* yuv.h */; };
+		4D08148626DD9123001BF800 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08125F26DD9120001BF800 /* yuv.h */; };
+		4D08148726DD9123001BF800 /* quant.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126026DD9120001BF800 /* quant.h */; };
+		4D08148826DD9123001BF800 /* quant.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126026DD9120001BF800 /* quant.h */; };
+		4D08148926DD9123001BF800 /* quant.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126026DD9120001BF800 /* quant.h */; };
+		4D08148A26DD9123001BF800 /* cost_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126126DD9120001BF800 /* cost_neon.c */; };
+		4D08148B26DD9123001BF800 /* cost_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126126DD9120001BF800 /* cost_neon.c */; };
+		4D08148C26DD9123001BF800 /* cost_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126126DD9120001BF800 /* cost_neon.c */; };
+		4D08148D26DD9123001BF800 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126226DD9120001BF800 /* enc_mips32.c */; };
+		4D08148E26DD9123001BF800 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126226DD9120001BF800 /* enc_mips32.c */; };
+		4D08148F26DD9123001BF800 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126226DD9120001BF800 /* enc_mips32.c */; };
+		4D08149026DD9123001BF800 /* filters_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126326DD9120001BF800 /* filters_neon.c */; };
+		4D08149126DD9123001BF800 /* filters_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126326DD9120001BF800 /* filters_neon.c */; };
+		4D08149226DD9123001BF800 /* filters_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126326DD9120001BF800 /* filters_neon.c */; };
+		4D08149326DD9123001BF800 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126426DD9120001BF800 /* upsampling_sse2.c */; };
+		4D08149426DD9123001BF800 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126426DD9120001BF800 /* upsampling_sse2.c */; };
+		4D08149526DD9123001BF800 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126426DD9120001BF800 /* upsampling_sse2.c */; };
+		4D08149626DD9123001BF800 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126526DD9120001BF800 /* yuv_sse2.c */; };
+		4D08149726DD9123001BF800 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126526DD9120001BF800 /* yuv_sse2.c */; };
+		4D08149826DD9123001BF800 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126526DD9120001BF800 /* yuv_sse2.c */; };
+		4D08149926DD9123001BF800 /* filters_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126626DD9120001BF800 /* filters_msa.c */; };
+		4D08149A26DD9123001BF800 /* filters_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126626DD9120001BF800 /* filters_msa.c */; };
+		4D08149B26DD9123001BF800 /* filters_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126626DD9120001BF800 /* filters_msa.c */; };
+		4D08149C26DD9123001BF800 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126726DD9120001BF800 /* mips_macro.h */; };
+		4D08149D26DD9123001BF800 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126726DD9120001BF800 /* mips_macro.h */; };
+		4D08149E26DD9123001BF800 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08126726DD9120001BF800 /* mips_macro.h */; };
+		4D08149F26DD9123001BF800 /* rescaler_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126826DD9120001BF800 /* rescaler_msa.c */; };
+		4D0814A026DD9123001BF800 /* rescaler_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126826DD9120001BF800 /* rescaler_msa.c */; };
+		4D0814A126DD9123001BF800 /* rescaler_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126826DD9120001BF800 /* rescaler_msa.c */; };
+		4D0814A226DD9123001BF800 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126926DD9120001BF800 /* lossless_neon.c */; };
+		4D0814A326DD9123001BF800 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126926DD9120001BF800 /* lossless_neon.c */; };
+		4D0814A426DD9123001BF800 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126926DD9120001BF800 /* lossless_neon.c */; };
+		4D0814A526DD9123001BF800 /* lossless_enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126A26DD9120001BF800 /* lossless_enc_msa.c */; };
+		4D0814A626DD9123001BF800 /* lossless_enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126A26DD9120001BF800 /* lossless_enc_msa.c */; };
+		4D0814A726DD9123001BF800 /* lossless_enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126A26DD9120001BF800 /* lossless_enc_msa.c */; };
+		4D0814A826DD9123001BF800 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126B26DD9120001BF800 /* filters.c */; };
+		4D0814A926DD9123001BF800 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126B26DD9120001BF800 /* filters.c */; };
+		4D0814AA26DD9123001BF800 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126B26DD9120001BF800 /* filters.c */; };
+		4D0814AB26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126C26DD9120001BF800 /* alpha_processing_mips_dsp_r2.c */; };
+		4D0814AC26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126C26DD9120001BF800 /* alpha_processing_mips_dsp_r2.c */; };
+		4D0814AD26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126C26DD9120001BF800 /* alpha_processing_mips_dsp_r2.c */; };
+		4D0814AE26DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126D26DD9120001BF800 /* rescaler_mips_dsp_r2.c */; };
+		4D0814AF26DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126D26DD9120001BF800 /* rescaler_mips_dsp_r2.c */; };
+		4D0814B026DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126D26DD9120001BF800 /* rescaler_mips_dsp_r2.c */; };
+		4D0814B126DD9123001BF800 /* ssim_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126E26DD9120001BF800 /* ssim_sse2.c */; };
+		4D0814B226DD9123001BF800 /* ssim_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126E26DD9120001BF800 /* ssim_sse2.c */; };
+		4D0814B326DD9123001BF800 /* ssim_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126E26DD9120001BF800 /* ssim_sse2.c */; };
+		4D0814B426DD9123001BF800 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126F26DD9120001BF800 /* rescaler_mips32.c */; };
+		4D0814B526DD9123001BF800 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126F26DD9120001BF800 /* rescaler_mips32.c */; };
+		4D0814B626DD9123001BF800 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08126F26DD9120001BF800 /* rescaler_mips32.c */; };
+		4D0814B726DD9123001BF800 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127026DD9120001BF800 /* dec_sse41.c */; };
+		4D0814B826DD9123001BF800 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127026DD9120001BF800 /* dec_sse41.c */; };
+		4D0814B926DD9123001BF800 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127026DD9120001BF800 /* dec_sse41.c */; };
+		4D0814BA26DD9123001BF800 /* lossless_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127126DD9120001BF800 /* lossless_sse41.c */; };
+		4D0814BB26DD9123001BF800 /* lossless_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127126DD9120001BF800 /* lossless_sse41.c */; };
+		4D0814BC26DD9123001BF800 /* lossless_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127126DD9120001BF800 /* lossless_sse41.c */; };
+		4D0814BD26DD9123001BF800 /* yuv_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127226DD9120001BF800 /* yuv_sse41.c */; };
+		4D0814BE26DD9123001BF800 /* yuv_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127226DD9120001BF800 /* yuv_sse41.c */; };
+		4D0814BF26DD9123001BF800 /* yuv_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127226DD9120001BF800 /* yuv_sse41.c */; };
+		4D0814C026DD9123001BF800 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127326DD9120001BF800 /* rescaler_sse2.c */; };
+		4D0814C126DD9123001BF800 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127326DD9120001BF800 /* rescaler_sse2.c */; };
+		4D0814C226DD9123001BF800 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127326DD9120001BF800 /* rescaler_sse2.c */; };
+		4D0814C326DD9123001BF800 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127526DD9120001BF800 /* lossless_enc.c */; };
+		4D0814C426DD9123001BF800 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127526DD9120001BF800 /* lossless_enc.c */; };
+		4D0814C526DD9123001BF800 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127526DD9120001BF800 /* lossless_enc.c */; };
+		4D0814C626DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127626DD9120001BF800 /* yuv_mips_dsp_r2.c */; };
+		4D0814C726DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127626DD9120001BF800 /* yuv_mips_dsp_r2.c */; };
+		4D0814C826DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127626DD9120001BF800 /* yuv_mips_dsp_r2.c */; };
+		4D0814C926DD9123001BF800 /* alpha_processing_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127726DD9120001BF800 /* alpha_processing_neon.c */; };
+		4D0814CA26DD9123001BF800 /* alpha_processing_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127726DD9120001BF800 /* alpha_processing_neon.c */; };
+		4D0814CB26DD9123001BF800 /* alpha_processing_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127726DD9120001BF800 /* alpha_processing_neon.c */; };
+		4D0814CC26DD9123001BF800 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127826DD9120001BF800 /* dec.c */; };
+		4D0814CD26DD9123001BF800 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127826DD9120001BF800 /* dec.c */; };
+		4D0814CE26DD9123001BF800 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127826DD9120001BF800 /* dec.c */; };
+		4D0814CF26DD9123001BF800 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127926DD9120001BF800 /* lossless.c */; };
+		4D0814D026DD9123001BF800 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127926DD9120001BF800 /* lossless.c */; };
+		4D0814D126DD9123001BF800 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127926DD9120001BF800 /* lossless.c */; };
+		4D0814D226DD9123001BF800 /* ssim.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127A26DD9120001BF800 /* ssim.c */; };
+		4D0814D326DD9123001BF800 /* ssim.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127A26DD9120001BF800 /* ssim.c */; };
+		4D0814D426DD9123001BF800 /* ssim.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127A26DD9120001BF800 /* ssim.c */; };
+		4D0814D526DD9123001BF800 /* upsampling_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127B26DD9120001BF800 /* upsampling_msa.c */; };
+		4D0814D626DD9123001BF800 /* upsampling_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127B26DD9120001BF800 /* upsampling_msa.c */; };
+		4D0814D726DD9123001BF800 /* upsampling_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127B26DD9120001BF800 /* upsampling_msa.c */; };
+		4D0814D826DD9123001BF800 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127C26DD9120001BF800 /* lossless_enc_sse2.c */; };
+		4D0814D926DD9123001BF800 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127C26DD9120001BF800 /* lossless_enc_sse2.c */; };
+		4D0814DA26DD9123001BF800 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127C26DD9120001BF800 /* lossless_enc_sse2.c */; };
+		4D0814DB26DD9123001BF800 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127D26DD9120001BF800 /* yuv.c */; };
+		4D0814DC26DD9123001BF800 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127D26DD9120001BF800 /* yuv.c */; };
+		4D0814DD26DD9123001BF800 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127D26DD9120001BF800 /* yuv.c */; };
+		4D0814DE26DD9123001BF800 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127E26DD9120001BF800 /* enc_neon.c */; };
+		4D0814DF26DD9123001BF800 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127E26DD9120001BF800 /* enc_neon.c */; };
+		4D0814E026DD9123001BF800 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127E26DD9120001BF800 /* enc_neon.c */; };
+		4D0814E126DD9123001BF800 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127F26DD9120001BF800 /* dec_sse2.c */; };
+		4D0814E226DD9123001BF800 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127F26DD9120001BF800 /* dec_sse2.c */; };
+		4D0814E326DD9123001BF800 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08127F26DD9120001BF800 /* dec_sse2.c */; };
+		4D0814E426DD9123001BF800 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128026DD9120001BF800 /* dsp.h */; };
+		4D0814E526DD9123001BF800 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128026DD9120001BF800 /* dsp.h */; };
+		4D0814E626DD9123001BF800 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128026DD9120001BF800 /* dsp.h */; };
+		4D0814E726DD9123001BF800 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128126DD9120001BF800 /* enc_sse2.c */; };
+		4D0814E826DD9123001BF800 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128126DD9120001BF800 /* enc_sse2.c */; };
+		4D0814E926DD9123001BF800 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128126DD9120001BF800 /* enc_sse2.c */; };
+		4D0814EA26DD9123001BF800 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128226DD9120001BF800 /* lossless_enc_neon.c */; };
+		4D0814EB26DD9123001BF800 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128226DD9120001BF800 /* lossless_enc_neon.c */; };
+		4D0814EC26DD9124001BF800 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128226DD9120001BF800 /* lossless_enc_neon.c */; };
+		4D0814ED26DD9124001BF800 /* lossless_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128326DD9120001BF800 /* lossless_common.h */; };
+		4D0814EE26DD9124001BF800 /* lossless_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128326DD9120001BF800 /* lossless_common.h */; };
+		4D0814EF26DD9124001BF800 /* lossless_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128326DD9120001BF800 /* lossless_common.h */; };
+		4D0814F026DD9124001BF800 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128426DD9120001BF800 /* cost_mips32.c */; };
+		4D0814F126DD9124001BF800 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128426DD9120001BF800 /* cost_mips32.c */; };
+		4D0814F226DD9124001BF800 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128426DD9120001BF800 /* cost_mips32.c */; };
+		4D0814F326DD9124001BF800 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128526DD9120001BF800 /* alpha_processing_sse41.c */; };
+		4D0814F426DD9124001BF800 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128526DD9120001BF800 /* alpha_processing_sse41.c */; };
+		4D0814F526DD9124001BF800 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128526DD9120001BF800 /* alpha_processing_sse41.c */; };
+		4D0814F626DD9124001BF800 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128626DD9120001BF800 /* dec_neon.c */; };
+		4D0814F726DD9124001BF800 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128626DD9120001BF800 /* dec_neon.c */; };
+		4D0814F826DD9124001BF800 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128626DD9120001BF800 /* dec_neon.c */; };
+		4D0814F926DD9124001BF800 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128726DD9120001BF800 /* cost.c */; };
+		4D0814FA26DD9124001BF800 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128726DD9120001BF800 /* cost.c */; };
+		4D0814FB26DD9124001BF800 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128726DD9120001BF800 /* cost.c */; };
+		4D0814FC26DD9124001BF800 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128826DD9120001BF800 /* dec_mips32.c */; };
+		4D0814FD26DD9124001BF800 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128826DD9120001BF800 /* dec_mips32.c */; };
+		4D0814FE26DD9124001BF800 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128826DD9120001BF800 /* dec_mips32.c */; };
+		4D0814FF26DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128926DD9120001BF800 /* cost_mips_dsp_r2.c */; };
+		4D08150026DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128926DD9120001BF800 /* cost_mips_dsp_r2.c */; };
+		4D08150126DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128926DD9120001BF800 /* cost_mips_dsp_r2.c */; };
+		4D08150226DD9124001BF800 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128A26DD9120001BF800 /* alpha_processing_sse2.c */; };
+		4D08150326DD9124001BF800 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128A26DD9120001BF800 /* alpha_processing_sse2.c */; };
+		4D08150426DD9124001BF800 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128A26DD9120001BF800 /* alpha_processing_sse2.c */; };
+		4D08150526DD9124001BF800 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128B26DD9120001BF800 /* dec_clip_tables.c */; };
+		4D08150626DD9124001BF800 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128B26DD9120001BF800 /* dec_clip_tables.c */; };
+		4D08150726DD9124001BF800 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128B26DD9120001BF800 /* dec_clip_tables.c */; };
+		4D08150826DD9124001BF800 /* lossless_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128C26DD9120001BF800 /* lossless_msa.c */; };
+		4D08150926DD9124001BF800 /* lossless_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128C26DD9120001BF800 /* lossless_msa.c */; };
+		4D08150A26DD9124001BF800 /* lossless_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128C26DD9120001BF800 /* lossless_msa.c */; };
+		4D08150B26DD9124001BF800 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128D26DD9120001BF800 /* enc.c */; };
+		4D08150C26DD9124001BF800 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128D26DD9120001BF800 /* enc.c */; };
+		4D08150D26DD9124001BF800 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128D26DD9120001BF800 /* enc.c */; };
+		4D08150E26DD9124001BF800 /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128E26DD9120001BF800 /* common_sse2.h */; };
+		4D08150F26DD9124001BF800 /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128E26DD9120001BF800 /* common_sse2.h */; };
+		4D08151026DD9124001BF800 /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08128E26DD9120001BF800 /* common_sse2.h */; };
+		4D08151126DD9124001BF800 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128F26DD9120001BF800 /* lossless_enc_mips32.c */; };
+		4D08151226DD9124001BF800 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128F26DD9120001BF800 /* lossless_enc_mips32.c */; };
+		4D08151326DD9124001BF800 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08128F26DD9120001BF800 /* lossless_enc_mips32.c */; };
+		4D08151426DD9124001BF800 /* common_sse41.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08129026DD9120001BF800 /* common_sse41.h */; };
+		4D08151526DD9124001BF800 /* common_sse41.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08129026DD9120001BF800 /* common_sse41.h */; };
+		4D08151626DD9124001BF800 /* common_sse41.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D08129026DD9120001BF800 /* common_sse41.h */; };
+		4D08151726DD9124001BF800 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129126DD9120001BF800 /* yuv_mips32.c */; };
+		4D08151826DD9124001BF800 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129126DD9120001BF800 /* yuv_mips32.c */; };
+		4D08151926DD9124001BF800 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129126DD9120001BF800 /* yuv_mips32.c */; };
+		4D08151A26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129226DD9120001BF800 /* upsampling_mips_dsp_r2.c */; };
+		4D08151B26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129226DD9120001BF800 /* upsampling_mips_dsp_r2.c */; };
+		4D08151C26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129226DD9120001BF800 /* upsampling_mips_dsp_r2.c */; };
+		4D08151D26DD9124001BF800 /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129326DD9120001BF800 /* dec_msa.c */; };
+		4D08151E26DD9124001BF800 /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129326DD9120001BF800 /* dec_msa.c */; };
+		4D08151F26DD9124001BF800 /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D08129326DD9120001BF800 /* dec_msa.c */; };
 		4D4973461872370F00D46882 /* MOAIEase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4973441872370F00D46882 /* MOAIEase.cpp */; };
 		4D4973471872370F00D46882 /* MOAIEase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4973451872370F00D46882 /* MOAIEase.h */; };
 		4D49734A187258FA00D46882 /* MOAIEaseLinear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D497348187258FA00D46882 /* MOAIEaseLinear.cpp */; };
@@ -786,6 +1263,9 @@
 		4D851DAA1873E760009DF1C4 /* MOAIEaseElasticIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D851DA71873E760009DF1C4 /* MOAIEaseElasticIn.cpp */; };
 		4D851DAB1873E760009DF1C4 /* MOAIEaseElasticIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851DA81873E760009DF1C4 /* MOAIEaseElasticIn.h */; };
 		4D851DAC1873E760009DF1C4 /* MOAIEaseElasticIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D851DA81873E760009DF1C4 /* MOAIEaseElasticIn.h */; };
+		4DB1D11A26D736530034597F /* MOAIImage-webp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB1D11926D736530034597F /* MOAIImage-webp.cpp */; };
+		4DB1D11B26D736530034597F /* MOAIImage-webp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB1D11926D736530034597F /* MOAIImage-webp.cpp */; };
+		4DB1D11C26D736530034597F /* MOAIImage-webp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB1D11926D736530034597F /* MOAIImage-webp.cpp */; };
 		579E367318CF8EEF00A3CE47 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 579E367018CF8EEF00A3CE47 /* sqlite3.c */; };
 		579E367418CF8EEF00A3CE47 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 579E367018CF8EEF00A3CE47 /* sqlite3.c */; };
 		579E367518CF8EEF00A3CE47 /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 579E367118CF8EEF00A3CE47 /* sqlite3.h */; };
@@ -3604,6 +4084,180 @@
 		07F59343143E318B00C6D185 /* MOAIUntzSampleBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MOAIUntzSampleBuffer.h; path = "moaiext-untz/MOAIUntzSampleBuffer.h"; sourceTree = "<group>"; };
 		07FAC91513B8F1CA00AFD0B3 /* moaicore-pch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "moaicore-pch.cpp"; sourceTree = "<group>"; };
 		07FAC91713B8F1E000AFD0B3 /* uslscore-pch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "uslscore-pch.cpp"; sourceTree = "<group>"; };
+		4D0811E026DD9120001BF800 /* muxread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = muxread.c; sourceTree = "<group>"; };
+		4D0811E126DD9120001BF800 /* muxinternal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = muxinternal.c; sourceTree = "<group>"; };
+		4D0811E226DD9120001BF800 /* libwebpmux.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpmux.rc; sourceTree = "<group>"; };
+		4D0811E326DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D0811E426DD9120001BF800 /* anim_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = anim_encode.c; sourceTree = "<group>"; };
+		4D0811E526DD9120001BF800 /* animi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = animi.h; sourceTree = "<group>"; };
+		4D0811E626DD9120001BF800 /* libwebpmux.pc.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpmux.pc.in; sourceTree = "<group>"; };
+		4D0811E726DD9120001BF800 /* muxedit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = muxedit.c; sourceTree = "<group>"; };
+		4D0811E826DD9120001BF800 /* muxi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = muxi.h; sourceTree = "<group>"; };
+		4D0811E926DD9120001BF800 /* libwebp.pc.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebp.pc.in; sourceTree = "<group>"; };
+		4D0811EA26DD9120001BF800 /* libwebpdecoder.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpdecoder.rc; sourceTree = "<group>"; };
+		4D0811EB26DD9120001BF800 /* libwebpdecoder.pc.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpdecoder.pc.in; sourceTree = "<group>"; };
+		4D0811ED26DD9120001BF800 /* bit_writer_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bit_writer_utils.c; sourceTree = "<group>"; };
+		4D0811EE26DD9120001BF800 /* endian_inl_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endian_inl_utils.h; sourceTree = "<group>"; };
+		4D0811EF26DD9120001BF800 /* thread_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread_utils.c; sourceTree = "<group>"; };
+		4D0811F026DD9120001BF800 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		4D0811F126DD9120001BF800 /* bit_reader_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader_utils.h; sourceTree = "<group>"; };
+		4D0811F226DD9120001BF800 /* bit_reader_inl_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader_inl_utils.h; sourceTree = "<group>"; };
+		4D0811F326DD9120001BF800 /* rescaler_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_utils.c; sourceTree = "<group>"; };
+		4D0811F426DD9120001BF800 /* quant_levels_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_levels_utils.h; sourceTree = "<group>"; };
+		4D0811F526DD9120001BF800 /* quant_levels_dec_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_levels_dec_utils.h; sourceTree = "<group>"; };
+		4D0811F626DD9120001BF800 /* huffman_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = huffman_utils.c; sourceTree = "<group>"; };
+		4D0811F726DD9120001BF800 /* color_cache_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = color_cache_utils.h; sourceTree = "<group>"; };
+		4D0811F826DD9120001BF800 /* filters_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filters_utils.h; sourceTree = "<group>"; };
+		4D0811F926DD9120001BF800 /* huffman_encode_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = huffman_encode_utils.c; sourceTree = "<group>"; };
+		4D0811FA26DD9120001BF800 /* random_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = random_utils.h; sourceTree = "<group>"; };
+		4D0811FB26DD9120001BF800 /* rescaler_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rescaler_utils.h; sourceTree = "<group>"; };
+		4D0811FC26DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D0811FD26DD9120001BF800 /* quant_levels_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_levels_utils.c; sourceTree = "<group>"; };
+		4D0811FE26DD9120001BF800 /* quant_levels_dec_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_levels_dec_utils.c; sourceTree = "<group>"; };
+		4D0811FF26DD9120001BF800 /* bit_reader_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bit_reader_utils.c; sourceTree = "<group>"; };
+		4D08120026DD9120001BF800 /* thread_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_utils.h; sourceTree = "<group>"; };
+		4D08120126DD9120001BF800 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
+		4D08120226DD9120001BF800 /* bit_writer_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_writer_utils.h; sourceTree = "<group>"; };
+		4D08120326DD9120001BF800 /* huffman_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman_utils.h; sourceTree = "<group>"; };
+		4D08120426DD9120001BF800 /* huffman_encode_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman_encode_utils.h; sourceTree = "<group>"; };
+		4D08120526DD9120001BF800 /* color_cache_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = color_cache_utils.c; sourceTree = "<group>"; };
+		4D08120626DD9120001BF800 /* filters_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_utils.c; sourceTree = "<group>"; };
+		4D08120726DD9120001BF800 /* random_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = random_utils.c; sourceTree = "<group>"; };
+		4D08120926DD9120001BF800 /* format_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = format_constants.h; sourceTree = "<group>"; };
+		4D08120A26DD9120001BF800 /* mux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mux.h; sourceTree = "<group>"; };
+		4D08120B26DD9120001BF800 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		4D08120C26DD9120001BF800 /* demux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = demux.h; sourceTree = "<group>"; };
+		4D08120D26DD9120001BF800 /* mux_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mux_types.h; sourceTree = "<group>"; };
+		4D08120E26DD9120001BF800 /* encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode.h; sourceTree = "<group>"; };
+		4D08120F26DD9120001BF800 /* decode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decode.h; sourceTree = "<group>"; };
+		4D08121026DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D08121226DD9120001BF800 /* iterator_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = iterator_enc.c; sourceTree = "<group>"; };
+		4D08121326DD9120001BF800 /* backward_references_enc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backward_references_enc.h; sourceTree = "<group>"; };
+		4D08121426DD9120001BF800 /* cost_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_enc.c; sourceTree = "<group>"; };
+		4D08121526DD9120001BF800 /* alpha_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_enc.c; sourceTree = "<group>"; };
+		4D08121626DD9120001BF800 /* histogram_enc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = histogram_enc.h; sourceTree = "<group>"; };
+		4D08121726DD9120001BF800 /* picture_psnr_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picture_psnr_enc.c; sourceTree = "<group>"; };
+		4D08121826DD9120001BF800 /* token_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = token_enc.c; sourceTree = "<group>"; };
+		4D08121926DD9120001BF800 /* vp8i_enc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8i_enc.h; sourceTree = "<group>"; };
+		4D08121A26DD9120001BF800 /* tree_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tree_enc.c; sourceTree = "<group>"; };
+		4D08121B26DD9120001BF800 /* filter_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_enc.c; sourceTree = "<group>"; };
+		4D08121C26DD9120001BF800 /* picture_csp_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picture_csp_enc.c; sourceTree = "<group>"; };
+		4D08121D26DD9120001BF800 /* frame_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame_enc.c; sourceTree = "<group>"; };
+		4D08121E26DD9120001BF800 /* syntax_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = syntax_enc.c; sourceTree = "<group>"; };
+		4D08121F26DD9120001BF800 /* cost_enc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cost_enc.h; sourceTree = "<group>"; };
+		4D08122026DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D08122126DD9120001BF800 /* predictor_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = predictor_enc.c; sourceTree = "<group>"; };
+		4D08122226DD9120001BF800 /* config_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = config_enc.c; sourceTree = "<group>"; };
+		4D08122326DD9120001BF800 /* backward_references_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = backward_references_enc.c; sourceTree = "<group>"; };
+		4D08122426DD9120001BF800 /* picture_tools_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picture_tools_enc.c; sourceTree = "<group>"; };
+		4D08122526DD9120001BF800 /* webp_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webp_enc.c; sourceTree = "<group>"; };
+		4D08122626DD9120001BF800 /* vp8l_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8l_enc.c; sourceTree = "<group>"; };
+		4D08122726DD9120001BF800 /* histogram_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = histogram_enc.c; sourceTree = "<group>"; };
+		4D08122826DD9120001BF800 /* analysis_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = analysis_enc.c; sourceTree = "<group>"; };
+		4D08122926DD9120001BF800 /* vp8li_enc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8li_enc.h; sourceTree = "<group>"; };
+		4D08122A26DD9120001BF800 /* quant_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_enc.c; sourceTree = "<group>"; };
+		4D08122B26DD9120001BF800 /* near_lossless_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = near_lossless_enc.c; sourceTree = "<group>"; };
+		4D08122C26DD9120001BF800 /* picture_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picture_enc.c; sourceTree = "<group>"; };
+		4D08122D26DD9120001BF800 /* backward_references_cost_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = backward_references_cost_enc.c; sourceTree = "<group>"; };
+		4D08122E26DD9120001BF800 /* picture_rescale_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = picture_rescale_enc.c; sourceTree = "<group>"; };
+		4D08123026DD9120001BF800 /* demux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux.c; sourceTree = "<group>"; };
+		4D08123126DD9120001BF800 /* libwebpdemux.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpdemux.rc; sourceTree = "<group>"; };
+		4D08123226DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D08123326DD9120001BF800 /* anim_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = anim_decode.c; sourceTree = "<group>"; };
+		4D08123426DD9120001BF800 /* libwebpdemux.pc.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebpdemux.pc.in; sourceTree = "<group>"; };
+		4D08123526DD9120001BF800 /* libwebp.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libwebp.rc; sourceTree = "<group>"; };
+		4D08123726DD9120001BF800 /* io_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = io_dec.c; sourceTree = "<group>"; };
+		4D08123826DD9120001BF800 /* frame_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame_dec.c; sourceTree = "<group>"; };
+		4D08123926DD9120001BF800 /* tree_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tree_dec.c; sourceTree = "<group>"; };
+		4D08123A26DD9120001BF800 /* vp8i_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8i_dec.h; sourceTree = "<group>"; };
+		4D08123B26DD9120001BF800 /* vp8_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_dec.h; sourceTree = "<group>"; };
+		4D08123C26DD9120001BF800 /* alpha_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_dec.c; sourceTree = "<group>"; };
+		4D08123D26DD9120001BF800 /* common_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_dec.h; sourceTree = "<group>"; };
+		4D08123E26DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D08123F26DD9120001BF800 /* buffer_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = buffer_dec.c; sourceTree = "<group>"; };
+		4D08124026DD9120001BF800 /* quant_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_dec.c; sourceTree = "<group>"; };
+		4D08124126DD9120001BF800 /* vp8li_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8li_dec.h; sourceTree = "<group>"; };
+		4D08124226DD9120001BF800 /* idec_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = idec_dec.c; sourceTree = "<group>"; };
+		4D08124326DD9120001BF800 /* webp_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webp_dec.c; sourceTree = "<group>"; };
+		4D08124426DD9120001BF800 /* vp8l_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8l_dec.c; sourceTree = "<group>"; };
+		4D08124526DD9120001BF800 /* alphai_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alphai_dec.h; sourceTree = "<group>"; };
+		4D08124626DD9120001BF800 /* vp8_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8_dec.c; sourceTree = "<group>"; };
+		4D08124726DD9120001BF800 /* webpi_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webpi_dec.h; sourceTree = "<group>"; };
+		4D08124926DD9120001BF800 /* upsampling.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling.c; sourceTree = "<group>"; };
+		4D08124A26DD9120001BF800 /* lossless_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_sse2.c; sourceTree = "<group>"; };
+		4D08124B26DD9120001BF800 /* lossless.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lossless.h; sourceTree = "<group>"; };
+		4D08124C26DD9120001BF800 /* lossless_enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08124D26DD9120001BF800 /* enc_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_msa.c; sourceTree = "<group>"; };
+		4D08124E26DD9120001BF800 /* msa_macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = msa_macro.h; sourceTree = "<group>"; };
+		4D08124F26DD9120001BF800 /* neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neon.h; sourceTree = "<group>"; };
+		4D08125026DD9120001BF800 /* filters_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08125126DD9120001BF800 /* rescaler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler.c; sourceTree = "<group>"; };
+		4D08125226DD9120001BF800 /* dec_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08125326DD9120001BF800 /* rescaler_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_neon.c; sourceTree = "<group>"; };
+		4D08125426DD9120001BF800 /* cost_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_sse2.c; sourceTree = "<group>"; };
+		4D08125526DD9120001BF800 /* upsampling_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_sse41.c; sourceTree = "<group>"; };
+		4D08125626DD9120001BF800 /* enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_sse41.c; sourceTree = "<group>"; };
+		4D08125726DD9120001BF800 /* lossless_enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_sse41.c; sourceTree = "<group>"; };
+		4D08125826DD9120001BF800 /* upsampling_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_neon.c; sourceTree = "<group>"; };
+		4D08125926DD9120001BF800 /* filters_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_sse2.c; sourceTree = "<group>"; };
+		4D08125A26DD9120001BF800 /* lossless_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08125B26DD9120001BF800 /* enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08125C26DD9120001BF800 /* cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cpu.c; sourceTree = "<group>"; };
+		4D08125D26DD9120001BF800 /* yuv_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_neon.c; sourceTree = "<group>"; };
+		4D08125E26DD9120001BF800 /* alpha_processing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing.c; sourceTree = "<group>"; };
+		4D08125F26DD9120001BF800 /* yuv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yuv.h; sourceTree = "<group>"; };
+		4D08126026DD9120001BF800 /* quant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant.h; sourceTree = "<group>"; };
+		4D08126126DD9120001BF800 /* cost_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_neon.c; sourceTree = "<group>"; };
+		4D08126226DD9120001BF800 /* enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_mips32.c; sourceTree = "<group>"; };
+		4D08126326DD9120001BF800 /* filters_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_neon.c; sourceTree = "<group>"; };
+		4D08126426DD9120001BF800 /* upsampling_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_sse2.c; sourceTree = "<group>"; };
+		4D08126526DD9120001BF800 /* yuv_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_sse2.c; sourceTree = "<group>"; };
+		4D08126626DD9120001BF800 /* filters_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_msa.c; sourceTree = "<group>"; };
+		4D08126726DD9120001BF800 /* mips_macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mips_macro.h; sourceTree = "<group>"; };
+		4D08126826DD9120001BF800 /* rescaler_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_msa.c; sourceTree = "<group>"; };
+		4D08126926DD9120001BF800 /* lossless_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_neon.c; sourceTree = "<group>"; };
+		4D08126A26DD9120001BF800 /* lossless_enc_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_msa.c; sourceTree = "<group>"; };
+		4D08126B26DD9120001BF800 /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters.c; sourceTree = "<group>"; };
+		4D08126C26DD9120001BF800 /* alpha_processing_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08126D26DD9120001BF800 /* rescaler_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08126E26DD9120001BF800 /* ssim_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssim_sse2.c; sourceTree = "<group>"; };
+		4D08126F26DD9120001BF800 /* rescaler_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_mips32.c; sourceTree = "<group>"; };
+		4D08127026DD9120001BF800 /* dec_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_sse41.c; sourceTree = "<group>"; };
+		4D08127126DD9120001BF800 /* lossless_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_sse41.c; sourceTree = "<group>"; };
+		4D08127226DD9120001BF800 /* yuv_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_sse41.c; sourceTree = "<group>"; };
+		4D08127326DD9120001BF800 /* rescaler_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_sse2.c; sourceTree = "<group>"; };
+		4D08127426DD9120001BF800 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		4D08127526DD9120001BF800 /* lossless_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc.c; sourceTree = "<group>"; };
+		4D08127626DD9120001BF800 /* yuv_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08127726DD9120001BF800 /* alpha_processing_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_neon.c; sourceTree = "<group>"; };
+		4D08127826DD9120001BF800 /* dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec.c; sourceTree = "<group>"; };
+		4D08127926DD9120001BF800 /* lossless.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless.c; sourceTree = "<group>"; };
+		4D08127A26DD9120001BF800 /* ssim.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssim.c; sourceTree = "<group>"; };
+		4D08127B26DD9120001BF800 /* upsampling_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_msa.c; sourceTree = "<group>"; };
+		4D08127C26DD9120001BF800 /* lossless_enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_sse2.c; sourceTree = "<group>"; };
+		4D08127D26DD9120001BF800 /* yuv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv.c; sourceTree = "<group>"; };
+		4D08127E26DD9120001BF800 /* enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_neon.c; sourceTree = "<group>"; };
+		4D08127F26DD9120001BF800 /* dec_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_sse2.c; sourceTree = "<group>"; };
+		4D08128026DD9120001BF800 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dsp.h; sourceTree = "<group>"; };
+		4D08128126DD9120001BF800 /* enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_sse2.c; sourceTree = "<group>"; };
+		4D08128226DD9120001BF800 /* lossless_enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_neon.c; sourceTree = "<group>"; };
+		4D08128326DD9120001BF800 /* lossless_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lossless_common.h; sourceTree = "<group>"; };
+		4D08128426DD9120001BF800 /* cost_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_mips32.c; sourceTree = "<group>"; };
+		4D08128526DD9120001BF800 /* alpha_processing_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_sse41.c; sourceTree = "<group>"; };
+		4D08128626DD9120001BF800 /* dec_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_neon.c; sourceTree = "<group>"; };
+		4D08128726DD9120001BF800 /* cost.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost.c; sourceTree = "<group>"; };
+		4D08128826DD9120001BF800 /* dec_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_mips32.c; sourceTree = "<group>"; };
+		4D08128926DD9120001BF800 /* cost_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08128A26DD9120001BF800 /* alpha_processing_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_sse2.c; sourceTree = "<group>"; };
+		4D08128B26DD9120001BF800 /* dec_clip_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_clip_tables.c; sourceTree = "<group>"; };
+		4D08128C26DD9120001BF800 /* lossless_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_msa.c; sourceTree = "<group>"; };
+		4D08128D26DD9120001BF800 /* enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc.c; sourceTree = "<group>"; };
+		4D08128E26DD9120001BF800 /* common_sse2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_sse2.h; sourceTree = "<group>"; };
+		4D08128F26DD9120001BF800 /* lossless_enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_mips32.c; sourceTree = "<group>"; };
+		4D08129026DD9120001BF800 /* common_sse41.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_sse41.h; sourceTree = "<group>"; };
+		4D08129126DD9120001BF800 /* yuv_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_mips32.c; sourceTree = "<group>"; };
+		4D08129226DD9120001BF800 /* upsampling_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_mips_dsp_r2.c; sourceTree = "<group>"; };
+		4D08129326DD9120001BF800 /* dec_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_msa.c; sourceTree = "<group>"; };
 		4D4973441872370F00D46882 /* MOAIEase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIEase.cpp; sourceTree = "<group>"; };
 		4D4973451872370F00D46882 /* MOAIEase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIEase.h; sourceTree = "<group>"; };
 		4D497348187258FA00D46882 /* MOAIEaseLinear.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIEaseLinear.cpp; sourceTree = "<group>"; };
@@ -3630,6 +4284,7 @@
 		4D851DA21873E5ED009DF1C4 /* MOAIEaseElasticBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIEaseElasticBase.h; sourceTree = "<group>"; };
 		4D851DA71873E760009DF1C4 /* MOAIEaseElasticIn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIEaseElasticIn.cpp; sourceTree = "<group>"; };
 		4D851DA81873E760009DF1C4 /* MOAIEaseElasticIn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIEaseElasticIn.h; sourceTree = "<group>"; };
+		4DB1D11926D736530034597F /* MOAIImage-webp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "MOAIImage-webp.cpp"; sourceTree = "<group>"; };
 		5751E6CC18565F8B00775234 /* base-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "base-debug.xcconfig"; path = "../configs/base-debug.xcconfig"; sourceTree = "<group>"; };
 		5751E6CD18565F8B00775234 /* base-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "base-release.xcconfig"; path = "../configs/base-release.xcconfig"; sourceTree = "<group>"; };
 		5751E6CE18565F8B00775234 /* libmoai-ios-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "libmoai-ios-debug.xcconfig"; path = "../configs/libmoai-ios-debug.xcconfig"; sourceTree = "<group>"; };
@@ -4467,6 +5122,7 @@
 		032409EE13564CAF000ADC60 /* 3rd party */ = {
 			isa = PBXGroup;
 			children = (
+				4D08115926DD9120001BF800 /* libwebp */,
 				F055A9471846ABC30031F295 /* openssl */,
 				DD80D69816D8027A00C172D2 /* sfmt */,
 				0725E2EB14F45AC700551DB5 /* adcolony */,
@@ -5075,6 +5731,252 @@
 			sourceTree = "<group>";
 			usesTabs = 1;
 		};
+		4D08115926DD9120001BF800 /* libwebp */ = {
+			isa = PBXGroup;
+			children = (
+				4D0811DE26DD9120001BF800 /* src */,
+			);
+			name = libwebp;
+			path = ../../3rdparty/libwebp;
+			sourceTree = "<group>";
+		};
+		4D0811DE26DD9120001BF800 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				4D08123626DD9120001BF800 /* dec */,
+				4D08122F26DD9120001BF800 /* demux */,
+				4D08124826DD9120001BF800 /* dsp */,
+				4D08121126DD9120001BF800 /* enc */,
+				4D0811E926DD9120001BF800 /* libwebp.pc.in */,
+				4D08123526DD9120001BF800 /* libwebp.rc */,
+				4D0811EB26DD9120001BF800 /* libwebpdecoder.pc.in */,
+				4D0811EA26DD9120001BF800 /* libwebpdecoder.rc */,
+				4D08121026DD9120001BF800 /* Makefile.am */,
+				4D0811DF26DD9120001BF800 /* mux */,
+				4D0811EC26DD9120001BF800 /* utils */,
+				4D08120826DD9120001BF800 /* webp */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		4D0811DF26DD9120001BF800 /* mux */ = {
+			isa = PBXGroup;
+			children = (
+				4D0811E426DD9120001BF800 /* anim_encode.c */,
+				4D0811E526DD9120001BF800 /* animi.h */,
+				4D0811E626DD9120001BF800 /* libwebpmux.pc.in */,
+				4D0811E226DD9120001BF800 /* libwebpmux.rc */,
+				4D0811E326DD9120001BF800 /* Makefile.am */,
+				4D0811E726DD9120001BF800 /* muxedit.c */,
+				4D0811E826DD9120001BF800 /* muxi.h */,
+				4D0811E126DD9120001BF800 /* muxinternal.c */,
+				4D0811E026DD9120001BF800 /* muxread.c */,
+			);
+			path = mux;
+			sourceTree = "<group>";
+		};
+		4D0811EC26DD9120001BF800 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				4D0811F226DD9120001BF800 /* bit_reader_inl_utils.h */,
+				4D0811FF26DD9120001BF800 /* bit_reader_utils.c */,
+				4D0811F126DD9120001BF800 /* bit_reader_utils.h */,
+				4D0811ED26DD9120001BF800 /* bit_writer_utils.c */,
+				4D08120226DD9120001BF800 /* bit_writer_utils.h */,
+				4D08120526DD9120001BF800 /* color_cache_utils.c */,
+				4D0811F726DD9120001BF800 /* color_cache_utils.h */,
+				4D0811EE26DD9120001BF800 /* endian_inl_utils.h */,
+				4D08120626DD9120001BF800 /* filters_utils.c */,
+				4D0811F826DD9120001BF800 /* filters_utils.h */,
+				4D0811F926DD9120001BF800 /* huffman_encode_utils.c */,
+				4D08120426DD9120001BF800 /* huffman_encode_utils.h */,
+				4D0811F626DD9120001BF800 /* huffman_utils.c */,
+				4D08120326DD9120001BF800 /* huffman_utils.h */,
+				4D0811FC26DD9120001BF800 /* Makefile.am */,
+				4D0811FE26DD9120001BF800 /* quant_levels_dec_utils.c */,
+				4D0811F526DD9120001BF800 /* quant_levels_dec_utils.h */,
+				4D0811FD26DD9120001BF800 /* quant_levels_utils.c */,
+				4D0811F426DD9120001BF800 /* quant_levels_utils.h */,
+				4D08120726DD9120001BF800 /* random_utils.c */,
+				4D0811FA26DD9120001BF800 /* random_utils.h */,
+				4D0811F326DD9120001BF800 /* rescaler_utils.c */,
+				4D0811FB26DD9120001BF800 /* rescaler_utils.h */,
+				4D0811EF26DD9120001BF800 /* thread_utils.c */,
+				4D08120026DD9120001BF800 /* thread_utils.h */,
+				4D08120126DD9120001BF800 /* utils.c */,
+				4D0811F026DD9120001BF800 /* utils.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		4D08120826DD9120001BF800 /* webp */ = {
+			isa = PBXGroup;
+			children = (
+				4D08120F26DD9120001BF800 /* decode.h */,
+				4D08120C26DD9120001BF800 /* demux.h */,
+				4D08120E26DD9120001BF800 /* encode.h */,
+				4D08120926DD9120001BF800 /* format_constants.h */,
+				4D08120D26DD9120001BF800 /* mux_types.h */,
+				4D08120A26DD9120001BF800 /* mux.h */,
+				4D08120B26DD9120001BF800 /* types.h */,
+			);
+			path = webp;
+			sourceTree = "<group>";
+		};
+		4D08121126DD9120001BF800 /* enc */ = {
+			isa = PBXGroup;
+			children = (
+				4D08121526DD9120001BF800 /* alpha_enc.c */,
+				4D08122826DD9120001BF800 /* analysis_enc.c */,
+				4D08122D26DD9120001BF800 /* backward_references_cost_enc.c */,
+				4D08122326DD9120001BF800 /* backward_references_enc.c */,
+				4D08121326DD9120001BF800 /* backward_references_enc.h */,
+				4D08122226DD9120001BF800 /* config_enc.c */,
+				4D08121426DD9120001BF800 /* cost_enc.c */,
+				4D08121F26DD9120001BF800 /* cost_enc.h */,
+				4D08121B26DD9120001BF800 /* filter_enc.c */,
+				4D08121D26DD9120001BF800 /* frame_enc.c */,
+				4D08122726DD9120001BF800 /* histogram_enc.c */,
+				4D08121626DD9120001BF800 /* histogram_enc.h */,
+				4D08121226DD9120001BF800 /* iterator_enc.c */,
+				4D08122026DD9120001BF800 /* Makefile.am */,
+				4D08122B26DD9120001BF800 /* near_lossless_enc.c */,
+				4D08121C26DD9120001BF800 /* picture_csp_enc.c */,
+				4D08122C26DD9120001BF800 /* picture_enc.c */,
+				4D08121726DD9120001BF800 /* picture_psnr_enc.c */,
+				4D08122E26DD9120001BF800 /* picture_rescale_enc.c */,
+				4D08122426DD9120001BF800 /* picture_tools_enc.c */,
+				4D08122126DD9120001BF800 /* predictor_enc.c */,
+				4D08122A26DD9120001BF800 /* quant_enc.c */,
+				4D08121E26DD9120001BF800 /* syntax_enc.c */,
+				4D08121826DD9120001BF800 /* token_enc.c */,
+				4D08121A26DD9120001BF800 /* tree_enc.c */,
+				4D08121926DD9120001BF800 /* vp8i_enc.h */,
+				4D08122626DD9120001BF800 /* vp8l_enc.c */,
+				4D08122926DD9120001BF800 /* vp8li_enc.h */,
+				4D08122526DD9120001BF800 /* webp_enc.c */,
+			);
+			path = enc;
+			sourceTree = "<group>";
+		};
+		4D08122F26DD9120001BF800 /* demux */ = {
+			isa = PBXGroup;
+			children = (
+				4D08123326DD9120001BF800 /* anim_decode.c */,
+				4D08123026DD9120001BF800 /* demux.c */,
+				4D08123426DD9120001BF800 /* libwebpdemux.pc.in */,
+				4D08123126DD9120001BF800 /* libwebpdemux.rc */,
+				4D08123226DD9120001BF800 /* Makefile.am */,
+			);
+			path = demux;
+			sourceTree = "<group>";
+		};
+		4D08123626DD9120001BF800 /* dec */ = {
+			isa = PBXGroup;
+			children = (
+				4D08123C26DD9120001BF800 /* alpha_dec.c */,
+				4D08124526DD9120001BF800 /* alphai_dec.h */,
+				4D08123F26DD9120001BF800 /* buffer_dec.c */,
+				4D08123D26DD9120001BF800 /* common_dec.h */,
+				4D08123826DD9120001BF800 /* frame_dec.c */,
+				4D08124226DD9120001BF800 /* idec_dec.c */,
+				4D08123726DD9120001BF800 /* io_dec.c */,
+				4D08123E26DD9120001BF800 /* Makefile.am */,
+				4D08124026DD9120001BF800 /* quant_dec.c */,
+				4D08123926DD9120001BF800 /* tree_dec.c */,
+				4D08124626DD9120001BF800 /* vp8_dec.c */,
+				4D08123B26DD9120001BF800 /* vp8_dec.h */,
+				4D08123A26DD9120001BF800 /* vp8i_dec.h */,
+				4D08124426DD9120001BF800 /* vp8l_dec.c */,
+				4D08124126DD9120001BF800 /* vp8li_dec.h */,
+				4D08124326DD9120001BF800 /* webp_dec.c */,
+				4D08124726DD9120001BF800 /* webpi_dec.h */,
+			);
+			path = dec;
+			sourceTree = "<group>";
+		};
+		4D08124826DD9120001BF800 /* dsp */ = {
+			isa = PBXGroup;
+			children = (
+				4D08126C26DD9120001BF800 /* alpha_processing_mips_dsp_r2.c */,
+				4D08127726DD9120001BF800 /* alpha_processing_neon.c */,
+				4D08128A26DD9120001BF800 /* alpha_processing_sse2.c */,
+				4D08128526DD9120001BF800 /* alpha_processing_sse41.c */,
+				4D08125E26DD9120001BF800 /* alpha_processing.c */,
+				4D08128E26DD9120001BF800 /* common_sse2.h */,
+				4D08129026DD9120001BF800 /* common_sse41.h */,
+				4D08128926DD9120001BF800 /* cost_mips_dsp_r2.c */,
+				4D08128426DD9120001BF800 /* cost_mips32.c */,
+				4D08126126DD9120001BF800 /* cost_neon.c */,
+				4D08125426DD9120001BF800 /* cost_sse2.c */,
+				4D08128726DD9120001BF800 /* cost.c */,
+				4D08125C26DD9120001BF800 /* cpu.c */,
+				4D08128B26DD9120001BF800 /* dec_clip_tables.c */,
+				4D08125226DD9120001BF800 /* dec_mips_dsp_r2.c */,
+				4D08128826DD9120001BF800 /* dec_mips32.c */,
+				4D08129326DD9120001BF800 /* dec_msa.c */,
+				4D08128626DD9120001BF800 /* dec_neon.c */,
+				4D08127F26DD9120001BF800 /* dec_sse2.c */,
+				4D08127026DD9120001BF800 /* dec_sse41.c */,
+				4D08127826DD9120001BF800 /* dec.c */,
+				4D08128026DD9120001BF800 /* dsp.h */,
+				4D08125B26DD9120001BF800 /* enc_mips_dsp_r2.c */,
+				4D08126226DD9120001BF800 /* enc_mips32.c */,
+				4D08124D26DD9120001BF800 /* enc_msa.c */,
+				4D08127E26DD9120001BF800 /* enc_neon.c */,
+				4D08128126DD9120001BF800 /* enc_sse2.c */,
+				4D08125626DD9120001BF800 /* enc_sse41.c */,
+				4D08128D26DD9120001BF800 /* enc.c */,
+				4D08125026DD9120001BF800 /* filters_mips_dsp_r2.c */,
+				4D08126626DD9120001BF800 /* filters_msa.c */,
+				4D08126326DD9120001BF800 /* filters_neon.c */,
+				4D08125926DD9120001BF800 /* filters_sse2.c */,
+				4D08126B26DD9120001BF800 /* filters.c */,
+				4D08128326DD9120001BF800 /* lossless_common.h */,
+				4D08124C26DD9120001BF800 /* lossless_enc_mips_dsp_r2.c */,
+				4D08128F26DD9120001BF800 /* lossless_enc_mips32.c */,
+				4D08126A26DD9120001BF800 /* lossless_enc_msa.c */,
+				4D08128226DD9120001BF800 /* lossless_enc_neon.c */,
+				4D08127C26DD9120001BF800 /* lossless_enc_sse2.c */,
+				4D08125726DD9120001BF800 /* lossless_enc_sse41.c */,
+				4D08127526DD9120001BF800 /* lossless_enc.c */,
+				4D08125A26DD9120001BF800 /* lossless_mips_dsp_r2.c */,
+				4D08128C26DD9120001BF800 /* lossless_msa.c */,
+				4D08126926DD9120001BF800 /* lossless_neon.c */,
+				4D08124A26DD9120001BF800 /* lossless_sse2.c */,
+				4D08127126DD9120001BF800 /* lossless_sse41.c */,
+				4D08127926DD9120001BF800 /* lossless.c */,
+				4D08124B26DD9120001BF800 /* lossless.h */,
+				4D08127426DD9120001BF800 /* Makefile.am */,
+				4D08126726DD9120001BF800 /* mips_macro.h */,
+				4D08124E26DD9120001BF800 /* msa_macro.h */,
+				4D08124F26DD9120001BF800 /* neon.h */,
+				4D08126026DD9120001BF800 /* quant.h */,
+				4D08126D26DD9120001BF800 /* rescaler_mips_dsp_r2.c */,
+				4D08126F26DD9120001BF800 /* rescaler_mips32.c */,
+				4D08126826DD9120001BF800 /* rescaler_msa.c */,
+				4D08125326DD9120001BF800 /* rescaler_neon.c */,
+				4D08127326DD9120001BF800 /* rescaler_sse2.c */,
+				4D08125126DD9120001BF800 /* rescaler.c */,
+				4D08126E26DD9120001BF800 /* ssim_sse2.c */,
+				4D08127A26DD9120001BF800 /* ssim.c */,
+				4D08129226DD9120001BF800 /* upsampling_mips_dsp_r2.c */,
+				4D08127B26DD9120001BF800 /* upsampling_msa.c */,
+				4D08125826DD9120001BF800 /* upsampling_neon.c */,
+				4D08126426DD9120001BF800 /* upsampling_sse2.c */,
+				4D08125526DD9120001BF800 /* upsampling_sse41.c */,
+				4D08124926DD9120001BF800 /* upsampling.c */,
+				4D08127626DD9120001BF800 /* yuv_mips_dsp_r2.c */,
+				4D08129126DD9120001BF800 /* yuv_mips32.c */,
+				4D08125D26DD9120001BF800 /* yuv_neon.c */,
+				4D08126526DD9120001BF800 /* yuv_sse2.c */,
+				4D08127226DD9120001BF800 /* yuv_sse41.c */,
+				4D08127D26DD9120001BF800 /* yuv.c */,
+				4D08125F26DD9120001BF800 /* yuv.h */,
+			);
+			path = dsp;
+			sourceTree = "<group>";
+		};
 		66459FB71511641F0075BF13 /* moaiext-audiosampler */ = {
 			isa = PBXGroup;
 			children = (
@@ -5468,6 +6370,7 @@
 				CDEB91451360A78800AAC558 /* MOAIImage.h */,
 				0795290F1447902700143A72 /* MOAIImage-jpg.cpp */,
 				079529101447902700143A72 /* MOAIImage-png.cpp */,
+				4DB1D11926D736530034597F /* MOAIImage-webp.cpp */,
 				0324E54713564BC7000ADC60 /* MOAIIndexBuffer.cpp */,
 				0324E54813564BC7000ADC60 /* MOAIIndexBuffer.h */,
 				CDEFB3EA13E37F3C000A9523 /* MOAIPvrHeader.h */,
@@ -6411,6 +7314,7 @@
 			files = (
 				8DF744671E4CF1CD003A62C4 /* ftconfig.h in Headers */,
 				8DF744681E4CF1CD003A62C4 /* ftheader.h in Headers */,
+				4D08135F26DD9121001BF800 /* utils.h in Headers */,
 				8DF744691E4CF1CD003A62C4 /* ftmodule.h in Headers */,
 				8DF7446A1E4CF1CD003A62C4 /* ftoption.h in Headers */,
 				8DF7446B1E4CF1CD003A62C4 /* ftstdlib.h in Headers */,
@@ -6420,16 +7324,19 @@
 				03240BF313564CB0000ADC60 /* cpConstraint.h in Headers */,
 				03240BF513564CB0000ADC60 /* cpDampedRotarySpring.h in Headers */,
 				03240BF713564CB0000ADC60 /* cpDampedSpring.h in Headers */,
+				4D08148826DD9123001BF800 /* quant.h in Headers */,
 				03240BF913564CB0000ADC60 /* cpGearJoint.h in Headers */,
 				03240BFB13564CB0000ADC60 /* cpGrooveJoint.h in Headers */,
 				03240BFD13564CB0000ADC60 /* cpPinJoint.h in Headers */,
 				03240BFF13564CB0000ADC60 /* cpPivotJoint.h in Headers */,
 				03240C0113564CB0000ADC60 /* cpRatchetJoint.h in Headers */,
 				03240C0313564CB0000ADC60 /* cpRotaryLimitJoint.h in Headers */,
+				4D08139526DD9122001BF800 /* huffman_utils.h in Headers */,
 				03240C0513564CB0000ADC60 /* cpSimpleMotor.h in Headers */,
 				03240C0713564CB0000ADC60 /* cpSlideJoint.h in Headers */,
 				03240C0813564CB0000ADC60 /* util.h in Headers */,
 				03240C0913564CB0000ADC60 /* chipmunk_ffi.h in Headers */,
+				4D0813E026DD9122001BF800 /* cost_enc.h in Headers */,
 				03240C0A13564CB0000ADC60 /* chipmunk_private.h in Headers */,
 				03240C0B13564CB0000ADC60 /* chipmunk_types.h in Headers */,
 				03240C0C13564CB0000ADC60 /* chipmunk_unsafe.h in Headers */,
@@ -6444,41 +7351,54 @@
 				03240C1C13564CB0000ADC60 /* cpPolyShape.h in Headers */,
 				03240C1E13564CB0000ADC60 /* cpShape.h in Headers */,
 				03240C2013564CB0000ADC60 /* cpSpace.h in Headers */,
+				4D08138C26DD9122001BF800 /* thread_utils.h in Headers */,
 				03240C2313564CB0000ADC60 /* cpSpaceHash.h in Headers */,
 				03240C2713564CB0000ADC60 /* cpVect.h in Headers */,
 				03240C2813564CB0000ADC60 /* prime.h in Headers */,
 				03240C2A13564CB0000ADC60 /* utf8.h in Headers */,
 				03240CC213564CB0000ADC60 /* ascii.h in Headers */,
+				4D08150F26DD9124001BF800 /* common_sse2.h in Headers */,
 				03240CC313564CB0000ADC60 /* asciitab.h in Headers */,
 				03240CC413564CB0000ADC60 /* expat.h in Headers */,
 				03240CC513564CB0000ADC60 /* expat_external.h in Headers */,
 				03240CC613564CB0000ADC60 /* iasciitab.h in Headers */,
+				4D08145226DD9123001BF800 /* msa_macro.h in Headers */,
 				03240CC713564CB0000ADC60 /* internal.h in Headers */,
 				03240CC813564CB0000ADC60 /* latin1tab.h in Headers */,
 				03240CC913564CB0000ADC60 /* macconfig.h in Headers */,
+				4D0813B626DD9122001BF800 /* decode.h in Headers */,
 				03240CCA13564CB0000ADC60 /* nametab.h in Headers */,
 				03240CCB13564CB0000ADC60 /* utf8tab.h in Headers */,
 				03240CCC13564CB0000ADC60 /* winconfig.h in Headers */,
 				03240CCF13564CB0000ADC60 /* xmlrole.h in Headers */,
 				03240CD113564CB0000ADC60 /* xmltok.h in Headers */,
+				4D08148526DD9123001BF800 /* yuv.h in Headers */,
 				03240CD313564CB0000ADC60 /* xmltok_impl.h in Headers */,
 				03240D0313564CB0000ADC60 /* png.h in Headers */,
+				4D08145526DD9123001BF800 /* neon.h in Headers */,
 				03240D0413564CB0000ADC60 /* pngconf.h in Headers */,
 				03240D0913564CB0000ADC60 /* pngpriv.h in Headers */,
+				4D08136226DD9121001BF800 /* bit_reader_utils.h in Headers */,
+				4D0813AD26DD9122001BF800 /* demux.h in Headers */,
 				03240D4E13564CB0000ADC60 /* tinyxml.h in Headers */,
 				CD218F8C13A7FD6E008337E7 /* luasql.h in Headers */,
 				CD218FB213A7FDBA008337E7 /* hashtable.h in Headers */,
+				4D08144926DD9123001BF800 /* lossless.h in Headers */,
 				CD218FB313A7FDBA008337E7 /* jansson_config.h in Headers */,
 				CD218FB413A7FDBA008337E7 /* jansson_private.h in Headers */,
 				CD218FB513A7FDBA008337E7 /* jansson.h in Headers */,
 				CD218FBA13A7FDBA008337E7 /* strbuffer.h in Headers */,
 				CD218FBC13A7FDBA008337E7 /* utf.h in Headers */,
 				CD4900AB141AB6EC00913D80 /* lapi.h in Headers */,
+				4D08137426DD9122001BF800 /* color_cache_utils.h in Headers */,
 				CD4900AD141AB6EC00913D80 /* lauxlib.h in Headers */,
 				CD4900B0141AB6EC00913D80 /* lcode.h in Headers */,
 				CD4900B3141AB6EC00913D80 /* ldebug.h in Headers */,
+				4D08135326DD9121001BF800 /* muxi.h in Headers */,
 				CD4900B5141AB6EC00913D80 /* ldo.h in Headers */,
+				4D0813C526DD9122001BF800 /* histogram_enc.h in Headers */,
 				CD4900B8141AB6EC00913D80 /* lfunc.h in Headers */,
+				4D08143A26DD9123001BF800 /* alphai_dec.h in Headers */,
 				CD4900BA141AB6EC00913D80 /* lgc.h in Headers */,
 				CD4900BE141AB6EC00913D80 /* llex.h in Headers */,
 				CD4900BF141AB6EC00913D80 /* llimits.h in Headers */,
@@ -6492,31 +7412,41 @@
 				CD4900D4141AB6EC00913D80 /* ltm.h in Headers */,
 				CD4900D5141AB6EC00913D80 /* lua.h in Headers */,
 				CD4900D6141AB6EC00913D80 /* luaconf.h in Headers */,
+				4D08139826DD9122001BF800 /* huffman_encode_utils.h in Headers */,
+				4D0813CE26DD9122001BF800 /* vp8i_enc.h in Headers */,
 				CD4900D7141AB6EC00913D80 /* lualib.h in Headers */,
 				CD4900D9141AB6EC00913D80 /* lundump.h in Headers */,
 				CD4900DB141AB6EC00913D80 /* lvm.h in Headers */,
 				CD4900DD141AB6EC00913D80 /* lzio.h in Headers */,
 				07952A401447907100143A72 /* jconfig.h in Headers */,
 				07952A4C1447907100143A72 /* jdct.h in Headers */,
+				4D08134D26DD9121001BF800 /* animi.h in Headers */,
 				07952A591447907100143A72 /* jerror.h in Headers */,
+				4D08144026DD9123001BF800 /* webpi_dec.h in Headers */,
 				07952A601447907100143A72 /* jinclude.h in Headers */,
 				07952A681447907100143A72 /* jmemsys.h in Headers */,
 				07952A691447907100143A72 /* jmorecfg.h in Headers */,
 				07952A6A1447907100143A72 /* jpegint.h in Headers */,
 				07952A6B1447907100143A72 /* jpeglib.h in Headers */,
+				4D08142526DD9122001BF800 /* common_dec.h in Headers */,
+				4D0813FB26DD9122001BF800 /* vp8li_enc.h in Headers */,
 				07952A701447907100143A72 /* jversion.h in Headers */,
 				07658751145CD06900723A7D /* tlsf.h in Headers */,
 				07658753145CD06900723A7D /* tlsfbits.h in Headers */,
+				4D08137D26DD9122001BF800 /* random_utils.h in Headers */,
 				CDEBDD3E1468C16B00C86DF9 /* Box2D.h in Headers */,
 				CDEBDD4F1468C18000C86DF9 /* b2BroadPhase.h in Headers */,
 				CDEBDD591468C18000C86DF9 /* b2Collision.h in Headers */,
+				4D08139226DD9122001BF800 /* bit_writer_utils.h in Headers */,
 				CDEBDD5D1468C18000C86DF9 /* b2Distance.h in Headers */,
 				CDEBDD611468C18000C86DF9 /* b2DynamicTree.h in Headers */,
 				CDEBDD651468C18000C86DF9 /* b2TimeOfImpact.h in Headers */,
+				4D0813A426DD9122001BF800 /* format_constants.h in Headers */,
 				CDEBDD721468C19D00C86DF9 /* b2ChainShape.h in Headers */,
 				CDEBDD761468C19D00C86DF9 /* b2CircleShape.h in Headers */,
 				CDEBDD7A1468C19D00C86DF9 /* b2EdgeShape.h in Headers */,
 				CDEBDD7E1468C19D00C86DF9 /* b2PolygonShape.h in Headers */,
+				4D08136B26DD9121001BF800 /* quant_levels_utils.h in Headers */,
 				579E367618CF8EEF00A3CE47 /* sqlite3.h in Headers */,
 				CDEBDD801468C19D00C86DF9 /* b2Shape.h in Headers */,
 				CDEBDD911468C1AF00C86DF9 /* b2BlockAllocator.h in Headers */,
@@ -6526,26 +7456,38 @@
 				CDEBDD9F1468C1AF00C86DF9 /* b2Settings.h in Headers */,
 				CDEBDDA31468C1AF00C86DF9 /* b2StackAllocator.h in Headers */,
 				CDEBDDA71468C1AF00C86DF9 /* b2Timer.h in Headers */,
+				4D0813AA26DD9122001BF800 /* types.h in Headers */,
 				CDEBDDB81468C1BF00C86DF9 /* b2Body.h in Headers */,
 				CDEBDDBC1468C1BF00C86DF9 /* b2ContactManager.h in Headers */,
 				CDEBDDC01468C1BF00C86DF9 /* b2Fixture.h in Headers */,
+				4D08141F26DD9122001BF800 /* vp8_dec.h in Headers */,
 				CDEBDDC41468C1BF00C86DF9 /* b2Island.h in Headers */,
 				CDEBDDC61468C1BF00C86DF9 /* b2TimeStep.h in Headers */,
 				CDEBDDCA1468C1BF00C86DF9 /* b2World.h in Headers */,
+				4D08136526DD9121001BF800 /* bit_reader_inl_utils.h in Headers */,
 				CDEBDDCE1468C1BF00C86DF9 /* b2WorldCallbacks.h in Headers */,
+				4D0813A726DD9122001BF800 /* mux.h in Headers */,
 				CDEBDDE41468C1D900C86DF9 /* b2ChainAndCircleContact.h in Headers */,
 				CDEBDDE81468C1D900C86DF9 /* b2ChainAndPolygonContact.h in Headers */,
+				4D08142E26DD9123001BF800 /* vp8li_dec.h in Headers */,
+				4D08151526DD9124001BF800 /* common_sse41.h in Headers */,
 				CDEBDDEC1468C1D900C86DF9 /* b2CircleContact.h in Headers */,
 				CDEBDDF01468C1D900C86DF9 /* b2Contact.h in Headers */,
 				CDEBDDF41468C1D900C86DF9 /* b2ContactSolver.h in Headers */,
+				4D08135926DD9121001BF800 /* endian_inl_utils.h in Headers */,
 				CDEBDDF81468C1D900C86DF9 /* b2EdgeAndCircleContact.h in Headers */,
 				CDEBDDFC1468C1D900C86DF9 /* b2EdgeAndPolygonContact.h in Headers */,
 				CDEBDE001468C1D900C86DF9 /* b2PolygonAndCircleContact.h in Headers */,
 				CDEBDE041468C1D900C86DF9 /* b2PolygonContact.h in Headers */,
+				4D08136E26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */,
 				CDEBDE1E1468C1EC00C86DF9 /* b2DistanceJoint.h in Headers */,
+				4D0814E526DD9123001BF800 /* dsp.h in Headers */,
 				CDEBDE221468C1EC00C86DF9 /* b2FrictionJoint.h in Headers */,
+				4D08149D26DD9123001BF800 /* mips_macro.h in Headers */,
 				CDEBDE261468C1EC00C86DF9 /* b2GearJoint.h in Headers */,
+				4D0814EE26DD9124001BF800 /* lossless_common.h in Headers */,
 				CDEBDE2A1468C1EC00C86DF9 /* b2Joint.h in Headers */,
+				4D0813BC26DD9122001BF800 /* backward_references_enc.h in Headers */,
 				CDEBDE2E1468C1EC00C86DF9 /* b2MouseJoint.h in Headers */,
 				CDEBDE321468C1EC00C86DF9 /* b2PrismaticJoint.h in Headers */,
 				CDEBDE361468C1EC00C86DF9 /* b2PulleyJoint.h in Headers */,
@@ -6553,13 +7495,18 @@
 				CDEBDE3E1468C1EC00C86DF9 /* b2RopeJoint.h in Headers */,
 				CDEBDE421468C1EC00C86DF9 /* b2WeldJoint.h in Headers */,
 				CDEBDE461468C1EC00C86DF9 /* b2WheelJoint.h in Headers */,
+				4D08141C26DD9122001BF800 /* vp8i_dec.h in Headers */,
 				CDEBDE4C1468C1FD00C86DF9 /* b2Rope.h in Headers */,
 				CD04AED814725714009C20E5 /* crc32.h in Headers */,
 				CD04AEDE14725714009C20E5 /* deflate.h in Headers */,
 				CD04AEEA14725714009C20E5 /* inffast.h in Headers */,
 				CD04AEED14725714009C20E5 /* inffixed.h in Headers */,
+				4D08138026DD9122001BF800 /* rescaler_utils.h in Headers */,
 				CD04AEF314725714009C20E5 /* inflate.h in Headers */,
+				4D0813B326DD9122001BF800 /* encode.h in Headers */,
+				4D08137726DD9122001BF800 /* filters_utils.h in Headers */,
 				CD04AEF914725714009C20E5 /* inftrees.h in Headers */,
+				4D0813B026DD9122001BF800 /* mux_types.h in Headers */,
 				CD04AEFF14725714009C20E5 /* trees.h in Headers */,
 				CD04AF0514725714009C20E5 /* zconf.h in Headers */,
 				CD04AF0814725714009C20E5 /* zlib.h in Headers */,
@@ -6897,30 +7844,40 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0813C426DD9122001BF800 /* histogram_enc.h in Headers */,
 				8DF744611E4CF1B1003A62C4 /* ftconfig.h in Headers */,
+				4D08151426DD9124001BF800 /* common_sse41.h in Headers */,
+				4D0813A926DD9122001BF800 /* types.h in Headers */,
 				8DF744621E4CF1B1003A62C4 /* ftheader.h in Headers */,
+				4D08137626DD9122001BF800 /* filters_utils.h in Headers */,
 				8DF744631E4CF1B1003A62C4 /* ftmodule.h in Headers */,
 				8DF744641E4CF1B1003A62C4 /* ftoption.h in Headers */,
 				8DF744651E4CF1B1003A62C4 /* ftstdlib.h in Headers */,
+				4D08143F26DD9123001BF800 /* webpi_dec.h in Headers */,
 				8DF744661E4CF1B1003A62C4 /* ft2build.h in Headers */,
 				03240D9913564CB0000ADC60 /* cpConstraint.h in Headers */,
 				03240D9B13564CB0000ADC60 /* cpDampedRotarySpring.h in Headers */,
 				03240D9D13564CB0000ADC60 /* cpDampedSpring.h in Headers */,
+				4D08141B26DD9122001BF800 /* vp8i_dec.h in Headers */,
 				03240D9F13564CB0000ADC60 /* cpGearJoint.h in Headers */,
 				03240DA113564CB0000ADC60 /* cpGrooveJoint.h in Headers */,
 				03240DA313564CB0000ADC60 /* cpPinJoint.h in Headers */,
 				03240DA513564CB0000ADC60 /* cpPivotJoint.h in Headers */,
 				03240DA713564CB0000ADC60 /* cpRatchetJoint.h in Headers */,
+				4D08139126DD9122001BF800 /* bit_writer_utils.h in Headers */,
 				03240DA913564CB0000ADC60 /* cpRotaryLimitJoint.h in Headers */,
 				03240DAB13564CB0000ADC60 /* cpSimpleMotor.h in Headers */,
 				03240DAD13564CB0000ADC60 /* cpSlideJoint.h in Headers */,
 				03240DAE13564CB0000ADC60 /* util.h in Headers */,
 				03240DAF13564CB0000ADC60 /* chipmunk_ffi.h in Headers */,
 				03240DB013564CB0000ADC60 /* chipmunk_private.h in Headers */,
+				4D08148426DD9123001BF800 /* yuv.h in Headers */,
+				4D08139426DD9122001BF800 /* huffman_utils.h in Headers */,
 				03240DB113564CB0000ADC60 /* chipmunk_types.h in Headers */,
 				03240DB213564CB0000ADC60 /* chipmunk_unsafe.h in Headers */,
 				03240DB413564CB0000ADC60 /* chipmunk.h in Headers */,
 				03240DB613564CB0000ADC60 /* cpArbiter.h in Headers */,
+				4D0813CD26DD9122001BF800 /* vp8i_enc.h in Headers */,
 				03240DB813564CB0000ADC60 /* cpArray.h in Headers */,
 				03240DBA13564CB0000ADC60 /* cpBB.h in Headers */,
 				03240DBC13564CB0000ADC60 /* cpBody.h in Headers */,
@@ -6930,41 +7887,52 @@
 				03240DC413564CB0000ADC60 /* cpShape.h in Headers */,
 				03240DC613564CB0000ADC60 /* cpSpace.h in Headers */,
 				03240DC913564CB0000ADC60 /* cpSpaceHash.h in Headers */,
+				4D08136D26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */,
 				03240DCD13564CB0000ADC60 /* cpVect.h in Headers */,
 				03240DCE13564CB0000ADC60 /* prime.h in Headers */,
 				03240DD013564CB0000ADC60 /* utf8.h in Headers */,
 				03240E6813564CB0000ADC60 /* ascii.h in Headers */,
 				03240E6913564CB0000ADC60 /* asciitab.h in Headers */,
 				03240E6A13564CB0000ADC60 /* expat.h in Headers */,
+				4D08142426DD9122001BF800 /* common_dec.h in Headers */,
 				03240E6B13564CB0000ADC60 /* expat_external.h in Headers */,
+				4D0813DF26DD9122001BF800 /* cost_enc.h in Headers */,
 				03240E6C13564CB0000ADC60 /* iasciitab.h in Headers */,
 				03240E6D13564CB0000ADC60 /* internal.h in Headers */,
 				03240E6E13564CB0000ADC60 /* latin1tab.h in Headers */,
 				03240E6F13564CB0000ADC60 /* macconfig.h in Headers */,
 				03240E7013564CB0000ADC60 /* nametab.h in Headers */,
 				03240E7113564CB0000ADC60 /* utf8tab.h in Headers */,
+				4D0813FA26DD9122001BF800 /* vp8li_enc.h in Headers */,
 				03240E7213564CB0000ADC60 /* winconfig.h in Headers */,
 				03240E7513564CB0000ADC60 /* xmlrole.h in Headers */,
 				03240E7713564CB0000ADC60 /* xmltok.h in Headers */,
 				03240E7913564CB0000ADC60 /* xmltok_impl.h in Headers */,
 				579E367718CF8EEF00A3CE47 /* sqlite3ext.h in Headers */,
 				03240EA913564CB0000ADC60 /* png.h in Headers */,
+				4D0814ED26DD9124001BF800 /* lossless_common.h in Headers */,
+				4D08142D26DD9123001BF800 /* vp8li_dec.h in Headers */,
 				03240EAA13564CB0000ADC60 /* pngconf.h in Headers */,
 				03240EAF13564CB0000ADC60 /* pngpriv.h in Headers */,
 				03240EF413564CB0000ADC60 /* tinyxml.h in Headers */,
+				4D08137C26DD9122001BF800 /* random_utils.h in Headers */,
 				CD80F63F135BBCFF006B0683 /* MOAIISO8601DateFormatter.h in Headers */,
 				CD218F8913A7FD6E008337E7 /* luasql.h in Headers */,
 				CD218FA313A7FDBA008337E7 /* hashtable.h in Headers */,
 				CD218FA413A7FDBA008337E7 /* jansson_config.h in Headers */,
 				CD218FA513A7FDBA008337E7 /* jansson_private.h in Headers */,
 				CD218FA613A7FDBA008337E7 /* jansson.h in Headers */,
+				4D08135826DD9121001BF800 /* endian_inl_utils.h in Headers */,
 				CD218FAB13A7FDBA008337E7 /* strbuffer.h in Headers */,
 				CD218FAD13A7FDBA008337E7 /* utf.h in Headers */,
+				4D0813A326DD9122001BF800 /* format_constants.h in Headers */,
 				CD490076141AB6EC00913D80 /* lapi.h in Headers */,
 				CD490078141AB6EC00913D80 /* lauxlib.h in Headers */,
 				CD49007B141AB6EC00913D80 /* lcode.h in Headers */,
+				4D08136126DD9121001BF800 /* bit_reader_utils.h in Headers */,
 				CD49007E141AB6EC00913D80 /* ldebug.h in Headers */,
 				CD490080141AB6EC00913D80 /* ldo.h in Headers */,
+				4D0813AF26DD9122001BF800 /* mux_types.h in Headers */,
 				CD490083141AB6EC00913D80 /* lfunc.h in Headers */,
 				CD490085141AB6EC00913D80 /* lgc.h in Headers */,
 				CD490089141AB6EC00913D80 /* llex.h in Headers */,
@@ -6972,11 +7940,15 @@
 				CD49008D141AB6EC00913D80 /* lmem.h in Headers */,
 				CD490090141AB6EC00913D80 /* lobject.h in Headers */,
 				CD490092141AB6EC00913D80 /* lopcodes.h in Headers */,
+				4D08135226DD9121001BF800 /* muxi.h in Headers */,
+				4D0813B526DD9122001BF800 /* decode.h in Headers */,
 				CD490095141AB6EC00913D80 /* lparser.h in Headers */,
 				CD490097141AB6EC00913D80 /* lstate.h in Headers */,
 				579E367518CF8EEF00A3CE47 /* sqlite3.h in Headers */,
+				4D08136A26DD9121001BF800 /* quant_levels_utils.h in Headers */,
 				CD490099141AB6EC00913D80 /* lstring.h in Headers */,
 				CD49009C141AB6EC00913D80 /* ltable.h in Headers */,
+				4D08137326DD9122001BF800 /* color_cache_utils.h in Headers */,
 				CD49009F141AB6EC00913D80 /* ltm.h in Headers */,
 				CD4900A0141AB6EC00913D80 /* lua.h in Headers */,
 				CD4900A1141AB6EC00913D80 /* luaconf.h in Headers */,
@@ -6992,39 +7964,51 @@
 				07952A131447907100143A72 /* jmorecfg.h in Headers */,
 				07952A141447907100143A72 /* jpegint.h in Headers */,
 				07952A151447907100143A72 /* jpeglib.h in Headers */,
+				4D08135E26DD9121001BF800 /* utils.h in Headers */,
 				07952A1A1447907100143A72 /* jversion.h in Headers */,
 				07658750145CD06900723A7D /* tlsf.h in Headers */,
+				4D0813B226DD9122001BF800 /* encode.h in Headers */,
 				07658752145CD06900723A7D /* tlsfbits.h in Headers */,
 				CDEBDD3D1468C16B00C86DF9 /* Box2D.h in Headers */,
 				CDEBDD4E1468C18000C86DF9 /* b2BroadPhase.h in Headers */,
+				4D08139726DD9122001BF800 /* huffman_encode_utils.h in Headers */,
 				CDEBDD581468C18000C86DF9 /* b2Collision.h in Headers */,
 				CDEBDD5C1468C18000C86DF9 /* b2Distance.h in Headers */,
 				CDEBDD601468C18000C86DF9 /* b2DynamicTree.h in Headers */,
 				CDEBDD641468C18000C86DF9 /* b2TimeOfImpact.h in Headers */,
 				CDEBDD711468C19D00C86DF9 /* b2ChainShape.h in Headers */,
+				4D08136426DD9121001BF800 /* bit_reader_inl_utils.h in Headers */,
 				CDEBDD751468C19D00C86DF9 /* b2CircleShape.h in Headers */,
 				CDEBDD791468C19D00C86DF9 /* b2EdgeShape.h in Headers */,
 				CDEBDD7D1468C19D00C86DF9 /* b2PolygonShape.h in Headers */,
 				CDEBDD7F1468C19D00C86DF9 /* b2Shape.h in Headers */,
+				4D0813AC26DD9122001BF800 /* demux.h in Headers */,
 				CDEBDD901468C1AF00C86DF9 /* b2BlockAllocator.h in Headers */,
 				CDEBDD941468C1AF00C86DF9 /* b2Draw.h in Headers */,
 				CDEBDD961468C1AF00C86DF9 /* b2GrowableStack.h in Headers */,
 				CDEBDD9A1468C1AF00C86DF9 /* b2Math.h in Headers */,
+				4D08137F26DD9122001BF800 /* rescaler_utils.h in Headers */,
 				CDEBDD9E1468C1AF00C86DF9 /* b2Settings.h in Headers */,
 				CDEBDDA21468C1AF00C86DF9 /* b2StackAllocator.h in Headers */,
 				CDEBDDA61468C1AF00C86DF9 /* b2Timer.h in Headers */,
 				CDEBDDB71468C1BF00C86DF9 /* b2Body.h in Headers */,
+				4D08149C26DD9123001BF800 /* mips_macro.h in Headers */,
 				CDEBDDBB1468C1BF00C86DF9 /* b2ContactManager.h in Headers */,
+				4D08150E26DD9124001BF800 /* common_sse2.h in Headers */,
 				CDEBDDBF1468C1BF00C86DF9 /* b2Fixture.h in Headers */,
 				CDEBDDC31468C1BF00C86DF9 /* b2Island.h in Headers */,
 				CDEBDDC51468C1BF00C86DF9 /* b2TimeStep.h in Headers */,
 				CDEBDDC91468C1BF00C86DF9 /* b2World.h in Headers */,
 				CDEBDDCD1468C1BF00C86DF9 /* b2WorldCallbacks.h in Headers */,
+				4D0813A626DD9122001BF800 /* mux.h in Headers */,
 				CDEBDDE31468C1D900C86DF9 /* b2ChainAndCircleContact.h in Headers */,
+				4D08144826DD9123001BF800 /* lossless.h in Headers */,
 				CDEBDDE71468C1D900C86DF9 /* b2ChainAndPolygonContact.h in Headers */,
 				CDEBDDEB1468C1D900C86DF9 /* b2CircleContact.h in Headers */,
 				CDEBDDEF1468C1D900C86DF9 /* b2Contact.h in Headers */,
+				4D08148726DD9123001BF800 /* quant.h in Headers */,
 				CDEBDDF31468C1D900C86DF9 /* b2ContactSolver.h in Headers */,
+				4D08143926DD9123001BF800 /* alphai_dec.h in Headers */,
 				CDEBDDF71468C1D900C86DF9 /* b2EdgeAndCircleContact.h in Headers */,
 				CDEBDDFB1468C1D900C86DF9 /* b2EdgeAndPolygonContact.h in Headers */,
 				CDEBDDFF1468C1D900C86DF9 /* b2PolygonAndCircleContact.h in Headers */,
@@ -7032,6 +8016,7 @@
 				CDEBDE1D1468C1EC00C86DF9 /* b2DistanceJoint.h in Headers */,
 				CDEBDE211468C1EC00C86DF9 /* b2FrictionJoint.h in Headers */,
 				CDEBDE251468C1EC00C86DF9 /* b2GearJoint.h in Headers */,
+				4D08134C26DD9121001BF800 /* animi.h in Headers */,
 				CDEBDE291468C1EC00C86DF9 /* b2Joint.h in Headers */,
 				CDEBDE2D1468C1EC00C86DF9 /* b2MouseJoint.h in Headers */,
 				CDEBDE311468C1EC00C86DF9 /* b2PrismaticJoint.h in Headers */,
@@ -7046,11 +8031,17 @@
 				CD04AEE814725714009C20E5 /* inffast.h in Headers */,
 				CD04AEEB14725714009C20E5 /* inffixed.h in Headers */,
 				CD04AEF114725714009C20E5 /* inflate.h in Headers */,
+				4D08145426DD9123001BF800 /* neon.h in Headers */,
+				4D08141E26DD9122001BF800 /* vp8_dec.h in Headers */,
 				CD04AEF714725714009C20E5 /* inftrees.h in Headers */,
 				CD04AEFD14725714009C20E5 /* trees.h in Headers */,
 				CD04AF0314725714009C20E5 /* zconf.h in Headers */,
+				4D0814E426DD9123001BF800 /* dsp.h in Headers */,
 				CD04AF0614725714009C20E5 /* zlib.h in Headers */,
+				4D08138B26DD9122001BF800 /* thread_utils.h in Headers */,
+				4D08145126DD9123001BF800 /* msa_macro.h in Headers */,
 				CD04AF0C14725714009C20E5 /* zutil.h in Headers */,
+				4D0813BB26DD9122001BF800 /* backward_references_enc.h in Headers */,
 				663704191612813E002D0D27 /* whirlpool.h in Headers */,
 				DD80D65E16D8021D00C172D2 /* MOAIMath.h in Headers */,
 				DD80D68616D8025000C172D2 /* MOAIFrameBufferTexture.h in Headers */,
@@ -7816,7 +8807,11 @@
 				EB9EE0101BE9422800E8938F /* cpDampedSpring.h in Headers */,
 				EB9EE0111BE9422800E8938F /* cpGearJoint.h in Headers */,
 				EB9EE0121BE9422800E8938F /* cpGrooveJoint.h in Headers */,
+				4D08136C26DD9121001BF800 /* quant_levels_utils.h in Headers */,
+				4D08139326DD9122001BF800 /* bit_writer_utils.h in Headers */,
 				EB9EE0131BE9422800E8938F /* cpPinJoint.h in Headers */,
+				4D08135A26DD9121001BF800 /* endian_inl_utils.h in Headers */,
+				4D08151626DD9124001BF800 /* common_sse41.h in Headers */,
 				EB9EE0141BE9422800E8938F /* cpPivotJoint.h in Headers */,
 				EB9EE0151BE9422800E8938F /* cpRatchetJoint.h in Headers */,
 				EB9EE0161BE9422800E8938F /* cpRotaryLimitJoint.h in Headers */,
@@ -7831,12 +8826,17 @@
 				EB9EE01F1BE9422800E8938F /* cpArbiter.h in Headers */,
 				EB9EE0201BE9422800E8938F /* cpArray.h in Headers */,
 				EB9EE0211BE9422800E8938F /* cpBB.h in Headers */,
+				4D08141D26DD9122001BF800 /* vp8i_dec.h in Headers */,
+				4D08135426DD9121001BF800 /* muxi.h in Headers */,
 				EB9EE0221BE9422800E8938F /* cpBody.h in Headers */,
 				EB9EE0231BE9422800E8938F /* cpCollision.h in Headers */,
+				4D08142026DD9122001BF800 /* vp8_dec.h in Headers */,
+				4D0813AE26DD9122001BF800 /* demux.h in Headers */,
 				EB9EE0241BE9422800E8938F /* cpHashSet.h in Headers */,
 				EB9EE0251BE9422800E8938F /* cpPolyShape.h in Headers */,
 				EB9EE0261BE9422800E8938F /* cpShape.h in Headers */,
 				EB9EE0271BE9422800E8938F /* cpSpace.h in Headers */,
+				4D08142626DD9122001BF800 /* common_dec.h in Headers */,
 				EB9EE0281BE9422800E8938F /* cpSpaceHash.h in Headers */,
 				EB9EE0291BE9422800E8938F /* cpVect.h in Headers */,
 				EB9EE02A1BE9422800E8938F /* prime.h in Headers */,
@@ -7847,8 +8847,15 @@
 				EB9EE02F1BE9422800E8938F /* expat_external.h in Headers */,
 				EB9EE0301BE9422800E8938F /* iasciitab.h in Headers */,
 				EB9EE0311BE9422800E8938F /* internal.h in Headers */,
+				4D08137826DD9122001BF800 /* filters_utils.h in Headers */,
 				EB9EE0321BE9422800E8938F /* latin1tab.h in Headers */,
+				4D08143B26DD9123001BF800 /* alphai_dec.h in Headers */,
+				4D0813AB26DD9122001BF800 /* types.h in Headers */,
+				4D08142F26DD9123001BF800 /* vp8li_dec.h in Headers */,
+				4D0813A826DD9122001BF800 /* mux.h in Headers */,
+				4D08134E26DD9121001BF800 /* animi.h in Headers */,
 				EB9EE0331BE9422800E8938F /* macconfig.h in Headers */,
+				4D08139926DD9122001BF800 /* huffman_encode_utils.h in Headers */,
 				EB9EE0341BE9422800E8938F /* nametab.h in Headers */,
 				EB9EE0351BE9422800E8938F /* utf8tab.h in Headers */,
 				EB9EE0361BE9422800E8938F /* winconfig.h in Headers */,
@@ -7858,15 +8865,24 @@
 				EB9EE03A1BE9422800E8938F /* sqlite3ext.h in Headers */,
 				EB9EE0411BE9422800E8938F /* png.h in Headers */,
 				EB9EE0421BE9422800E8938F /* pngconf.h in Headers */,
+				4D08151026DD9124001BF800 /* common_sse2.h in Headers */,
+				4D0813CF26DD9122001BF800 /* vp8i_enc.h in Headers */,
 				EB9EE0431BE9422800E8938F /* pngpriv.h in Headers */,
 				EB9EE0441BE9422800E8938F /* tinyxml.h in Headers */,
 				EB9EE0451BE9422800E8938F /* MOAIISO8601DateFormatter.h in Headers */,
 				EB9EE0461BE9422800E8938F /* luasql.h in Headers */,
 				EB9EE0471BE9422800E8938F /* hashtable.h in Headers */,
 				EB9EE0481BE9422800E8938F /* jansson_config.h in Headers */,
+				4D08136026DD9121001BF800 /* utils.h in Headers */,
+				4D08149E26DD9123001BF800 /* mips_macro.h in Headers */,
+				4D08138D26DD9122001BF800 /* thread_utils.h in Headers */,
 				EB9EE0491BE9422800E8938F /* jansson_private.h in Headers */,
+				4D08136626DD9121001BF800 /* bit_reader_inl_utils.h in Headers */,
+				4D0813A526DD9122001BF800 /* format_constants.h in Headers */,
 				EB9EE04A1BE9422800E8938F /* jansson.h in Headers */,
+				4D0813B426DD9122001BF800 /* encode.h in Headers */,
 				EB9EE04B1BE9422800E8938F /* strbuffer.h in Headers */,
+				4D08139626DD9122001BF800 /* huffman_utils.h in Headers */,
 				EB9EE04C1BE9422800E8938F /* utf.h in Headers */,
 				EB9EE04D1BE9422800E8938F /* lapi.h in Headers */,
 				EB9EE04E1BE9422800E8938F /* lauxlib.h in Headers */,
@@ -7882,11 +8898,15 @@
 				EB9EE0581BE9422800E8938F /* lopcodes.h in Headers */,
 				EB9EE0591BE9422800E8938F /* lparser.h in Headers */,
 				EB9EE05A1BE9422800E8938F /* lstate.h in Headers */,
+				4D0813B726DD9122001BF800 /* decode.h in Headers */,
+				4D0814E626DD9123001BF800 /* dsp.h in Headers */,
 				EB9EE05B1BE9422800E8938F /* sqlite3.h in Headers */,
 				EB9EE05C1BE9422800E8938F /* lstring.h in Headers */,
 				EB9EE05D1BE9422800E8938F /* ltable.h in Headers */,
 				EB9EE05E1BE9422800E8938F /* ltm.h in Headers */,
 				EB9EE05F1BE9422800E8938F /* lua.h in Headers */,
+				4D0814EF26DD9124001BF800 /* lossless_common.h in Headers */,
+				4D08148626DD9123001BF800 /* yuv.h in Headers */,
 				EB9EE0601BE9422800E8938F /* luaconf.h in Headers */,
 				EB9EE0611BE9422800E8938F /* lualib.h in Headers */,
 				EB9EE0621BE9422800E8938F /* lundump.h in Headers */,
@@ -7906,9 +8926,11 @@
 				EB9EE0701BE9422800E8938F /* Box2D.h in Headers */,
 				EB9EE0711BE9422800E8938F /* b2BroadPhase.h in Headers */,
 				EB9EE0721BE9422800E8938F /* b2Collision.h in Headers */,
+				4D08148926DD9123001BF800 /* quant.h in Headers */,
 				EB9EE0731BE9422800E8938F /* b2Distance.h in Headers */,
 				EB9EE0741BE9422800E8938F /* b2DynamicTree.h in Headers */,
 				EB9EE0751BE9422800E8938F /* b2TimeOfImpact.h in Headers */,
+				4D08145326DD9123001BF800 /* msa_macro.h in Headers */,
 				EB9EE0761BE9422800E8938F /* b2ChainShape.h in Headers */,
 				EB9EE0771BE9422800E8938F /* b2CircleShape.h in Headers */,
 				EB9EE0781BE9422800E8938F /* b2EdgeShape.h in Headers */,
@@ -7916,6 +8938,7 @@
 				EB9EE07A1BE9422800E8938F /* b2Shape.h in Headers */,
 				EB9EE07B1BE9422800E8938F /* b2BlockAllocator.h in Headers */,
 				EB9EE07C1BE9422800E8938F /* b2Draw.h in Headers */,
+				4D08138126DD9122001BF800 /* rescaler_utils.h in Headers */,
 				EB9EE07D1BE9422800E8938F /* b2GrowableStack.h in Headers */,
 				EB9EE07E1BE9422800E8938F /* b2Math.h in Headers */,
 				EB9EE07F1BE9422800E8938F /* b2Settings.h in Headers */,
@@ -7924,31 +8947,41 @@
 				EB9EE0821BE9422800E8938F /* b2Body.h in Headers */,
 				EB9EE0831BE9422800E8938F /* b2ContactManager.h in Headers */,
 				EB9EE0841BE9422800E8938F /* b2Fixture.h in Headers */,
+				4D0813B126DD9122001BF800 /* mux_types.h in Headers */,
 				EB9EE0851BE9422800E8938F /* b2Island.h in Headers */,
 				EB9EE0861BE9422800E8938F /* b2TimeStep.h in Headers */,
+				4D08145626DD9123001BF800 /* neon.h in Headers */,
+				4D0813E126DD9122001BF800 /* cost_enc.h in Headers */,
 				EB9EE0871BE9422800E8938F /* b2World.h in Headers */,
+				4D08136F26DD9121001BF800 /* quant_levels_dec_utils.h in Headers */,
 				EB9EE0881BE9422800E8938F /* b2WorldCallbacks.h in Headers */,
 				EB9EE0891BE9422800E8938F /* b2ChainAndCircleContact.h in Headers */,
 				EB9EE08A1BE9422800E8938F /* b2ChainAndPolygonContact.h in Headers */,
+				4D08137E26DD9122001BF800 /* random_utils.h in Headers */,
 				EB9EE08B1BE9422800E8938F /* b2CircleContact.h in Headers */,
 				EB9EE08C1BE9422800E8938F /* b2Contact.h in Headers */,
 				EB9EE08D1BE9422800E8938F /* b2ContactSolver.h in Headers */,
 				EB9EE08E1BE9422800E8938F /* b2EdgeAndCircleContact.h in Headers */,
 				EB9EE08F1BE9422800E8938F /* b2EdgeAndPolygonContact.h in Headers */,
+				4D0813BD26DD9122001BF800 /* backward_references_enc.h in Headers */,
 				EB9EE0901BE9422800E8938F /* b2PolygonAndCircleContact.h in Headers */,
 				EB9EE0911BE9422800E8938F /* b2PolygonContact.h in Headers */,
 				EB9EE0921BE9422800E8938F /* b2DistanceJoint.h in Headers */,
+				4D0813C626DD9122001BF800 /* histogram_enc.h in Headers */,
 				EB9EE0931BE9422800E8938F /* b2FrictionJoint.h in Headers */,
 				EB9EE0941BE9422800E8938F /* b2GearJoint.h in Headers */,
 				EB9EE0951BE9422800E8938F /* b2Joint.h in Headers */,
 				EB9EE0961BE9422800E8938F /* b2MouseJoint.h in Headers */,
 				EB9EE0971BE9422800E8938F /* b2PrismaticJoint.h in Headers */,
 				EB9EE0981BE9422800E8938F /* b2PulleyJoint.h in Headers */,
+				4D0813FC26DD9122001BF800 /* vp8li_enc.h in Headers */,
 				EB9EE0991BE9422800E8938F /* b2RevoluteJoint.h in Headers */,
 				EB9EE09A1BE9422800E8938F /* b2RopeJoint.h in Headers */,
 				EB9EE09B1BE9422800E8938F /* b2WeldJoint.h in Headers */,
 				EB9EE09C1BE9422800E8938F /* b2WheelJoint.h in Headers */,
+				4D08137526DD9122001BF800 /* color_cache_utils.h in Headers */,
 				EB9EE09D1BE9422800E8938F /* b2Rope.h in Headers */,
+				4D08144126DD9123001BF800 /* webpi_dec.h in Headers */,
 				EB9EE09E1BE9422800E8938F /* crc32.h in Headers */,
 				EB9EE09F1BE9422800E8938F /* deflate.h in Headers */,
 				EB9EE0A01BE9422800E8938F /* inffast.h in Headers */,
@@ -7957,6 +8990,8 @@
 				EB9EE0A31BE9422800E8938F /* inftrees.h in Headers */,
 				EB9EE0A41BE9422800E8938F /* trees.h in Headers */,
 				EB9EE0A51BE9422800E8938F /* zconf.h in Headers */,
+				4D08136326DD9121001BF800 /* bit_reader_utils.h in Headers */,
+				4D08144A26DD9123001BF800 /* lossless.h in Headers */,
 				EB9EE0A61BE9422800E8938F /* zlib.h in Headers */,
 				EB9EE0A71BE9422800E8938F /* zutil.h in Headers */,
 				EB9EE0A81BE9422800E8938F /* whirlpool.h in Headers */,
@@ -8287,15 +9322,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0814A626DD9123001BF800 /* lossless_enc_msa.c in Sources */,
 				8DF7446D1E4CF1EB003A62C4 /* smooth.c in Sources */,
+				4D0814A926DD9123001BF800 /* filters.c in Sources */,
 				8DF7446E1E4CF1EB003A62C4 /* ftlzw.c in Sources */,
 				8DF7446F1E4CF1EB003A62C4 /* ftgzip.c in Sources */,
 				8DF744701E4CF1EB003A62C4 /* ftcache.c in Sources */,
+				4D08147326DD9123001BF800 /* filters_sse2.c in Sources */,
 				8DF744711E4CF1EB003A62C4 /* ftbase.c in Sources */,
 				8DF744721E4CF1EB003A62C4 /* ftbitmap.c in Sources */,
 				8DF744731E4CF1EB003A62C4 /* ftdebug.c in Sources */,
 				8DF744741E4CF1EB003A62C4 /* ftfstype.c in Sources */,
+				4D0814EB26DD9123001BF800 /* lossless_enc_neon.c in Sources */,
 				8DF744751E4CF1EB003A62C4 /* ftgasp.c in Sources */,
+				4D08146126DD9123001BF800 /* rescaler_neon.c in Sources */,
 				8DF744761E4CF1EB003A62C4 /* ftglyph.c in Sources */,
 				8DF744771E4CF1EB003A62C4 /* ftinit.c in Sources */,
 				8DF744781E4CF1EB003A62C4 /* ftstroke.c in Sources */,
@@ -8304,25 +9344,38 @@
 				8DF7447B1E4CF1EB003A62C4 /* bdf.c in Sources */,
 				8DF7447C1E4CF1EB003A62C4 /* autofit.c in Sources */,
 				8DF7447D1E4CF1EB003A62C4 /* type1cid.c in Sources */,
+				4D08143726DD9123001BF800 /* vp8l_dec.c in Sources */,
 				8DF7447E1E4CF1EB003A62C4 /* winfnt.c in Sources */,
 				8DF7447F1E4CF1EB003A62C4 /* type42.c in Sources */,
 				8DF744801E4CF1EB003A62C4 /* type1.c in Sources */,
+				4D0814DC26DD9123001BF800 /* yuv.c in Sources */,
 				8DF744811E4CF1EB003A62C4 /* truetype.c in Sources */,
 				8DF744821E4CF1EB003A62C4 /* sfnt.c in Sources */,
 				8DF744831E4CF1EB003A62C4 /* raster.c in Sources */,
+				4D08150626DD9124001BF800 /* dec_clip_tables.c in Sources */,
 				8DF744841E4CF1EB003A62C4 /* psmodule.c in Sources */,
 				8DF744851E4CF1EB003A62C4 /* pshinter.c in Sources */,
+				4D0814FD26DD9124001BF800 /* dec_mips32.c in Sources */,
+				4D08149A26DD9123001BF800 /* filters_msa.c in Sources */,
 				8DF744861E4CF1EB003A62C4 /* psaux.c in Sources */,
+				4D08151826DD9124001BF800 /* yuv_mips32.c in Sources */,
+				4D0814AC26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */,
+				4D0814A026DD9123001BF800 /* rescaler_msa.c in Sources */,
 				8DF744871E4CF1EB003A62C4 /* pfr.c in Sources */,
 				8DF744881E4CF1EB003A62C4 /* pcf.c in Sources */,
 				8DF744891E4CF1EB003A62C4 /* ftbbox.c in Sources */,
 				8DF7448A1E4CF1EB003A62C4 /* ftgxval.c in Sources */,
 				8DF7448B1E4CF1EB003A62C4 /* ftlcdfil.c in Sources */,
 				8DF7448C1E4CF1EB003A62C4 /* ftmm.c in Sources */,
+				4D08137126DD9121001BF800 /* huffman_utils.c in Sources */,
+				4D0813E326DD9122001BF800 /* predictor_enc.c in Sources */,
+				4D08149126DD9123001BF800 /* filters_neon.c in Sources */,
 				8DF7448D1E4CF1EB003A62C4 /* ftotval.c in Sources */,
+				4D08140D26DD9122001BF800 /* demux.c in Sources */,
 				8DF7448E1E4CF1EB003A62C4 /* ftpatent.c in Sources */,
 				8DF7448F1E4CF1EB003A62C4 /* ftpfr.c in Sources */,
 				8DF744901E4CF1EB003A62C4 /* ftsynth.c in Sources */,
+				4D08150C26DD9124001BF800 /* enc.c in Sources */,
 				8DF744911E4CF1EB003A62C4 /* fttype1.c in Sources */,
 				8DF744921E4CF1EB003A62C4 /* ftwinfnt.c in Sources */,
 				F00D617218C00FFE00625DA9 /* mem_clr.c in Sources */,
@@ -8337,33 +9390,46 @@
 				03240BF413564CB0000ADC60 /* cpDampedRotarySpring.c in Sources */,
 				03240BF613564CB0000ADC60 /* cpDampedSpring.c in Sources */,
 				03240BF813564CB0000ADC60 /* cpGearJoint.c in Sources */,
+				4D08140126DD9122001BF800 /* near_lossless_enc.c in Sources */,
 				03240BFA13564CB0000ADC60 /* cpGrooveJoint.c in Sources */,
 				03240BFC13564CB0000ADC60 /* cpPinJoint.c in Sources */,
 				03240BFE13564CB0000ADC60 /* cpPivotJoint.c in Sources */,
+				4D08143126DD9123001BF800 /* idec_dec.c in Sources */,
 				03240C0013564CB0000ADC60 /* cpRatchetJoint.c in Sources */,
+				4D0814B526DD9123001BF800 /* rescaler_mips32.c in Sources */,
 				03240C0213564CB0000ADC60 /* cpRotaryLimitJoint.c in Sources */,
 				03240C0413564CB0000ADC60 /* cpSimpleMotor.c in Sources */,
 				03240C0613564CB0000ADC60 /* cpSlideJoint.c in Sources */,
 				03240C0D13564CB0000ADC60 /* chipmunk.c in Sources */,
+				4D0814C426DD9123001BF800 /* lossless_enc.c in Sources */,
 				03240C0F13564CB0000ADC60 /* cpArbiter.c in Sources */,
+				4D08144626DD9123001BF800 /* lossless_sse2.c in Sources */,
 				03240C1113564CB0000ADC60 /* cpArray.c in Sources */,
 				03240C1313564CB0000ADC60 /* cpBB.c in Sources */,
 				03240C1513564CB0000ADC60 /* cpBody.c in Sources */,
 				03240C1713564CB0000ADC60 /* cpCollision.c in Sources */,
 				03240C1913564CB0000ADC60 /* cpHashSet.c in Sources */,
+				4D08140A26DD9122001BF800 /* picture_rescale_enc.c in Sources */,
+				4D08145B26DD9123001BF800 /* rescaler.c in Sources */,
 				03240C1B13564CB0000ADC60 /* cpPolyShape.c in Sources */,
 				03240C1D13564CB0000ADC60 /* cpShape.c in Sources */,
 				03240C1F13564CB0000ADC60 /* cpSpace.c in Sources */,
 				03240C2113564CB0000ADC60 /* cpSpaceComponent.c in Sources */,
+				4D0813BF26DD9122001BF800 /* cost_enc.c in Sources */,
 				03240C2213564CB0000ADC60 /* cpSpaceHash.c in Sources */,
+				4D08148226DD9123001BF800 /* alpha_processing.c in Sources */,
+				4D08146D26DD9123001BF800 /* lossless_enc_sse41.c in Sources */,
 				03240C2413564CB0000ADC60 /* cpSpaceQuery.c in Sources */,
 				03240C2513564CB0000ADC60 /* cpSpaceStep.c in Sources */,
 				03240C2613564CB0000ADC60 /* cpVect.c in Sources */,
 				03240C2913564CB0000ADC60 /* utf8.c in Sources */,
 				03240CCD13564CB0000ADC60 /* xmlparse.c in Sources */,
+				4D08136826DD9121001BF800 /* rescaler_utils.c in Sources */,
+				4D08144C26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */,
 				03240CCE13564CB0000ADC60 /* xmlrole.c in Sources */,
 				03240CD013564CB0000ADC60 /* xmltok.c in Sources */,
 				03240CD213564CB0000ADC60 /* xmltok_impl.c in Sources */,
+				4D0813FE26DD9122001BF800 /* quant_enc.c in Sources */,
 				03240CD413564CB0000ADC60 /* xmltok_ns.c in Sources */,
 				03240D0213564CB0000ADC60 /* png.c in Sources */,
 				03240D0513564CB0000ADC60 /* pngerror.c in Sources */,
@@ -8373,40 +9439,61 @@
 				03240D0A13564CB0000ADC60 /* pngread.c in Sources */,
 				03240D0B13564CB0000ADC60 /* pngrio.c in Sources */,
 				03240D0C13564CB0000ADC60 /* pngrtran.c in Sources */,
+				4D08140726DD9122001BF800 /* backward_references_cost_enc.c in Sources */,
 				03240D0D13564CB0000ADC60 /* pngrutil.c in Sources */,
+				4D0814CA26DD9123001BF800 /* alpha_processing_neon.c in Sources */,
 				03240D0E13564CB0000ADC60 /* pngset.c in Sources */,
+				4D0813F226DD9122001BF800 /* vp8l_enc.c in Sources */,
 				03240D1013564CB0000ADC60 /* pngtrans.c in Sources */,
 				03240D1113564CB0000ADC60 /* pngwio.c in Sources */,
+				4D08142826DD9122001BF800 /* buffer_dec.c in Sources */,
+				4D08145E26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */,
 				03240D1213564CB0000ADC60 /* pngwrite.c in Sources */,
+				4D08147F26DD9123001BF800 /* yuv_neon.c in Sources */,
 				03240D1313564CB0000ADC60 /* pngwtran.c in Sources */,
 				03240D1413564CB0000ADC60 /* pngwutil.c in Sources */,
 				03240D4D13564CB0000ADC60 /* tinyxml.cpp in Sources */,
 				03240D4F13564CB0000ADC60 /* tinyxmlerror.cpp in Sources */,
+				4D0814BE26DD9123001BF800 /* yuv_sse41.c in Sources */,
 				03240D5013564CB0000ADC60 /* tinyxmlparser.cpp in Sources */,
 				CD218F8A13A7FD6E008337E7 /* ls_sqlite3.c in Sources */,
 				CD218F8B13A7FD6E008337E7 /* luasql.c in Sources */,
 				CD218FAF13A7FDBA008337E7 /* dump.c in Sources */,
 				CD218FB013A7FDBA008337E7 /* error.c in Sources */,
 				CD218FB113A7FDBA008337E7 /* hashtable.c in Sources */,
+				4D0814AF26DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */,
 				CD218FB613A7FDBA008337E7 /* load.c in Sources */,
 				CD218FB713A7FDBA008337E7 /* memory.c in Sources */,
 				CD218FB813A7FDBA008337E7 /* pack_unpack.c in Sources */,
+				4D08145826DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */,
+				4D08142B26DD9122001BF800 /* quant_dec.c in Sources */,
 				CD218FB913A7FDBA008337E7 /* strbuffer.c in Sources */,
 				CD218FBB13A7FDBA008337E7 /* utf.c in Sources */,
 				CD218FBD13A7FDBA008337E7 /* value.c in Sources */,
 				CD4900AA141AB6EC00913D80 /* lapi.c in Sources */,
+				4D0813D426DD9122001BF800 /* filter_enc.c in Sources */,
+				4D08141026DD9122001BF800 /* anim_decode.c in Sources */,
+				4D0813CB26DD9122001BF800 /* token_enc.c in Sources */,
 				CD4900AC141AB6EC00913D80 /* lauxlib.c in Sources */,
 				CD4900AE141AB6EC00913D80 /* lbaselib.c in Sources */,
+				4D0813E926DD9122001BF800 /* backward_references_enc.c in Sources */,
 				CD4900AF141AB6EC00913D80 /* lcode.c in Sources */,
 				CD4900B1141AB6EC00913D80 /* ldblib.c in Sources */,
+				4D08144F26DD9123001BF800 /* enc_msa.c in Sources */,
+				4D08134726DD9121001BF800 /* muxinternal.c in Sources */,
 				CD4900B2141AB6EC00913D80 /* ldebug.c in Sources */,
+				4D0814B226DD9123001BF800 /* ssim_sse2.c in Sources */,
+				4D0813C226DD9122001BF800 /* alpha_enc.c in Sources */,
 				CD4900B4141AB6EC00913D80 /* ldo.c in Sources */,
 				CD4900B6141AB6EC00913D80 /* ldump.c in Sources */,
 				CD4900B7141AB6EC00913D80 /* lfunc.c in Sources */,
 				CD4900B9141AB6EC00913D80 /* lgc.c in Sources */,
 				CD4900BB141AB6EC00913D80 /* linit.c in Sources */,
+				4D08137A26DD9122001BF800 /* huffman_encode_utils.c in Sources */,
 				CD4900BC141AB6EC00913D80 /* liolib.c in Sources */,
 				CD4900BD141AB6EC00913D80 /* llex.c in Sources */,
+				4D08135026DD9121001BF800 /* muxedit.c in Sources */,
+				4D08147026DD9123001BF800 /* upsampling_neon.c in Sources */,
 				CD4900C0141AB6EC00913D80 /* lmathlib.c in Sources */,
 				CD4900C1141AB6EC00913D80 /* lmem.c in Sources */,
 				CD4900C3141AB6EC00913D80 /* loadlib.c in Sources */,
@@ -8417,66 +9504,104 @@
 				CD4900CB141AB6EC00913D80 /* lstate.c in Sources */,
 				CD4900CD141AB6EC00913D80 /* lstring.c in Sources */,
 				CD4900CF141AB6EC00913D80 /* lstrlib.c in Sources */,
+				4D08147C26DD9123001BF800 /* cpu.c in Sources */,
 				CD4900D0141AB6EC00913D80 /* ltable.c in Sources */,
 				CD4900D2141AB6EC00913D80 /* ltablib.c in Sources */,
 				CD4900D3141AB6EC00913D80 /* ltm.c in Sources */,
 				CD4900D8141AB6EC00913D80 /* lundump.c in Sources */,
+				4D0814D326DD9123001BF800 /* ssim.c in Sources */,
 				CD4900DA141AB6EC00913D80 /* lvm.c in Sources */,
 				CD4900DC141AB6EC00913D80 /* lzio.c in Sources */,
+				4D0814DF26DD9123001BF800 /* enc_neon.c in Sources */,
 				CD4900DE141AB6EC00913D80 /* print.c in Sources */,
 				07952A331447907100143A72 /* jaricom.c in Sources */,
+				4D08139B26DD9122001BF800 /* color_cache_utils.c in Sources */,
 				07952A341447907100143A72 /* jcapimin.c in Sources */,
 				07952A351447907100143A72 /* jcapistd.c in Sources */,
 				07952A361447907100143A72 /* jcarith.c in Sources */,
+				4D0814CD26DD9123001BF800 /* dec.c in Sources */,
+				4D0814E226DD9123001BF800 /* dec_sse2.c in Sources */,
 				07952A371447907100143A72 /* jccoefct.c in Sources */,
+				4D0813DD26DD9122001BF800 /* syntax_enc.c in Sources */,
 				07952A381447907100143A72 /* jccolor.c in Sources */,
+				4D08151E26DD9124001BF800 /* dec_msa.c in Sources */,
 				07952A391447907100143A72 /* jcdctmgr.c in Sources */,
+				4D08138626DD9122001BF800 /* quant_levels_dec_utils.c in Sources */,
 				07952A3A1447907100143A72 /* jchuff.c in Sources */,
 				07952A3B1447907100143A72 /* jcinit.c in Sources */,
+				4D08148B26DD9123001BF800 /* cost_neon.c in Sources */,
 				07952A3C1447907100143A72 /* jcmainct.c in Sources */,
 				07952A3D1447907100143A72 /* jcmarker.c in Sources */,
+				4D08142226DD9122001BF800 /* alpha_dec.c in Sources */,
 				07952A3E1447907100143A72 /* jcmaster.c in Sources */,
+				4D08141326DD9122001BF800 /* io_dec.c in Sources */,
+				4D08146A26DD9123001BF800 /* enc_sse41.c in Sources */,
 				07952A3F1447907100143A72 /* jcomapi.c in Sources */,
 				07952A411447907100143A72 /* jcparam.c in Sources */,
+				4D08146726DD9123001BF800 /* upsampling_sse41.c in Sources */,
 				07952A421447907100143A72 /* jcprepct.c in Sources */,
+				4D08139E26DD9122001BF800 /* filters_utils.c in Sources */,
+				4D0814B826DD9123001BF800 /* dec_sse41.c in Sources */,
+				4D0813B926DD9122001BF800 /* iterator_enc.c in Sources */,
 				07952A431447907100143A72 /* jcsample.c in Sources */,
 				07952A441447907100143A72 /* jctrans.c in Sources */,
 				07952A451447907100143A72 /* jdapimin.c in Sources */,
 				07952A461447907100143A72 /* jdapistd.c in Sources */,
+				4D08134A26DD9121001BF800 /* anim_encode.c in Sources */,
+				4D08141626DD9122001BF800 /* frame_dec.c in Sources */,
+				4D0813EC26DD9122001BF800 /* picture_tools_enc.c in Sources */,
+				4D0814C726DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */,
 				07952A471447907100143A72 /* jdarith.c in Sources */,
 				07952A481447907100143A72 /* jdatadst.c in Sources */,
+				4D08138F26DD9122001BF800 /* utils.c in Sources */,
 				07952A491447907100143A72 /* jdatasrc.c in Sources */,
+				4D08150926DD9124001BF800 /* lossless_msa.c in Sources */,
+				4D08149726DD9123001BF800 /* yuv_sse2.c in Sources */,
 				07952A4A1447907100143A72 /* jdcoefct.c in Sources */,
 				07952A4B1447907100143A72 /* jdcolor.c in Sources */,
 				07952A4D1447907100143A72 /* jddctmgr.c in Sources */,
 				07952A4E1447907100143A72 /* jdhuff.c in Sources */,
 				07952A4F1447907100143A72 /* jdinput.c in Sources */,
+				4D08144326DD9123001BF800 /* upsampling.c in Sources */,
+				4D0813DA26DD9122001BF800 /* frame_enc.c in Sources */,
 				07952A501447907100143A72 /* jdmainct.c in Sources */,
 				07952A511447907100143A72 /* jdmarker.c in Sources */,
 				07952A521447907100143A72 /* jdmaster.c in Sources */,
+				4D08148E26DD9123001BF800 /* enc_mips32.c in Sources */,
 				07952A531447907100143A72 /* jdmerge.c in Sources */,
 				07952A541447907100143A72 /* jdpostct.c in Sources */,
+				4D08151226DD9124001BF800 /* lossless_enc_mips32.c in Sources */,
 				07952A551447907100143A72 /* jdsample.c in Sources */,
+				4D0813EF26DD9122001BF800 /* webp_enc.c in Sources */,
 				07952A561447907100143A72 /* jdtrans.c in Sources */,
 				07952A571447907100143A72 /* jerror-moai.c in Sources */,
 				07952A5A1447907100143A72 /* jfdctflt.c in Sources */,
 				07952A5B1447907100143A72 /* jfdctfst.c in Sources */,
+				4D08143D26DD9123001BF800 /* vp8_dec.c in Sources */,
 				07952A5C1447907100143A72 /* jfdctint.c in Sources */,
 				07952A5D1447907100143A72 /* jidctflt.c in Sources */,
+				4D08150326DD9124001BF800 /* alpha_processing_sse2.c in Sources */,
 				07952A5E1447907100143A72 /* jidctfst.c in Sources */,
 				07952A5F1447907100143A72 /* jidctint.c in Sources */,
+				4D0814D926DD9123001BF800 /* lossless_enc_sse2.c in Sources */,
 				07952A651447907100143A72 /* jmemmgr.c in Sources */,
+				4D08140426DD9122001BF800 /* picture_enc.c in Sources */,
 				07952A671447907100143A72 /* jmemnobs.c in Sources */,
+				4D0813D126DD9122001BF800 /* tree_enc.c in Sources */,
+				4D08138326DD9122001BF800 /* quant_levels_utils.c in Sources */,
 				07952A6D1447907100143A72 /* jquant1.c in Sources */,
 				07952A6E1447907100143A72 /* jquant2.c in Sources */,
 				07952A6F1447907100143A72 /* jutils.c in Sources */,
 				0765874F145CD06900723A7D /* tlsf.c in Sources */,
 				CDEBDD4D1468C18000C86DF9 /* b2BroadPhase.cpp in Sources */,
+				4D08138926DD9122001BF800 /* bit_reader_utils.c in Sources */,
 				CDEBDD511468C18000C86DF9 /* b2CollideCircle.cpp in Sources */,
 				CDEBDD531468C18000C86DF9 /* b2CollideEdge.cpp in Sources */,
 				CDEBDD551468C18000C86DF9 /* b2CollidePolygon.cpp in Sources */,
 				CDEBDD571468C18000C86DF9 /* b2Collision.cpp in Sources */,
+				4D0814A326DD9123001BF800 /* lossless_neon.c in Sources */,
 				CDEBDD5B1468C18000C86DF9 /* b2Distance.cpp in Sources */,
+				4D0813F526DD9122001BF800 /* histogram_enc.c in Sources */,
 				CDEBDD5F1468C18000C86DF9 /* b2DynamicTree.cpp in Sources */,
 				CDEBDD631468C18000C86DF9 /* b2TimeOfImpact.cpp in Sources */,
 				CDEBDD701468C19D00C86DF9 /* b2ChainShape.cpp in Sources */,
@@ -8484,30 +9609,50 @@
 				CDEBDD781468C19D00C86DF9 /* b2EdgeShape.cpp in Sources */,
 				CDEBDD7C1468C19D00C86DF9 /* b2PolygonShape.cpp in Sources */,
 				CDEBDD8F1468C1AF00C86DF9 /* b2BlockAllocator.cpp in Sources */,
+				4D0814F726DD9124001BF800 /* dec_neon.c in Sources */,
 				CDEBDD931468C1AF00C86DF9 /* b2Draw.cpp in Sources */,
 				CDEBDD991468C1AF00C86DF9 /* b2Math.cpp in Sources */,
 				CDEBDD9D1468C1AF00C86DF9 /* b2Settings.cpp in Sources */,
 				CDEBDDA11468C1AF00C86DF9 /* b2StackAllocator.cpp in Sources */,
 				CDEBDDA51468C1AF00C86DF9 /* b2Timer.cpp in Sources */,
 				CDEBDDB61468C1BF00C86DF9 /* b2Body.cpp in Sources */,
+				4D08141926DD9122001BF800 /* tree_dec.c in Sources */,
 				CDEBDDBA1468C1BF00C86DF9 /* b2ContactManager.cpp in Sources */,
+				4D0814E826DD9123001BF800 /* enc_sse2.c in Sources */,
 				CDEBDDBE1468C1BF00C86DF9 /* b2Fixture.cpp in Sources */,
+				4D0814C126DD9123001BF800 /* rescaler_sse2.c in Sources */,
 				CDEBDDC21468C1BF00C86DF9 /* b2Island.cpp in Sources */,
 				CDEBDDC81468C1BF00C86DF9 /* b2World.cpp in Sources */,
+				4D0814BB26DD9123001BF800 /* lossless_sse41.c in Sources */,
 				CDEBDDCC1468C1BF00C86DF9 /* b2WorldCallbacks.cpp in Sources */,
 				CDEBDDE21468C1D900C86DF9 /* b2ChainAndCircleContact.cpp in Sources */,
 				CDEBDDE61468C1D900C86DF9 /* b2ChainAndPolygonContact.cpp in Sources */,
+				4D08135626DD9121001BF800 /* bit_writer_utils.c in Sources */,
+				4D0813A126DD9122001BF800 /* random_utils.c in Sources */,
 				CDEBDDEA1468C1D900C86DF9 /* b2CircleContact.cpp in Sources */,
+				4D0813F826DD9122001BF800 /* analysis_enc.c in Sources */,
+				4D08135C26DD9121001BF800 /* thread_utils.c in Sources */,
+				4D0814F126DD9124001BF800 /* cost_mips32.c in Sources */,
+				4D0814D026DD9123001BF800 /* lossless.c in Sources */,
+				4D08134426DD9121001BF800 /* muxread.c in Sources */,
 				CDEBDDEE1468C1D900C86DF9 /* b2Contact.cpp in Sources */,
 				CDEBDDF21468C1D900C86DF9 /* b2ContactSolver.cpp in Sources */,
+				4D0814FA26DD9124001BF800 /* cost.c in Sources */,
 				CDEBDDF61468C1D900C86DF9 /* b2EdgeAndCircleContact.cpp in Sources */,
 				CDEBDDFA1468C1D900C86DF9 /* b2EdgeAndPolygonContact.cpp in Sources */,
+				4D08146426DD9123001BF800 /* cost_sse2.c in Sources */,
 				CDEBDDFE1468C1D900C86DF9 /* b2PolygonAndCircleContact.cpp in Sources */,
 				CDEBDE021468C1D900C86DF9 /* b2PolygonContact.cpp in Sources */,
+				4D0814F426DD9124001BF800 /* alpha_processing_sse41.c in Sources */,
+				4D0813D726DD9122001BF800 /* picture_csp_enc.c in Sources */,
+				4D08143426DD9123001BF800 /* webp_dec.c in Sources */,
+				4D0813C826DD9122001BF800 /* picture_psnr_enc.c in Sources */,
 				CDEBDE1C1468C1EC00C86DF9 /* b2DistanceJoint.cpp in Sources */,
+				4D0814D626DD9123001BF800 /* upsampling_msa.c in Sources */,
 				CDEBDE201468C1EC00C86DF9 /* b2FrictionJoint.cpp in Sources */,
 				CDEBDE241468C1EC00C86DF9 /* b2GearJoint.cpp in Sources */,
 				CDEBDE281468C1EC00C86DF9 /* b2Joint.cpp in Sources */,
+				4D08147626DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */,
 				579E367418CF8EEF00A3CE47 /* sqlite3.c in Sources */,
 				CDEBDE2C1468C1EC00C86DF9 /* b2MouseJoint.cpp in Sources */,
 				CDEBDE301468C1EC00C86DF9 /* b2PrismaticJoint.cpp in Sources */,
@@ -8524,6 +9669,8 @@
 				CD04AEE114725714009C20E5 /* gzio.c in Sources */,
 				CD04AEE414725714009C20E5 /* infback.c in Sources */,
 				CD04AEE714725714009C20E5 /* inffast.c in Sources */,
+				4D0813E626DD9122001BF800 /* config_enc.c in Sources */,
+				4D08150026DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */,
 				CD04AEF014725714009C20E5 /* inflate.c in Sources */,
 				CD04AEF614725714009C20E5 /* inftrees.c in Sources */,
 				CD04AEFC14725714009C20E5 /* trees.c in Sources */,
@@ -8531,6 +9678,9 @@
 				CD04AF0B14725714009C20E5 /* zutil.c in Sources */,
 				66E345471614CA710021FC4B /* whirlpool.c in Sources */,
 				DD80D65716D8021D00C172D2 /* MOAIMath.cpp in Sources */,
+				4D08149426DD9123001BF800 /* upsampling_sse2.c in Sources */,
+				4D08151B26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */,
+				4D08147926DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */,
 				DD80D67F16D8025000C172D2 /* MOAIFrameBufferTexture.cpp in Sources */,
 				DD80D6A716D8029700C172D2 /* SFMT.c in Sources */,
 			);
@@ -8759,6 +9909,7 @@
 				66C572561575582900A486AB /* MOAIStreamWriter.cpp in Sources */,
 				66C5725C1575587400A486AB /* MOAIStreamReader.cpp in Sources */,
 				66C5726215756E4300A486AB /* MOAIFileStream.cpp in Sources */,
+				4DB1D11B26D736530034597F /* MOAIImage-webp.cpp in Sources */,
 				EB70432D18761D9A0057E450 /* MOAIEaseSineOut.cpp in Sources */,
 				66C572681575700A00A486AB /* MOAIStream.cpp in Sources */,
 				66C572701575703300A486AB /* MOAIMemStream.cpp in Sources */,
@@ -8817,8 +9968,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DF7443B1E4CF18C003A62C4 /* smooth.c in Sources */,
+				4D0813E226DD9122001BF800 /* predictor_enc.c in Sources */,
+				4D08134626DD9121001BF800 /* muxinternal.c in Sources */,
+				4D08143C26DD9123001BF800 /* vp8_dec.c in Sources */,
 				8DF7443C1E4CF18C003A62C4 /* ftlzw.c in Sources */,
 				8DF7443D1E4CF18C003A62C4 /* ftgzip.c in Sources */,
+				4D0813E826DD9122001BF800 /* backward_references_enc.c in Sources */,
+				4D0814B726DD9123001BF800 /* dec_sse41.c in Sources */,
 				8DF7443E1E4CF18C003A62C4 /* ftcache.c in Sources */,
 				8DF7443F1E4CF18C003A62C4 /* ftbase.c in Sources */,
 				8DF744401E4CF18C003A62C4 /* ftbitmap.c in Sources */,
@@ -8827,17 +9983,23 @@
 				8DF744431E4CF18C003A62C4 /* ftgasp.c in Sources */,
 				8DF744441E4CF18C003A62C4 /* ftglyph.c in Sources */,
 				8DF744451E4CF18C003A62C4 /* ftinit.c in Sources */,
+				4D08134F26DD9121001BF800 /* muxedit.c in Sources */,
 				8DF744461E4CF18C003A62C4 /* ftstroke.c in Sources */,
+				4D08146F26DD9123001BF800 /* upsampling_neon.c in Sources */,
 				8DF744471E4CF18C003A62C4 /* ftsystem.c in Sources */,
+				4D08151726DD9124001BF800 /* yuv_mips32.c in Sources */,
 				8DF744481E4CF18C003A62C4 /* cff.c in Sources */,
 				8DF744491E4CF18C003A62C4 /* bdf.c in Sources */,
 				8DF7444A1E4CF18C003A62C4 /* autofit.c in Sources */,
 				8DF7444B1E4CF18C003A62C4 /* type1cid.c in Sources */,
 				8DF7444C1E4CF18C003A62C4 /* winfnt.c in Sources */,
 				8DF7444D1E4CF18C003A62C4 /* type42.c in Sources */,
+				4D08140326DD9122001BF800 /* picture_enc.c in Sources */,
 				8DF7444E1E4CF18C003A62C4 /* type1.c in Sources */,
 				8DF7444F1E4CF18C003A62C4 /* truetype.c in Sources */,
 				8DF744501E4CF18C003A62C4 /* sfnt.c in Sources */,
+				4D08147826DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */,
+				4D0814E126DD9123001BF800 /* dec_sse2.c in Sources */,
 				8DF744511E4CF18C003A62C4 /* raster.c in Sources */,
 				8DF744521E4CF18C003A62C4 /* psmodule.c in Sources */,
 				8DF744531E4CF18C003A62C4 /* pshinter.c in Sources */,
@@ -8848,133 +10010,207 @@
 				8DF744581E4CF18C003A62C4 /* ftgxval.c in Sources */,
 				8DF744591E4CF18C003A62C4 /* ftlcdfil.c in Sources */,
 				8DF7445A1E4CF18C003A62C4 /* ftmm.c in Sources */,
+				4D0814D826DD9123001BF800 /* lossless_enc_sse2.c in Sources */,
 				8DF7445B1E4CF18C003A62C4 /* ftotval.c in Sources */,
 				8DF7445C1E4CF18C003A62C4 /* ftpatent.c in Sources */,
 				8DF7445D1E4CF18C003A62C4 /* ftpfr.c in Sources */,
+				4D0814A526DD9123001BF800 /* lossless_enc_msa.c in Sources */,
 				8DF7445E1E4CF18C003A62C4 /* ftsynth.c in Sources */,
 				8DF7445F1E4CF18C003A62C4 /* fttype1.c in Sources */,
+				4D0813F126DD9122001BF800 /* vp8l_enc.c in Sources */,
 				8DF744601E4CF18C003A62C4 /* ftwinfnt.c in Sources */,
 				03240DCF13564CB0000ADC60 /* utf8.c in Sources */,
+				4D08147526DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */,
 				03240E7313564CB0000ADC60 /* xmlparse.c in Sources */,
+				4D0814A826DD9123001BF800 /* filters.c in Sources */,
 				03240E7413564CB0000ADC60 /* xmlrole.c in Sources */,
+				4D0813BE26DD9122001BF800 /* cost_enc.c in Sources */,
+				4D0814D526DD9123001BF800 /* upsampling_msa.c in Sources */,
+				4D08151126DD9124001BF800 /* lossless_enc_mips32.c in Sources */,
 				03240E7613564CB0000ADC60 /* xmltok.c in Sources */,
 				03240E7813564CB0000ADC60 /* xmltok_impl.c in Sources */,
+				4D0814AE26DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */,
+				4D08150B26DD9124001BF800 /* enc.c in Sources */,
+				4D0814DE26DD9123001BF800 /* enc_neon.c in Sources */,
 				03240E7A13564CB0000ADC60 /* xmltok_ns.c in Sources */,
 				03240EA813564CB0000ADC60 /* png.c in Sources */,
 				03240EAB13564CB0000ADC60 /* pngerror.c in Sources */,
+				4D0814CF26DD9123001BF800 /* lossless.c in Sources */,
 				03240EAC13564CB0000ADC60 /* pngget.c in Sources */,
 				03240EAD13564CB0000ADC60 /* pngmem.c in Sources */,
+				4D0814DB26DD9123001BF800 /* yuv.c in Sources */,
 				03240EAE13564CB0000ADC60 /* pngpread.c in Sources */,
 				03240EB013564CB0000ADC60 /* pngread.c in Sources */,
 				03240EB113564CB0000ADC60 /* pngrio.c in Sources */,
 				03240EB213564CB0000ADC60 /* pngrtran.c in Sources */,
 				03240EB313564CB0000ADC60 /* pngrutil.c in Sources */,
+				4D0813EE26DD9122001BF800 /* webp_enc.c in Sources */,
 				03240EB413564CB0000ADC60 /* pngset.c in Sources */,
 				03240EB613564CB0000ADC60 /* pngtrans.c in Sources */,
 				03240EB713564CB0000ADC60 /* pngwio.c in Sources */,
 				03240EB813564CB0000ADC60 /* pngwrite.c in Sources */,
 				03240EB913564CB0000ADC60 /* pngwtran.c in Sources */,
 				03240EBA13564CB0000ADC60 /* pngwutil.c in Sources */,
+				4D0814FF26DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */,
 				03240EF313564CB0000ADC60 /* tinyxml.cpp in Sources */,
+				4D0814F326DD9124001BF800 /* alpha_processing_sse41.c in Sources */,
 				03240EF513564CB0000ADC60 /* tinyxmlerror.cpp in Sources */,
 				03240EF613564CB0000ADC60 /* tinyxmlparser.cpp in Sources */,
 				CD80F641135BBCFF006B0683 /* MOAIISO8601DateFormatter.m in Sources */,
+				4D08143026DD9123001BF800 /* idec_dec.c in Sources */,
 				CD218F8713A7FD6E008337E7 /* ls_sqlite3.c in Sources */,
+				4D08138226DD9122001BF800 /* quant_levels_utils.c in Sources */,
 				CD218F8813A7FD6E008337E7 /* luasql.c in Sources */,
 				CD218FA013A7FDBA008337E7 /* dump.c in Sources */,
 				CD218FA113A7FDBA008337E7 /* error.c in Sources */,
 				CD218FA213A7FDBA008337E7 /* hashtable.c in Sources */,
+				4D08134326DD9121001BF800 /* muxread.c in Sources */,
 				CD218FA713A7FDBA008337E7 /* load.c in Sources */,
 				CD218FA813A7FDBA008337E7 /* memory.c in Sources */,
 				CD218FA913A7FDBA008337E7 /* pack_unpack.c in Sources */,
+				4D0814AB26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */,
 				CD218FAA13A7FDBA008337E7 /* strbuffer.c in Sources */,
 				CD218FAC13A7FDBA008337E7 /* utf.c in Sources */,
+				4D08142126DD9122001BF800 /* alpha_dec.c in Sources */,
+				4D08139D26DD9122001BF800 /* filters_utils.c in Sources */,
+				4D0814B426DD9123001BF800 /* rescaler_mips32.c in Sources */,
+				4D08139A26DD9122001BF800 /* color_cache_utils.c in Sources */,
+				4D0814BA26DD9123001BF800 /* lossless_sse41.c in Sources */,
 				CD218FAE13A7FDBA008337E7 /* value.c in Sources */,
 				CD490075141AB6EC00913D80 /* lapi.c in Sources */,
+				4D0814D226DD9123001BF800 /* ssim.c in Sources */,
 				CD490077141AB6EC00913D80 /* lauxlib.c in Sources */,
 				CD490079141AB6EC00913D80 /* lbaselib.c in Sources */,
+				4D08140C26DD9122001BF800 /* demux.c in Sources */,
 				CD49007A141AB6EC00913D80 /* lcode.c in Sources */,
 				CD49007C141AB6EC00913D80 /* ldblib.c in Sources */,
 				CD49007D141AB6EC00913D80 /* ldebug.c in Sources */,
 				CD490081141AB6EC00913D80 /* ldump.c in Sources */,
 				CD490082141AB6EC00913D80 /* lfunc.c in Sources */,
 				CD490084141AB6EC00913D80 /* lgc.c in Sources */,
+				4D0813D326DD9122001BF800 /* filter_enc.c in Sources */,
 				CD490086141AB6EC00913D80 /* linit.c in Sources */,
 				CD490087141AB6EC00913D80 /* liolib.c in Sources */,
+				4D08141826DD9122001BF800 /* tree_dec.c in Sources */,
+				4D08146C26DD9123001BF800 /* lossless_enc_sse41.c in Sources */,
 				CD490088141AB6EC00913D80 /* llex.c in Sources */,
 				CD49008B141AB6EC00913D80 /* lmathlib.c in Sources */,
 				CD49008C141AB6EC00913D80 /* lmem.c in Sources */,
+				4D08148126DD9123001BF800 /* alpha_processing.c in Sources */,
+				4D08134926DD9121001BF800 /* anim_encode.c in Sources */,
 				CD49008E141AB6EC00913D80 /* loadlib.c in Sources */,
 				CD49008F141AB6EC00913D80 /* lobject.c in Sources */,
 				CD490091141AB6EC00913D80 /* lopcodes.c in Sources */,
+				4D08150526DD9124001BF800 /* dec_clip_tables.c in Sources */,
 				CD490093141AB6EC00913D80 /* loslib.c in Sources */,
 				CD490094141AB6EC00913D80 /* lparser.c in Sources */,
+				4D08151A26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */,
 				CD490096141AB6EC00913D80 /* lstate.c in Sources */,
 				CD490098141AB6EC00913D80 /* lstring.c in Sources */,
 				CD49009A141AB6EC00913D80 /* lstrlib.c in Sources */,
+				4D0813F426DD9122001BF800 /* histogram_enc.c in Sources */,
 				CD49009B141AB6EC00913D80 /* ltable.c in Sources */,
+				4D0813B826DD9122001BF800 /* iterator_enc.c in Sources */,
 				CD49009D141AB6EC00913D80 /* ltablib.c in Sources */,
 				CD49009E141AB6EC00913D80 /* ltm.c in Sources */,
+				4D08145726DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */,
+				4D0813CA26DD9122001BF800 /* token_enc.c in Sources */,
 				CD4900A3141AB6EC00913D80 /* lundump.c in Sources */,
+				4D08140026DD9122001BF800 /* near_lossless_enc.c in Sources */,
 				CD4900A5141AB6EC00913D80 /* lvm.c in Sources */,
+				4D0814F026DD9124001BF800 /* cost_mips32.c in Sources */,
+				4D0814F626DD9124001BF800 /* dec_neon.c in Sources */,
 				CD4900A7141AB6EC00913D80 /* lzio.c in Sources */,
+				4D0813F726DD9122001BF800 /* analysis_enc.c in Sources */,
 				CD4900A9141AB6EC00913D80 /* print.c in Sources */,
 				079529DD1447907100143A72 /* jaricom.c in Sources */,
 				079529DE1447907100143A72 /* jcapimin.c in Sources */,
 				079529DF1447907100143A72 /* jcapistd.c in Sources */,
+				4D0814C026DD9123001BF800 /* rescaler_sse2.c in Sources */,
+				4D08138E26DD9122001BF800 /* utils.c in Sources */,
+				4D08149626DD9123001BF800 /* yuv_sse2.c in Sources */,
+				4D08142A26DD9122001BF800 /* quant_dec.c in Sources */,
 				079529E01447907100143A72 /* jcarith.c in Sources */,
 				079529E11447907100143A72 /* jccoefct.c in Sources */,
+				4D0814C926DD9123001BF800 /* alpha_processing_neon.c in Sources */,
 				079529E21447907100143A72 /* jccolor.c in Sources */,
 				079529E31447907100143A72 /* jcdctmgr.c in Sources */,
 				079529E41447907100143A72 /* jchuff.c in Sources */,
+				4D08140F26DD9122001BF800 /* anim_decode.c in Sources */,
 				079529E51447907100143A72 /* jcinit.c in Sources */,
+				4D0814C626DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */,
 				079529E61447907100143A72 /* jcmainct.c in Sources */,
 				079529E71447907100143A72 /* jcmarker.c in Sources */,
 				079529E81447907100143A72 /* jcmaster.c in Sources */,
 				079529E91447907100143A72 /* jcomapi.c in Sources */,
+				4D08149026DD9123001BF800 /* filters_neon.c in Sources */,
+				4D08145A26DD9123001BF800 /* rescaler.c in Sources */,
 				079529EB1447907100143A72 /* jcparam.c in Sources */,
 				079529EC1447907100143A72 /* jcprepct.c in Sources */,
+				4D08150826DD9124001BF800 /* lossless_msa.c in Sources */,
 				079529ED1447907100143A72 /* jcsample.c in Sources */,
 				079529EE1447907100143A72 /* jctrans.c in Sources */,
 				079529EF1447907100143A72 /* jdapimin.c in Sources */,
+				4D08146626DD9123001BF800 /* upsampling_sse41.c in Sources */,
 				079529F01447907100143A72 /* jdapistd.c in Sources */,
+				4D08143326DD9123001BF800 /* webp_dec.c in Sources */,
 				079529F11447907100143A72 /* jdarith.c in Sources */,
 				079529F21447907100143A72 /* jdatadst.c in Sources */,
 				079529F31447907100143A72 /* jdatasrc.c in Sources */,
+				4D08144E26DD9123001BF800 /* enc_msa.c in Sources */,
+				4D08151D26DD9124001BF800 /* dec_msa.c in Sources */,
 				079529F41447907100143A72 /* jdcoefct.c in Sources */,
 				079529F51447907100143A72 /* jdcolor.c in Sources */,
 				079529F71447907100143A72 /* jddctmgr.c in Sources */,
 				079529F81447907100143A72 /* jdhuff.c in Sources */,
+				4D08145D26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */,
+				4D08149926DD9123001BF800 /* filters_msa.c in Sources */,
+				4D0814A226DD9123001BF800 /* lossless_neon.c in Sources */,
 				079529F91447907100143A72 /* jdinput.c in Sources */,
 				079529FA1447907100143A72 /* jdmainct.c in Sources */,
 				079529FB1447907100143A72 /* jdmarker.c in Sources */,
 				079529FC1447907100143A72 /* jdmaster.c in Sources */,
 				079529FD1447907100143A72 /* jdmerge.c in Sources */,
 				079529FE1447907100143A72 /* jdpostct.c in Sources */,
+				4D08146026DD9123001BF800 /* rescaler_neon.c in Sources */,
 				079529FF1447907100143A72 /* jdsample.c in Sources */,
 				07952A001447907100143A72 /* jdtrans.c in Sources */,
 				07952A011447907100143A72 /* jerror-moai.c in Sources */,
 				07952A041447907100143A72 /* jfdctflt.c in Sources */,
+				4D08147226DD9123001BF800 /* filters_sse2.c in Sources */,
 				07952A051447907100143A72 /* jfdctfst.c in Sources */,
+				4D08147E26DD9123001BF800 /* yuv_neon.c in Sources */,
+				4D08149326DD9123001BF800 /* upsampling_sse2.c in Sources */,
+				4D08146926DD9123001BF800 /* enc_sse41.c in Sources */,
 				07952A061447907100143A72 /* jfdctint.c in Sources */,
 				07952A071447907100143A72 /* jidctflt.c in Sources */,
 				07952A081447907100143A72 /* jidctfst.c in Sources */,
 				07952A091447907100143A72 /* jidctint.c in Sources */,
+				4D08143626DD9123001BF800 /* vp8l_dec.c in Sources */,
+				4D08141226DD9122001BF800 /* io_dec.c in Sources */,
 				07952A0F1447907100143A72 /* jmemmgr.c in Sources */,
+				4D08149F26DD9123001BF800 /* rescaler_msa.c in Sources */,
 				07952A111447907100143A72 /* jmemnobs.c in Sources */,
+				4D0813D026DD9122001BF800 /* tree_enc.c in Sources */,
 				07952A171447907100143A72 /* jquant1.c in Sources */,
 				07952A181447907100143A72 /* jquant2.c in Sources */,
+				4D0814B126DD9123001BF800 /* ssim_sse2.c in Sources */,
 				07952A191447907100143A72 /* jutils.c in Sources */,
+				4D0814FC26DD9124001BF800 /* dec_mips32.c in Sources */,
 				0765874E145CD06900723A7D /* tlsf.c in Sources */,
 				CDEBDD4C1468C18000C86DF9 /* b2BroadPhase.cpp in Sources */,
 				CDEBDD501468C18000C86DF9 /* b2CollideCircle.cpp in Sources */,
 				CDEBDD521468C18000C86DF9 /* b2CollideEdge.cpp in Sources */,
 				CDEBDD541468C18000C86DF9 /* b2CollidePolygon.cpp in Sources */,
+				4D08137026DD9121001BF800 /* huffman_utils.c in Sources */,
 				CDEBDD561468C18000C86DF9 /* b2Collision.cpp in Sources */,
 				CDEBDD5A1468C18000C86DF9 /* b2Distance.cpp in Sources */,
 				CDEBDD5E1468C18000C86DF9 /* b2DynamicTree.cpp in Sources */,
+				4D08142726DD9122001BF800 /* buffer_dec.c in Sources */,
 				CDEBDD621468C18000C86DF9 /* b2TimeOfImpact.cpp in Sources */,
 				CDEBDD6F1468C19D00C86DF9 /* b2ChainShape.cpp in Sources */,
+				4D08141526DD9122001BF800 /* frame_dec.c in Sources */,
+				4D08140626DD9122001BF800 /* backward_references_cost_enc.c in Sources */,
 				CDEBDD731468C19D00C86DF9 /* b2CircleShape.cpp in Sources */,
 				CDEBDD771468C19D00C86DF9 /* b2EdgeShape.cpp in Sources */,
 				CDEBDD7B1468C19D00C86DF9 /* b2PolygonShape.cpp in Sources */,
@@ -8987,44 +10223,74 @@
 				CDEBDDB51468C1BF00C86DF9 /* b2Body.cpp in Sources */,
 				CDEBDDB91468C1BF00C86DF9 /* b2ContactManager.cpp in Sources */,
 				CDEBDDBD1468C1BF00C86DF9 /* b2Fixture.cpp in Sources */,
+				4D08144B26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */,
+				4D0813E526DD9122001BF800 /* config_enc.c in Sources */,
 				CDEBDDC11468C1BF00C86DF9 /* b2Island.cpp in Sources */,
 				CDEBDDC71468C1BF00C86DF9 /* b2World.cpp in Sources */,
 				CDEBDDCB1468C1BF00C86DF9 /* b2WorldCallbacks.cpp in Sources */,
+				4D08135B26DD9121001BF800 /* thread_utils.c in Sources */,
+				4D0813D626DD9122001BF800 /* picture_csp_enc.c in Sources */,
+				4D08148D26DD9123001BF800 /* enc_mips32.c in Sources */,
+				4D0814C326DD9123001BF800 /* lossless_enc.c in Sources */,
+				4D0813A026DD9122001BF800 /* random_utils.c in Sources */,
 				CDEBDDE11468C1D900C86DF9 /* b2ChainAndCircleContact.cpp in Sources */,
+				4D0814BD26DD9123001BF800 /* yuv_sse41.c in Sources */,
 				CDEBDDE51468C1D900C86DF9 /* b2ChainAndPolygonContact.cpp in Sources */,
 				CDEBDDE91468C1D900C86DF9 /* b2CircleContact.cpp in Sources */,
 				CDEBDDED1468C1D900C86DF9 /* b2Contact.cpp in Sources */,
+				4D0814E726DD9123001BF800 /* enc_sse2.c in Sources */,
 				CDEBDDF11468C1D900C86DF9 /* b2ContactSolver.cpp in Sources */,
 				CDEBDDF51468C1D900C86DF9 /* b2EdgeAndCircleContact.cpp in Sources */,
 				CDEBDDF91468C1D900C86DF9 /* b2EdgeAndPolygonContact.cpp in Sources */,
+				4D08138526DD9122001BF800 /* quant_levels_dec_utils.c in Sources */,
+				4D08150226DD9124001BF800 /* alpha_processing_sse2.c in Sources */,
 				579E367318CF8EEF00A3CE47 /* sqlite3.c in Sources */,
 				CDEBDDFD1468C1D900C86DF9 /* b2PolygonAndCircleContact.cpp in Sources */,
 				CDEBDE011468C1D900C86DF9 /* b2PolygonContact.cpp in Sources */,
+				4D0813EB26DD9122001BF800 /* picture_tools_enc.c in Sources */,
 				CDEBDE1B1468C1EC00C86DF9 /* b2DistanceJoint.cpp in Sources */,
 				CDEBDE1F1468C1EC00C86DF9 /* b2FrictionJoint.cpp in Sources */,
 				CDEBDE231468C1EC00C86DF9 /* b2GearJoint.cpp in Sources */,
+				4D08147B26DD9123001BF800 /* cpu.c in Sources */,
 				CDEBDE271468C1EC00C86DF9 /* b2Joint.cpp in Sources */,
+				4D08137926DD9122001BF800 /* huffman_encode_utils.c in Sources */,
+				4D0813FD26DD9122001BF800 /* quant_enc.c in Sources */,
+				4D0813D926DD9122001BF800 /* frame_enc.c in Sources */,
 				CDEBDE2B1468C1EC00C86DF9 /* b2MouseJoint.cpp in Sources */,
+				4D08144526DD9123001BF800 /* lossless_sse2.c in Sources */,
 				CDEBDE2F1468C1EC00C86DF9 /* b2PrismaticJoint.cpp in Sources */,
 				CDEBDE331468C1EC00C86DF9 /* b2PulleyJoint.cpp in Sources */,
+				4D0814F926DD9124001BF800 /* cost.c in Sources */,
 				CDEBDE371468C1EC00C86DF9 /* b2RevoluteJoint.cpp in Sources */,
+				4D08144226DD9123001BF800 /* upsampling.c in Sources */,
 				CDEBDE3B1468C1EC00C86DF9 /* b2RopeJoint.cpp in Sources */,
 				CDEBDE3F1468C1EC00C86DF9 /* b2WeldJoint.cpp in Sources */,
+				4D08146326DD9123001BF800 /* cost_sse2.c in Sources */,
 				CDEBDE431468C1EC00C86DF9 /* b2WheelJoint.cpp in Sources */,
+				4D0814CC26DD9123001BF800 /* dec.c in Sources */,
 				CDEBDE491468C1FD00C86DF9 /* b2Rope.cpp in Sources */,
 				CD04AECD14725714009C20E5 /* adler32.c in Sources */,
+				4D0813DC26DD9122001BF800 /* syntax_enc.c in Sources */,
 				CD04AED014725714009C20E5 /* compress.c in Sources */,
 				CD04AED314725714009C20E5 /* crc32.c in Sources */,
+				4D08138826DD9122001BF800 /* bit_reader_utils.c in Sources */,
 				CD04AED914725714009C20E5 /* deflate.c in Sources */,
+				4D08140926DD9122001BF800 /* picture_rescale_enc.c in Sources */,
 				CD04AEDF14725714009C20E5 /* gzio.c in Sources */,
 				CD04AEE214725714009C20E5 /* infback.c in Sources */,
+				4D08148A26DD9123001BF800 /* cost_neon.c in Sources */,
 				CD04AEE514725714009C20E5 /* inffast.c in Sources */,
 				CD04AEEE14725714009C20E5 /* inflate.c in Sources */,
 				CD04AEF414725714009C20E5 /* inftrees.c in Sources */,
+				4D0813C726DD9122001BF800 /* picture_psnr_enc.c in Sources */,
+				4D08136726DD9121001BF800 /* rescaler_utils.c in Sources */,
 				CD04AEFA14725714009C20E5 /* trees.c in Sources */,
+				4D0813C126DD9122001BF800 /* alpha_enc.c in Sources */,
 				CD04AF0014725714009C20E5 /* uncompr.c in Sources */,
 				CD04AF0914725714009C20E5 /* zutil.c in Sources */,
 				66E345461614CA710021FC4B /* whirlpool.c in Sources */,
+				4D08135526DD9121001BF800 /* bit_writer_utils.c in Sources */,
+				4D0814EA26DD9123001BF800 /* lossless_enc_neon.c in Sources */,
 				DD80D64B16D8021D00C172D2 /* MOAIMath.cpp in Sources */,
 				DD80D67316D8025000C172D2 /* MOAIFrameBufferTexture.cpp in Sources */,
 				DD80D69B16D8029700C172D2 /* SFMT.c in Sources */,
@@ -9161,6 +10427,7 @@
 				0324E74413564BC8000ADC60 /* MOAIViewport.cpp in Sources */,
 				0324E74613564BC8000ADC60 /* MOAIXmlParser.cpp in Sources */,
 				0324E75113564BC8000ADC60 /* STLString.cpp in Sources */,
+				4DB1D11A26D736530034597F /* MOAIImage-webp.cpp in Sources */,
 				0324E75613564BC8000ADC60 /* USByteStream.cpp in Sources */,
 				0324E76113564BC8000ADC60 /* USDeviceTime_apple.cpp in Sources */,
 				0324E76213564BC8000ADC60 /* USDeviceTime_posix.cpp in Sources */,
@@ -9544,6 +10811,7 @@
 				EB9EDF091BE9421B00E8938F /* MOAIButtonSensor.cpp in Sources */,
 				EB9EDF0A1BE9421B00E8938F /* MOAIColor.cpp in Sources */,
 				EB9EDF0B1BE9421B00E8938F /* MOAIEaseBackBase.cpp in Sources */,
+				4DB1D11C26D736530034597F /* MOAIImage-webp.cpp in Sources */,
 				EB9EDF0C1BE9421B00E8938F /* MOAICompassSensor.cpp in Sources */,
 				EB9EDF0D1BE9421B00E8938F /* moaicore.cpp in Sources */,
 				EB9EDF0E1BE9421B00E8938F /* MOAICp.cpp in Sources */,
@@ -9791,27 +11059,52 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D08146B26DD9123001BF800 /* enc_sse41.c in Sources */,
 				EB9EE0AC1BE9422800E8938F /* utf8.c in Sources */,
+				4D0813E426DD9122001BF800 /* predictor_enc.c in Sources */,
+				4D08134B26DD9121001BF800 /* anim_encode.c in Sources */,
 				EB9EE0AD1BE9422800E8938F /* xmlparse.c in Sources */,
+				4D08141726DD9122001BF800 /* frame_dec.c in Sources */,
+				4D08150126DD9124001BF800 /* cost_mips_dsp_r2.c in Sources */,
+				4D08142326DD9122001BF800 /* alpha_dec.c in Sources */,
+				4D0813C926DD9122001BF800 /* picture_psnr_enc.c in Sources */,
 				EB9EE0AE1BE9422800E8938F /* xmlrole.c in Sources */,
 				EB9EE0AF1BE9422800E8938F /* xmltok.c in Sources */,
 				EB9EE0B01BE9422800E8938F /* xmltok_impl.c in Sources */,
+				4D08138726DD9122001BF800 /* quant_levels_dec_utils.c in Sources */,
+				4D08141426DD9122001BF800 /* io_dec.c in Sources */,
+				4D0814BC26DD9123001BF800 /* lossless_sse41.c in Sources */,
+				4D08144426DD9123001BF800 /* upsampling.c in Sources */,
 				EB9EE0B11BE9422800E8938F /* xmltok_ns.c in Sources */,
+				4D08149826DD9123001BF800 /* yuv_sse2.c in Sources */,
+				4D08151926DD9124001BF800 /* yuv_mips32.c in Sources */,
+				4D0813F026DD9122001BF800 /* webp_enc.c in Sources */,
 				EB9EE0D91BE9422800E8938F /* png.c in Sources */,
+				4D08151F26DD9124001BF800 /* dec_msa.c in Sources */,
 				EB9EE0DA1BE9422800E8938F /* pngerror.c in Sources */,
 				EB9EE0DB1BE9422800E8938F /* pngget.c in Sources */,
 				EB9EE0DC1BE9422800E8938F /* pngmem.c in Sources */,
 				EB9EE0DD1BE9422800E8938F /* pngpread.c in Sources */,
 				EB9EE0DE1BE9422800E8938F /* pngread.c in Sources */,
+				4D08146526DD9123001BF800 /* cost_sse2.c in Sources */,
+				4D08144D26DD9123001BF800 /* lossless_enc_mips_dsp_r2.c in Sources */,
+				4D08140E26DD9122001BF800 /* demux.c in Sources */,
 				EB9EE0DF1BE9422800E8938F /* pngrio.c in Sources */,
 				EB9EE0E01BE9422800E8938F /* pngrtran.c in Sources */,
+				4D0813F926DD9122001BF800 /* analysis_enc.c in Sources */,
 				EB9EE0E11BE9422800E8938F /* pngrutil.c in Sources */,
+				4D08135726DD9121001BF800 /* bit_writer_utils.c in Sources */,
 				EB9EE0E21BE9422800E8938F /* pngset.c in Sources */,
+				4D0814F826DD9124001BF800 /* dec_neon.c in Sources */,
+				4D08150726DD9124001BF800 /* dec_clip_tables.c in Sources */,
 				EB9EE0E31BE9422800E8938F /* pngtrans.c in Sources */,
+				4D08151326DD9124001BF800 /* lossless_enc_mips32.c in Sources */,
 				EB9EE0E41BE9422800E8938F /* pngwio.c in Sources */,
 				EB9EE0E51BE9422800E8938F /* pngwrite.c in Sources */,
+				4D0813CC26DD9122001BF800 /* token_enc.c in Sources */,
 				EB9EE0E61BE9422800E8938F /* pngwtran.c in Sources */,
 				EB9EE0E71BE9422800E8938F /* pngwutil.c in Sources */,
+				4D0813FF26DD9122001BF800 /* quant_enc.c in Sources */,
 				EB9EE0E81BE9422800E8938F /* tinyxml.cpp in Sources */,
 				EB9EE0E91BE9422800E8938F /* tinyxmlerror.cpp in Sources */,
 				EB9EE0EA1BE9422800E8938F /* tinyxmlparser.cpp in Sources */,
@@ -9821,9 +11114,11 @@
 				EB9EE0EE1BE9422800E8938F /* dump.c in Sources */,
 				EB9EE0EF1BE9422800E8938F /* error.c in Sources */,
 				EB9EE0F01BE9422800E8938F /* hashtable.c in Sources */,
+				4D0813C326DD9122001BF800 /* alpha_enc.c in Sources */,
 				EB9EE0F11BE9422800E8938F /* load.c in Sources */,
 				EB9EE0F21BE9422800E8938F /* memory.c in Sources */,
 				EB9EE0F31BE9422800E8938F /* pack_unpack.c in Sources */,
+				4D0814AA26DD9123001BF800 /* filters.c in Sources */,
 				EB9EE0F41BE9422800E8938F /* strbuffer.c in Sources */,
 				EB9EE0F51BE9422800E8938F /* utf.c in Sources */,
 				EB9EE0F61BE9422800E8938F /* value.c in Sources */,
@@ -9831,22 +11126,35 @@
 				EB9EE0F81BE9422800E8938F /* lauxlib.c in Sources */,
 				EB9EE0F91BE9422800E8938F /* lbaselib.c in Sources */,
 				EB9EE0FA1BE9422800E8938F /* lcode.c in Sources */,
+				4D08149226DD9123001BF800 /* filters_neon.c in Sources */,
+				4D08134826DD9121001BF800 /* muxinternal.c in Sources */,
+				4D08147A26DD9123001BF800 /* enc_mips_dsp_r2.c in Sources */,
 				EB9EE0FB1BE9422800E8938F /* ldblib.c in Sources */,
+				4D08140226DD9122001BF800 /* near_lossless_enc.c in Sources */,
+				4D0813D526DD9122001BF800 /* filter_enc.c in Sources */,
+				4D0814CE26DD9123001BF800 /* dec.c in Sources */,
 				EB9EE0FC1BE9422800E8938F /* ldebug.c in Sources */,
 				EB9EE0FD1BE9422800E8938F /* ldump.c in Sources */,
+				4D0814A426DD9123001BF800 /* lossless_neon.c in Sources */,
 				EB9EE0FE1BE9422800E8938F /* lfunc.c in Sources */,
+				4D0814F526DD9124001BF800 /* alpha_processing_sse41.c in Sources */,
 				EB9EE0FF1BE9422800E8938F /* lgc.c in Sources */,
 				EB9EE1001BE9422800E8938F /* linit.c in Sources */,
 				EB9EE1011BE9422800E8938F /* liolib.c in Sources */,
+				4D08148026DD9123001BF800 /* yuv_neon.c in Sources */,
 				EB9EE1021BE9422800E8938F /* llex.c in Sources */,
+				4D0813F326DD9122001BF800 /* vp8l_enc.c in Sources */,
 				EB9EE1031BE9422800E8938F /* lmathlib.c in Sources */,
 				EB9EE1041BE9422800E8938F /* lmem.c in Sources */,
 				EB9EE1051BE9422800E8938F /* loadlib.c in Sources */,
 				EB9EE1061BE9422800E8938F /* lobject.c in Sources */,
+				4D08136926DD9121001BF800 /* rescaler_utils.c in Sources */,
 				EB9EE1071BE9422800E8938F /* lopcodes.c in Sources */,
 				EB9EE1091BE9422800E8938F /* lparser.c in Sources */,
+				4D08140B26DD9122001BF800 /* picture_rescale_enc.c in Sources */,
 				EB9EE10A1BE9422800E8938F /* lstate.c in Sources */,
 				EB9EE10B1BE9422800E8938F /* lstring.c in Sources */,
+				4D08135D26DD9121001BF800 /* thread_utils.c in Sources */,
 				EB9EE10C1BE9422800E8938F /* lstrlib.c in Sources */,
 				EB9EE10D1BE9422800E8938F /* ltable.c in Sources */,
 				EB9EE10E1BE9422800E8938F /* ltablib.c in Sources */,
@@ -9856,27 +11164,38 @@
 				EB9EE1121BE9422800E8938F /* lzio.c in Sources */,
 				EB9EE1131BE9422800E8938F /* print.c in Sources */,
 				EB9EE1141BE9422800E8938F /* jaricom.c in Sources */,
+				4D0814E926DD9123001BF800 /* enc_sse2.c in Sources */,
+				4D08148326DD9123001BF800 /* alpha_processing.c in Sources */,
 				EB9EE1151BE9422800E8938F /* jcapimin.c in Sources */,
+				4D08139F26DD9122001BF800 /* filters_utils.c in Sources */,
 				EB9EE1161BE9422800E8938F /* jcapistd.c in Sources */,
 				EB9EE1171BE9422800E8938F /* jcarith.c in Sources */,
 				EB9EE1181BE9422800E8938F /* jccoefct.c in Sources */,
 				EB9EE1191BE9422800E8938F /* jccolor.c in Sources */,
 				EB9EE11A1BE9422800E8938F /* jcdctmgr.c in Sources */,
 				EB9EE11B1BE9422800E8938F /* jchuff.c in Sources */,
+				4D08148F26DD9123001BF800 /* enc_mips32.c in Sources */,
 				EB9EE11C1BE9422800E8938F /* jcinit.c in Sources */,
 				EB9EE11D1BE9422800E8938F /* jcmainct.c in Sources */,
 				EB9EE11E1BE9422800E8938F /* jcmarker.c in Sources */,
 				EB9EE11F1BE9422800E8938F /* jcmaster.c in Sources */,
+				4D0813DE26DD9122001BF800 /* syntax_enc.c in Sources */,
 				EB9EE1201BE9422800E8938F /* jcomapi.c in Sources */,
 				EB9EE1211BE9422800E8938F /* jcparam.c in Sources */,
+				4D08138A26DD9122001BF800 /* bit_reader_utils.c in Sources */,
+				4D08150A26DD9124001BF800 /* lossless_msa.c in Sources */,
 				EB9EE1221BE9422800E8938F /* jcprepct.c in Sources */,
+				4D0814DD26DD9123001BF800 /* yuv.c in Sources */,
+				4D08146E26DD9123001BF800 /* lossless_enc_sse41.c in Sources */,
 				EB9EE1231BE9422800E8938F /* jcsample.c in Sources */,
+				4D0813D826DD9122001BF800 /* picture_csp_enc.c in Sources */,
 				EB9EE1241BE9422800E8938F /* jctrans.c in Sources */,
 				EB9EE1251BE9422800E8938F /* jdapimin.c in Sources */,
 				EB9EE1261BE9422800E8938F /* jdapistd.c in Sources */,
 				EB9EE1271BE9422800E8938F /* jdarith.c in Sources */,
 				EB9EE1281BE9422800E8938F /* jdatadst.c in Sources */,
 				EB9EE1291BE9422800E8938F /* jdatasrc.c in Sources */,
+				4D0814C226DD9123001BF800 /* rescaler_sse2.c in Sources */,
 				EB9EE12A1BE9422800E8938F /* jdcoefct.c in Sources */,
 				EB9EE12B1BE9422800E8938F /* jdcolor.c in Sources */,
 				EB9EE12C1BE9422800E8938F /* jddctmgr.c in Sources */,
@@ -9884,49 +11203,95 @@
 				EB9EE12E1BE9422800E8938F /* jdinput.c in Sources */,
 				EB9EE12F1BE9422800E8938F /* jdmainct.c in Sources */,
 				EB9EE1301BE9422800E8938F /* jdmarker.c in Sources */,
+				4D0814F226DD9124001BF800 /* cost_mips32.c in Sources */,
+				4D08145026DD9123001BF800 /* enc_msa.c in Sources */,
+				4D08140526DD9122001BF800 /* picture_enc.c in Sources */,
 				EB9EE1311BE9422800E8938F /* jdmaster.c in Sources */,
 				EB9EE1321BE9422800E8938F /* jdmerge.c in Sources */,
+				4D0814BF26DD9123001BF800 /* yuv_sse41.c in Sources */,
 				EB9EE1331BE9422800E8938F /* jdpostct.c in Sources */,
+				4D08151C26DD9124001BF800 /* upsampling_mips_dsp_r2.c in Sources */,
 				EB9EE1341BE9422800E8938F /* jdsample.c in Sources */,
 				EB9EE1351BE9422800E8938F /* jdtrans.c in Sources */,
+				4D08150426DD9124001BF800 /* alpha_processing_sse2.c in Sources */,
 				EB9EE1361BE9422800E8938F /* jerror-moai.c in Sources */,
 				EB9EE1371BE9422800E8938F /* jfdctflt.c in Sources */,
 				EB9EE1381BE9422800E8938F /* jfdctfst.c in Sources */,
 				EB9EE1391BE9422800E8938F /* jfdctint.c in Sources */,
+				4D0814EC26DD9124001BF800 /* lossless_enc_neon.c in Sources */,
+				4D0814B326DD9123001BF800 /* ssim_sse2.c in Sources */,
 				EB9EE13A1BE9422800E8938F /* jidctflt.c in Sources */,
 				EB9EE13B1BE9422800E8938F /* jidctfst.c in Sources */,
+				4D0813F626DD9122001BF800 /* histogram_enc.c in Sources */,
 				EB9EE13C1BE9422800E8938F /* jidctint.c in Sources */,
+				4D08145C26DD9123001BF800 /* rescaler.c in Sources */,
 				EB9EE13D1BE9422800E8938F /* jmemmgr.c in Sources */,
 				EB9EE13E1BE9422800E8938F /* jmemnobs.c in Sources */,
+				4D0814E026DD9123001BF800 /* enc_neon.c in Sources */,
+				4D08141126DD9122001BF800 /* anim_decode.c in Sources */,
+				4D0814B626DD9123001BF800 /* rescaler_mips32.c in Sources */,
+				4D0813DB26DD9122001BF800 /* frame_enc.c in Sources */,
+				4D08145926DD9123001BF800 /* filters_mips_dsp_r2.c in Sources */,
+				4D0814A126DD9123001BF800 /* rescaler_msa.c in Sources */,
+				4D08140826DD9122001BF800 /* backward_references_cost_enc.c in Sources */,
+				4D0813C026DD9122001BF800 /* cost_enc.c in Sources */,
+				4D08149526DD9123001BF800 /* upsampling_sse2.c in Sources */,
 				EB9EE13F1BE9422800E8938F /* jquant1.c in Sources */,
+				4D08139C26DD9122001BF800 /* color_cache_utils.c in Sources */,
+				4D0813ED26DD9122001BF800 /* picture_tools_enc.c in Sources */,
 				EB9EE1401BE9422800E8938F /* jquant2.c in Sources */,
 				EB9EE1411BE9422800E8938F /* jutils.c in Sources */,
 				EB9EE1421BE9422800E8938F /* tlsf.c in Sources */,
+				4D08143226DD9123001BF800 /* idec_dec.c in Sources */,
+				4D08147726DD9123001BF800 /* lossless_mips_dsp_r2.c in Sources */,
 				EB9EE1431BE9422800E8938F /* b2BroadPhase.cpp in Sources */,
 				EB9EE1441BE9422800E8938F /* b2CollideCircle.cpp in Sources */,
+				4D08145F26DD9123001BF800 /* dec_mips_dsp_r2.c in Sources */,
+				4D0814E326DD9123001BF800 /* dec_sse2.c in Sources */,
 				EB9EE1451BE9422800E8938F /* b2CollideEdge.cpp in Sources */,
 				EB9EE1461BE9422800E8938F /* b2CollidePolygon.cpp in Sources */,
+				4D08137B26DD9122001BF800 /* huffman_encode_utils.c in Sources */,
+				4D08143526DD9123001BF800 /* webp_dec.c in Sources */,
+				4D0814C826DD9123001BF800 /* yuv_mips_dsp_r2.c in Sources */,
+				4D0813D226DD9122001BF800 /* tree_enc.c in Sources */,
 				EB9EE1471BE9422800E8938F /* b2Collision.cpp in Sources */,
+				4D08143826DD9123001BF800 /* vp8l_dec.c in Sources */,
 				EB9EE1481BE9422800E8938F /* b2Distance.cpp in Sources */,
+				4D08147126DD9123001BF800 /* upsampling_neon.c in Sources */,
 				EB9EE1491BE9422800E8938F /* b2DynamicTree.cpp in Sources */,
 				EB9EE14A1BE9422800E8938F /* b2TimeOfImpact.cpp in Sources */,
+				4D08143E26DD9123001BF800 /* vp8_dec.c in Sources */,
 				EB9EE14B1BE9422800E8938F /* b2ChainShape.cpp in Sources */,
+				4D0814DA26DD9123001BF800 /* lossless_enc_sse2.c in Sources */,
+				4D08135126DD9121001BF800 /* muxedit.c in Sources */,
 				EB9EE14C1BE9422800E8938F /* b2CircleShape.cpp in Sources */,
 				EB9EE14D1BE9422800E8938F /* b2EdgeShape.cpp in Sources */,
 				EB9EE14E1BE9422800E8938F /* b2PolygonShape.cpp in Sources */,
 				EB9EE14F1BE9422800E8938F /* b2BlockAllocator.cpp in Sources */,
+				4D0814D126DD9123001BF800 /* lossless.c in Sources */,
 				EB9EE1501BE9422800E8938F /* b2Draw.cpp in Sources */,
+				4D0813BA26DD9122001BF800 /* iterator_enc.c in Sources */,
 				EB9EE1511BE9422800E8938F /* b2Math.cpp in Sources */,
+				4D0814FB26DD9124001BF800 /* cost.c in Sources */,
 				EB9EE1521BE9422800E8938F /* b2Settings.cpp in Sources */,
 				EB9EE1531BE9422800E8938F /* b2StackAllocator.cpp in Sources */,
+				4D08149B26DD9123001BF800 /* filters_msa.c in Sources */,
+				4D0813E726DD9122001BF800 /* config_enc.c in Sources */,
 				EB9EE1541BE9422800E8938F /* b2Timer.cpp in Sources */,
+				4D0814CB26DD9123001BF800 /* alpha_processing_neon.c in Sources */,
+				4D0814B026DD9123001BF800 /* rescaler_mips_dsp_r2.c in Sources */,
 				EB9EE1551BE9422800E8938F /* b2Body.cpp in Sources */,
 				EB9EE1561BE9422800E8938F /* b2ContactManager.cpp in Sources */,
 				EB9EE1571BE9422800E8938F /* b2Fixture.cpp in Sources */,
 				EB9EE1581BE9422800E8938F /* b2Island.cpp in Sources */,
+				4D08150D26DD9124001BF800 /* enc.c in Sources */,
 				EB9EE1591BE9422800E8938F /* b2World.cpp in Sources */,
 				EB9EE15A1BE9422800E8938F /* b2WorldCallbacks.cpp in Sources */,
 				EB9EE15B1BE9422800E8938F /* b2ChainAndCircleContact.cpp in Sources */,
+				4D08142C26DD9123001BF800 /* quant_dec.c in Sources */,
+				4D0814FE26DD9124001BF800 /* dec_mips32.c in Sources */,
+				4D0814C526DD9123001BF800 /* lossless_enc.c in Sources */,
+				4D0813A226DD9122001BF800 /* random_utils.c in Sources */,
 				EB9EE15C1BE9422800E8938F /* b2ChainAndPolygonContact.cpp in Sources */,
 				EB9EE15D1BE9422800E8938F /* b2CircleContact.cpp in Sources */,
 				EB9EE15E1BE9422800E8938F /* b2Contact.cpp in Sources */,
@@ -9936,33 +11301,51 @@
 				EB9EE1621BE9422800E8938F /* sqlite3.c in Sources */,
 				EB9EE1631BE9422800E8938F /* b2PolygonAndCircleContact.cpp in Sources */,
 				EB9EE1641BE9422800E8938F /* b2PolygonContact.cpp in Sources */,
+				4D08148C26DD9123001BF800 /* cost_neon.c in Sources */,
 				EB9EE1651BE9422800E8938F /* b2DistanceJoint.cpp in Sources */,
 				EB9EE1661BE9422800E8938F /* b2FrictionJoint.cpp in Sources */,
+				4D08134526DD9121001BF800 /* muxread.c in Sources */,
 				EB9EE1671BE9422800E8938F /* b2GearJoint.cpp in Sources */,
 				EB9EE1681BE9422800E8938F /* b2Joint.cpp in Sources */,
+				4D08147D26DD9123001BF800 /* cpu.c in Sources */,
+				4D0814D426DD9123001BF800 /* ssim.c in Sources */,
+				4D0814B926DD9123001BF800 /* dec_sse41.c in Sources */,
 				EB9EE1691BE9422800E8938F /* b2MouseJoint.cpp in Sources */,
 				EB9EE16A1BE9422800E8938F /* b2PrismaticJoint.cpp in Sources */,
 				EB9EE16B1BE9422800E8938F /* b2PulleyJoint.cpp in Sources */,
+				4D08139026DD9122001BF800 /* utils.c in Sources */,
+				4D0814A726DD9123001BF800 /* lossless_enc_msa.c in Sources */,
 				EB9EE16C1BE9422800E8938F /* b2RevoluteJoint.cpp in Sources */,
+				4D0814AD26DD9123001BF800 /* alpha_processing_mips_dsp_r2.c in Sources */,
+				4D08138426DD9122001BF800 /* quant_levels_utils.c in Sources */,
 				EB9EE16D1BE9422800E8938F /* b2RopeJoint.cpp in Sources */,
+				4D08141A26DD9122001BF800 /* tree_dec.c in Sources */,
 				EB9EE16E1BE9422800E8938F /* b2WeldJoint.cpp in Sources */,
 				EB9EE16F1BE9422800E8938F /* b2WheelJoint.cpp in Sources */,
+				4D0814D726DD9123001BF800 /* upsampling_msa.c in Sources */,
 				EB9EE1701BE9422800E8938F /* b2Rope.cpp in Sources */,
 				EB9EE1711BE9422800E8938F /* adler32.c in Sources */,
 				EB9EE1721BE9422800E8938F /* compress.c in Sources */,
+				4D08142926DD9122001BF800 /* buffer_dec.c in Sources */,
+				4D0813EA26DD9122001BF800 /* backward_references_enc.c in Sources */,
 				EB9EE1731BE9422800E8938F /* crc32.c in Sources */,
 				EB9EE1741BE9422800E8938F /* deflate.c in Sources */,
 				EB9EE1751BE9422800E8938F /* gzio.c in Sources */,
 				EB9EE1761BE9422800E8938F /* infback.c in Sources */,
 				EB9EE1771BE9422800E8938F /* inffast.c in Sources */,
+				4D08146826DD9123001BF800 /* upsampling_sse41.c in Sources */,
 				EB9EE1781BE9422800E8938F /* inflate.c in Sources */,
+				4D08147426DD9123001BF800 /* filters_sse2.c in Sources */,
+				4D08137226DD9122001BF800 /* huffman_utils.c in Sources */,
 				EB9EE1791BE9422800E8938F /* inftrees.c in Sources */,
 				EB9EE17A1BE9422800E8938F /* trees.c in Sources */,
 				EB9EE17B1BE9422800E8938F /* uncompr.c in Sources */,
 				EB9EE17C1BE9422800E8938F /* zutil.c in Sources */,
 				EB9EE17D1BE9422800E8938F /* whirlpool.c in Sources */,
+				4D08144726DD9123001BF800 /* lossless_sse2.c in Sources */,
 				EB9EE17E1BE9422800E8938F /* MOAIMath.cpp in Sources */,
 				EB9EE17F1BE9422800E8938F /* MOAIFrameBufferTexture.cpp in Sources */,
+				4D08146226DD9123001BF800 /* rescaler_neon.c in Sources */,
 				EB9EE1801BE9422800E8938F /* SFMT.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10368,8 +11751,11 @@
 					"\"../../3rdparty/chartboostiOS-2.9.1\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"../../3rdparty/sfmt-1.4/",
+					../../3rdparty/libwebp/src,
+					../../3rdparty/libwebp,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
 				OTHER_CFLAGS = (
 					"-include",
 					"\"zlcore/zl_replace.h\"",
@@ -10591,8 +11977,11 @@
 					"\"../../3rdparty/chartboostiOS-2.9.1\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"../../3rdparty/sfmt-1.4/",
+					../../3rdparty/libwebp/src,
+					../../3rdparty/libwebp,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-include",


### PR DESCRIPTION
Addresses [ENG-5469](https://elevatelabs.atlassian.net/browse/ENG-5469)

Adds WebP image support to MOAI. 🖼️ 

**Important:** I didn't write most of the code in this PR, so please don't judge me for it.  😅

Most of this code came from [the main fork of MOAI's `develop` branch](https://github.com/moai/moai-dev/tree/develop/src/moai-image-webp), which has had WebP support for several years.  🕸️ Since our outdated fork of MOAI uses an older version of classes like `MOAIImage`, I simply copied over most of the `develop` WebP implementation and then changed a few details to make it compatible with our older fork.  🍴

One significant difference between my implementation and the `develop` version is that in my version, I added `libwebp` as a submodule.  MOAI has a bad habit of copying in the code for entire repositories, and I wanted to make sure we didn't continue this trend.  🙅 But beyond that, I've mostly resisted the urge to clean up the `develop` implementation.  MOAI's codebase has a very particular style, and I don't want to deviate from it too much.  👐

So far as I've been using this branch while working on adding WebP support to other systems, the code has been running without issues. 🆗  I've been on the lookout during my testing, and I'm reasonably sure there aren't any memory leaks or other situations that could cause stability issues.  One thing to watch out for will be performance when loading WebP files into textures.  We've seen performance hits when using MOAI's image loading code in the past, notably for PNG images, and that's the main reason why we originally decided to use `.pvr.gz` for all spritesheets. 🐢 Given how much processor/memory speeds have advanced since 2013 I think it's unlikely we'll have similar issues with WebP... but it is an important thing to keep an eye on.  👁️‍🗨️

### Related PRs (not required to merge this one)
- [ ] https://github.com/mindsnacks/wonder_content/pull/3473
- [ ] https://github.com/mindsnacks/wonder_content/pull/3474