### PR TITLE
Avoid calling `fflush` with a null argument to prevent Android ANR issues

### DIFF
--- a/src/zlcore/ZLFile.cpp
+++ b/src/zlcore/ZLFile.cpp
@@ -66,7 +66,7 @@ int ZLFile::CloseProcess () {
 //----------------------------------------------------------------//
 int	ZLFile::Flush () {
 	
-	if ( !this->mIsZip ) {
+	if ( !this->mIsZip && this->mPtr.mFile != nullptr ) {
 		return fflush ( this->mPtr.mFile );
 	}
 	return 0;


### PR DESCRIPTION
See @guilhermekrz 's [post](https://geniuses.slack.com/archives/C012ZQSTB2S/p1692788822370599) about his discovery that some process in MOAI seems to be a major factor contributing to slow startup times and Android ANR issues.  🕵️‍♂️👏

I did some investigation myself, and tracking down the source of the issue turned out to be fairly easy.  🔍👍 It seems like the issue is indeed coming from MOAI, in a call to `fflush` in `ZLFile::Flush()`.  🚽 I think that whoever wrote this line assumed (intuitively) that calling `fflush` with a null argument would have no effect.  However, according to the [documentation](https://cplusplus.com/reference/cstdio/fflush/) I was able to find, calling it with a null pointer causes it to flush *all* streams that are open at the time.  This unintended side effect seems to be causing gridlock while MOAI is starting up on Android. ❌🚦 In my testing it doesn't seem to have any impact on iOS, perhaps owing to different implementation details between the two OS's. 🍎🤖

As part of MOAI's bootstrap process, it creates three `ZLFile` objects for each of the [three streams](https://github.com/mindsnacks/moai-dev/blob/mindsnacks-dev/src/zlcore/zlcore.cpp#L263C1-L280C2): `stdin`, `stdout`, and `stderr`.  Each of these file objects calls `Flush()` in its constructor.  By default, `mIsZip` is `false`, and `mPtr.mFile` is null, which leads `Flush()` to call `fflush` on null.  To avoid this, I've added to the condition so that `fflush` only gets called when `mFile` is not null.  Newly initialized file objects will not have any data to write in them, so skipping the call to `fflush` should have no effect on them.  🆕💾🚫🚽🆗 

### To test this change:
1.  Install the Network Link Conditioner as described [here](https://nshipster.com/network-link-conditioner/). 🔗
2. Open up either Pegasus or Geonosis in Android Studio. 🤖
3. Run the app in an emulator with the Network Link Conditioner turned off and record the time it takes to reach the first animation after launch (using a stopwatch). ⏱️
4. Close down the running instance of the project in the emulator. 🔽 
5. In the Network Link Conditioner settings, select the *100% Loss* profile and turn it on.  💯 
6. Run the same project in the emulator again and record the time it takes to reach the first animation after launch with the NLC turned *on*.  ⏱️
7. On the `mindsnacks-dev` branch, startup times should be very long.  On `feature/moai-init-anr-fix`, startup times should be significantly shorter and roughly equal between tests. ✅

### Results from my testing in Geonosis (in the emulator):
This data is for Geonosis, but I observed the same effect in Pegasus.  I did three trials for each of the three settings with the fix, but only one trial without the fix. 📊

#### Without fix:
 - NLC not active: ~10.5 seconds
 - NLC active with **Very Bad Network**: ~14 seconds
 - NLC active with **100% Loss**: ~32 seconds

#### With fix:
- NLC not active: 
  - 11.3 seconds
  - 10.9 seconds
  - 10.6 seconds
- NLC active with **Very Bad Network**: 
  - 10.5 seconds
  - 10.7 seconds
  - 10.7 seconds
- NLC active with **100% Loss**: 
  - 10.7 seconds
  - 10.6 seconds
  - 10.6 seconds

### Results from my testing in Pegasus on a physical Android device:

#### Without fix:
- Without NLC (connected to home WiFi):
  - 9.8 seconds
  - 9.8 seconds
  - 10.1 seconds
  - 9.8 seconds

- With NLC on **100% Loss** (connected to personal hotspot from my iPhone):
  - 31.7 seconds
  - 128.2 seconds
  - 125.8 seconds

#### With fix:

- Without NLC (connected to home WiFi):
  - 10.5 seconds
  - 10.5 seconds
  - 9.7 seconds
  - 9.8 seconds

- Without NLC (connected to personal hotspot from my iPhone):
  - 10.1 seconds
  - 11.1 seconds
  - 10.3 seconds

- With NLC on **100% Loss** (connected to personal hotspot from my iPhone):
  - 11.2 seconds
  - 11.5 seconds
  - 11.5 seconds
