### PR TITLE
[TASK-3643] Prevent crash in Lua when built with newer NDKs

### DIFF
--- a/ant/libmoai/build.sh
+++ b/ant/libmoai/build.sh
@@ -13,7 +13,7 @@
 	verbose=
 	arm_mode="arm"
 	arm_arch="all"
-	app_platform="android-16"
+	app_platform="android-24"
 	use_fmod="false"
 	use_untz="true"
 	adcolony_flags=

--- a/ant/libmoai/jni/lua/Android.mk
+++ b/ant/libmoai/jni/lua/Android.mk
@@ -8,6 +8,8 @@
 
 	LOCAL_MODULE 		:= lua
 	LOCAL_ARM_MODE 		:= $(MY_ARM_MODE)
+    # The flags -U_FORTIFY_SOURCE and -D_FORTIFY_SOURCE=0 disable the FORTIFY checks
+    # that cause a crash in Lua on Android NDK r21 and later.
 	LOCAL_CFLAGS		:= -include $(MY_MOAI_ROOT)/src/zlcore/zl_replace.h -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 
 	LOCAL_C_INCLUDES 	:= $(MY_HEADER_SEARCH_PATHS)

--- a/ant/libmoai/jni/lua/Android.mk
+++ b/ant/libmoai/jni/lua/Android.mk
@@ -8,7 +8,7 @@
 
 	LOCAL_MODULE 		:= lua
 	LOCAL_ARM_MODE 		:= $(MY_ARM_MODE)
-	LOCAL_CFLAGS		:= -include $(MY_MOAI_ROOT)/src/zlcore/zl_replace.h
+	LOCAL_CFLAGS		:= -include $(MY_MOAI_ROOT)/src/zlcore/zl_replace.h -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 
 	LOCAL_C_INCLUDES 	:= $(MY_HEADER_SEARCH_PATHS)
 	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/lua-5.1.3/src/lapi.c


### PR DESCRIPTION
See @guilhermekrz 's Notion [writeup](https://www.notion.so/elevate/Elevate-Android-Tech-debt-Update-NDK-e24f8f49b7bc4939980dbef7e463ab51) on this crash, and my [writeup](https://www.notion.so/elevate/NDK-Fortify-Crash-Research-300f960866914a4d9dbd56f832f8aa22?pvs=4) on the investigation and this workaround. 📝🔍 

To avoid the crash, this PR adds flags to Lua's `Android.mk` file so that Lua will be built without FORTIFY enabled.  The rest of CoreMS and MOAI still build with FORTIFY and don't seem to have any trouble with it. 🆗

Note that I'm also changing the value of `app_platform` to `"android-24"`.  This avoids the warning: `Android NDK: android-16 is unsupported. Using minimum supported version android-21.` 🤫

I've tested that `griffin`, `pegasus`, `kamino`, and `geonosis` all still build and run without issues with this change. 🧪  However, we'll need followup PRs: 👇
- Bump MOAI in `CoreMS`/`wonder_content`, and `tatooine`
- Bump the NDK to the newest version in `pegasus`
- Eventually figure out how to add these flags to `geonosis`'s build process (using `cmake`) and bump the NDK there as well