### PR TITLE
Updating `USColor::Convert` with `RBG_888` images to a newer implementation

### DIFF
--- a/src/uslscore/USColor.cpp
+++ b/src/uslscore/USColor.cpp
@@ -82,12 +82,17 @@ void USColor::Convert ( void* dest, Format destFmt, const void* src, Format srcF
 				
 				for ( u32 i = 0; i < copy; ++i ) {
 					
-					color = *( u32* )src;
-					src = ( void* )(( uintptr )src + 3 );
+					color = *( u8* )src;
+					src = ( void* )(( size_t )src + 1 );
 					
-					buffer [ i ]= color | 0xff000000;
+					color += *( u8* )src << 0x08;
+					src = ( void* )(( size_t )src + 1 );
+					
+					color += *( u8* )src << 0x10;
+					src = ( void* )(( size_t )src + 1 );
+					
+					buffer [ i ]= color | 0xFF000000;
 				}
-				bufferPtr = buffer;
 				break;
 				
 			case RGB_565:


### PR DESCRIPTION
I've had this branch sitting here since we first encountered the [Android image conversion bug](https://elevatelabs.atlassian.net/browse/GPE-7) back before Miami, and I think that now is probably a good time to try merging it in.  🌴🔙

Here's the original commit message to explain what this PR is doing: 💬 
> Replacing the section of `USColor::Convert` under the `RGB_888` case for `srcFmt` with the corresponding code from `ZLColor::Convert` on the upstream `moai-dev` branch.  This seems to fix the crash on Android that started happening when we updated `compileSdkVersion` and `targetSdkVersion` to `32` from `30`.  It's possible the old implementation was accessing memory in an unsafe way, which the latest Android SDK version now disallows.

There's a big complication, however. ⚙️🦆⚙️  Sometime between May and now, *something* has changed that is preventing `pegasus` from crashing under the same circumstances where it crashed before. ⁉️  My best guess is that there has been a patch to Android 12 that keeps it from crashing... but I haven't been able to find any low-level changelogs that reference anything potentially related to this issue, so it's impossible to be sure.  🤖🤷‍♂️

Reasons not to merge this PR:
- I can't duplicate the crash that it is supposed to fix. 🙈
- I don't really understand *why* it crashed and why this change fixes it. 😬

Reasons to merge this PR:
- I'm certain it fixed the crash back in May. 💁‍♂️
- On the MOAI upstream, [this](https://github.com/moai/moai-dev/commit/a28e69b91490f67534dda00e85dd28b410ff91fd) is the commit that introduced this change to `ZLColor::Convert`.  The commit message cryptically reads: "Add test code for MOAIImage. Bug fixes." 🐛🤔
- We do need to update the `compileSdkVersion` and `targetSdkVersion` values eventually, and I'd much rather do that running the updated `Convert` code than our current version. 🔜🆙 