### PR TITLE
Adding `libwebp` source files to the `Android.mk` files so that they get built properly on Android.

### DIFF
--- a/ant/libmoai/jni/Android.mk
+++ b/ant/libmoai/jni/Android.mk
@@ -5,7 +5,7 @@
 #================================================================#
 
 	ORIGINAL_LOCAL_PATH := $(call my-dir)
-	
+
 	include ArmModeDefined.mk
 	include OptionalComponentsDefined.mk
 
@@ -40,7 +40,7 @@
 	LOCAL_ARM_MODE 	:= $(MY_ARM_MODE)
 	LOCAL_LDLIBS 	:= -llog -lGLESv1_CM -lGLESv2 crypto/libs/$(TARGET_ARCH_ABI)/libcrypto.a
 	LOCAL_CFLAGS	:= $(DISABLE_ADCOLONY) $(DISABLE_BILLING) $(DISABLE_CHARTBOOST) $(DISABLE_CRITTERCISM) $(DISABLE_FACEBOOK) $(DISABLE_NOTIFICATIONS) $(DISABLE_TAPJOY)
-	
+
 	ifeq ($(USE_FMOD),true)
 		LOCAL_CFLAGS	+= -DUSE_FMOD
 		LOCAL_SHARED_LIBRARIES := fmodex
@@ -51,11 +51,11 @@
 	else
     	LOCAL_CFLAGS += -Ofast
 	endif
-	
+
 #----------------------------------------------------------------#
 # header search paths
 #----------------------------------------------------------------#
-	
+
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/aku
@@ -90,6 +90,8 @@
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/freetype-2.7/config
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/jansson-2.1/src
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/jpeg-8c
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/libwebp
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/libwebp/src
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/lpng140
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/lua-5.1.3/src
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/luacrypto-0.2.0/src
@@ -110,7 +112,7 @@
 		MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/moaiext-fmod-ex
 		MY_HEADER_SEARCH_PATHS += $(FMOD_ANDROID_SDK_ROOT)/api/inc
 	endif
-	
+
 #----------------------------------------------------------------#
 # source files
 #----------------------------------------------------------------#
@@ -146,6 +148,7 @@
 	LOCAL_STATIC_LIBRARIES += libsqlite
 	LOCAL_STATIC_LIBRARIES += libssl
 	LOCAL_STATIC_LIBRARIES += libtinyxml
+	LOCAL_STATIC_LIBRARIES += libwebp
 	LOCAL_STATIC_LIBRARIES += libzlcore
 	LOCAL_STATIC_LIBRARIES += libluatrace
 
@@ -165,16 +168,17 @@
 	include lua/Android.mk
 	include moaiext-android/Android.mk
 	include moaiext-luaext/Android.mk
-	
+
 	ifeq ($(USE_FMOD),true)
 		include moaiext-fmod-ex/Android.mk
 	endif
 
 	include png/Android.mk
-	include sfmt/Android.mk	
+	include sfmt/Android.mk
 	include sqlite/Android.mk
 	include ssl/Android.mk
 	include tinyxml/Android.mk
+	include webp/Android.mk
 	include zlcore/Android.mk
 
 	include aku/Android.mk

--- a/ant/libmoai/jni/webp/Android.mk
+++ b/ant/libmoai/jni/webp/Android.mk
@@ -1,0 +1,82 @@
+#================================================================#
+# Copyright (c) 2010-2011 Zipline Games, Inc.
+# All Rights Reserved.
+# http://getmoai.com
+#================================================================#
+
+	include $(CLEAR_VARS)
+
+	LOCAL_MODULE 		:= webp
+	LOCAL_ARM_MODE 		:= $(MY_ARM_MODE)
+	LOCAL_CFLAGS		:= -include $(MY_MOAI_ROOT)/src/zlcore/zl_replace.h
+
+	LOCAL_C_INCLUDES 	:= $(MY_HEADER_SEARCH_PATHS)
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/alpha_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/buffer_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/frame_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/idec_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/io_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/quant_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/tree_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/vp8_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/vp8l_dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dec/webp_dec.c
+
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/demux/anim_decode.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/demux/demux.c
+
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/alpha_processing.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/alpha_processing_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/alpha_processing_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/alpha_processing_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/alpha_processing_sse41.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/cpu.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_clip_tables.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_mips32.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_msa.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/dec_sse41.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/filters.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/filters_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/filters_msa.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/filters_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/filters_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless_msa.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/lossless_sse41.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler_mips32.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler_msa.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/rescaler_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling_msa.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/upsampling_sse41.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv_mips32.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv_mips_dsp_r2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv_neon.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv_sse2.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/dsp/yuv_sse41.c
+
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/bit_reader_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/color_cache_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/filters_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/huffman_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/quant_levels_dec_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/random_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/rescaler_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/thread_utils.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/libwebp/src/utils/utils.c
+
+	include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Following up on [ENG-5469](https://elevatelabs.atlassian.net/browse/ENG-5469) ↩️

Naturally, the way we compile MOAI is different on iOS and on Android.  🗿📱🤖 On iOS, Xcode figures out which files to include based on which folders and files have been added to the Xcode project.  📁 For Pegasus, however, MOAI relies on the `Android.mk` files found in the `ant/` folder. 🐜  Since we added `libwebp` as a submodule, we need to add all the files from that submodule to the `Android.mk` files, or the compiler won't be able to find them.  I tried my best to add them following the same formatting that is used in the rest of MOAI.  ✍️

Unfortunately I forgot to commit these changes in the previous [MOAI WebP PR](https://github.com/mindsnacks/moai-dev/pull/130), and that's why we got [build errors on Pegasus](https://github.com/mindsnacks/CoreMS/pull/1259) last sprint (but not on Griffin or Achilles).  🙈🦄