### PR TITLE
Fix Xcode 16.3 and 16.4 incompatibility

### DIFF
--- a/3rdparty/zlib-1.2.3/zutil.h
+++ b/3rdparty/zlib-1.2.3/zutil.h
@@ -127,7 +127,8 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #    include <unix.h> /* for fdopen */
 #  else
-#    ifndef fdopen
+	 /* Don't redefine fdopen on modern iOS/macOS - it exists in the system */
+#    if !defined(__APPLE__) && !defined(fdopen)
 #      define fdopen(fd,mode) NULL /* No fdopen() */
 #    endif
 #  endif

--- a/src/moaiext-iphone/MOAIAppIOS.mm
+++ b/src/moaiext-iphone/MOAIAppIOS.mm
@@ -34,7 +34,7 @@ int MOAIAppIOS::_getDirectoryInDomain ( lua_State* L ) {
 	}
 	else {
 	
-		NSString *dir = [ NSSearchPathForDirectoriesInDomains ( dirCode, NSUserDomainMask, YES ) lastObject ];
+		NSString *dir = [ NSSearchPathForDirectoriesInDomains ( (NSSearchPathDirectory)dirCode, NSUserDomainMask, YES ) lastObject ];
 
 		if ( ![[ NSFileManager defaultManager ] fileExistsAtPath:dir ]) {
 			

--- a/src/uslscore/USList.h
+++ b/src/uslscore/USList.h
@@ -135,13 +135,13 @@ public:
 	//----------------------------------------------------------------//
 	void InsertAfter ( USLeanLink < TYPE >& cursor, TYPE& element ) {
 	
-		this->mList.InsertAfter ( cursor, this->AssignLink ( element ));
+		this->mList.InsertAfter ( cursor, this->NextFreeLink ( element ));
 	}
 
 	//----------------------------------------------------------------//
 	void InsertBefore ( USLeanLink < TYPE >& cursor, TYPE& element ) {
 	
-		this->mList.InsertBefore ( cursor, this->AssignLink ( element ));
+		this->mList.InsertBefore ( cursor, this->NextFreeLink ( element ));
 	}
 
 	//----------------------------------------------------------------//


### PR DESCRIPTION
The two interesting changes here are: Fixing a conflict with a macro in our old `zutil.h`, and a truly yolo fix to a call to a `AssignLink` in `USList.h`. The latter was a bit of a rabbit hole - I couldn't find where `AssignLink` used to (?) be defined. I'm going to just test this change thoroughly.