### PR TITLE
Fixing a crash on mutli-byte Unicode characters in `MOAIFreetypeFont:dimensionsOfLine`

### DIFF
--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -1649,7 +1649,7 @@ MOAITexture* MOAIFreeTypeFont::RenderTextureSingleLine(cc8 *text, float fontSize
 	FT_UInt numGlyphs;
 	FT_Error error;
 	
-	const size_t maxGlyphs = strlen(text);
+	const size_t maxGlyphs = glyphsInText(text);
 	
 	FT_Int maxDescender;
 	FT_Int maxAscender;

--- a/src/moaicore/MOAIFreeTypeFont.cpp
+++ b/src/moaicore/MOAIFreeTypeFont.cpp
@@ -590,7 +590,7 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, FT_Vector *
 	// Gather up the positions of each glyph
 	FT_Int penX = 0, penY = 0;
 	
-	for (size_t n = 0; n < maxGlyphs; ) {
+	for (size_t n = 0; numGlyphs < maxGlyphs; numGlyphs++) {
 		FT_UInt glyphIndex;
 		
 		int idx = (int)n;
@@ -625,7 +625,6 @@ USRect MOAIFreeTypeFont::DimensionsOfLine(cc8 *text, float fontSize, FT_Vector *
 		penX += glyphXAdvance;
 		
 		previousGlyphIndex = glyphIndex;
-		numGlyphs++;
 	}
 	
 	// compute the bounding box of the glyphs


### PR DESCRIPTION
While working on a way to let `SizeConstrainedTextArea` find the optimal font size without actually rendering any textures, I ran into an issue with `MOAIFreeTypeFont` and decided to address that first instead.  🔠🔧

Basically, the method `_dimensionsOfLine` crashes (intermittently) when called on strings that contain multi-byte Unicode characters. 💣💥 For example, calling `moaiFont:dimensionsOfLine("åpple", 10.0)` will (sometimes) cause a crash. 🙈 That's probably why we've avoided using `dimensionsOfLine` in our entire codebase.  💁‍♂️

It turns out the crash was happening because there were glyphs that were getting freed by `FT_Done_Glyph` that weren't allocated to begin with.  🙅 I fixed it by changing a `for` loop so that it uses the correct index variable in its condition statement.  Previously, the `for` loop was comparing to a different index variable... which got incremented by more than `1` when `u8_nextchar` encountered a multi-byte Unicode character. ❌ That threw off the loop that initialized the glyphs... which is why some of them weren't initialized when we called `FT_Done_Glyph` on them.  💣

After that fix, I also had to switch the calculation for `maxGlyphs` from `strlen` (which doesn't handle multi-byte Unicode characters properly) to a different function defined in `MOAIFreeTypeFont` (`glyphsInText`).  Before I changed that, labels that included multi-byte Unicode characters would sometimes render with garbage characters at the end.  🗑️

The code in this file is pretty sloppy (to say the least 😬), so after I tested out the fixes, I started to try renaming variables and doing some light refactoring and tidying up.  🕳️🐇 I got through the two methods I modified, but I ended up changing practically every line of code in them.  🧹🧹🧹 I still have that cleanup on a separate branch, but I figured we should start with just these three lines for now to keep the important change isolated and minimize risk. 🎲 If we do decide to go ahead with code cleanup in `MOAIFreeTypeFont`, I would advocate for rolling it out over the course of several sprints so we can have more confidence we're not introducing bugs to such a sensitive part of the games stack.  🗿🚫🐛 

For what it's worth, I made good progress on the no-render-`SizeConstrainedTextArea` project, but since it depends on `_dimensionsOfLine`, it'll have to wait for a future 5% Day.  😁🔜📆 
